### PR TITLE
2 quick fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ subcommands:
 
 ## winston.cfg example
 
+Environment variables will be expanded atuomatically.
+
 ```
 [default]
 container_engine              = podman
@@ -140,7 +142,7 @@ inventory_columns             = ansible_network_os,ansible_network_cli_ssh_type,
 loglevel                      = debug
 no_osc4                       = true
 playbook                      = ~/github/demo_content/gather.yaml
-tower_password                = password
+tower_password                = $TOWER_PASSWORD
 tower_url                     = http://myserver
 tower_username                = username
 

--- a/winston/actions/explore.py
+++ b/winston/actions/explore.py
@@ -698,7 +698,7 @@ class Action(App):
         :rtype: bool
         """
         self.update()
-        if not self.runner.finished:
+        if self.runner is not None and not self.runner.finished:
             if interaction.action.match.groupdict()["exclamation"]:
                 self._logger.debug("shutting down runner")
                 self.runner.cancelled = True

--- a/winston/cli.py
+++ b/winston/cli.py
@@ -1,5 +1,6 @@
 """ start here
 """
+import configparser
 import itertools
 import logging
 import os
@@ -19,7 +20,6 @@ from typing import Tuple
 from typing import Union
 
 
-from configparser import ConfigParser
 
 from curses import wrapper
 
@@ -38,6 +38,13 @@ COLLECTION_DOC_CACHE_FNAME = "collection_doc_cache.db"
 
 
 logger = logging.getLogger(APP_NAME)
+
+class EnvInterpolation(configparser.BasicInterpolation):
+    """Interpolation which expands environment variables in values."""
+
+    def before_get(self, parser, section, option, value, defaults):
+        value = super().before_get(parser, section, option, value, defaults)
+        return os.path.expandvars(value)
 
 
 class NoSuch:  # pylint: disable=too-few-public-methods
@@ -94,7 +101,7 @@ def update_args(
     msgs = []
     if config_file:
         msgs.append(f"Using {config_file}")
-        config = ConfigParser()
+        config = configparser.ConfigParser(interpolation=EnvInterpolation())
         try:
             config.read(config_file)
         except Exception as exc:  # pylint:disable=broad-except


### PR DESCRIPTION
Allow use of env vars in config file
When loading artifact, runner was None