### PR TITLE
[Docs] Modify quick install steps to use editable mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ cd ansible-navigator_demo
 python3 -m venv venv
 source venv/bin/activate
 pip install -U setuptools
-pip install ../ansible-navigator
+pip install -e ../ansible-navigator
 ```
 
 RHEL8/Centos8 prerequisites:


### PR DESCRIPTION
# SUMMARY

According to the PR #66, we need to use editable mode(-e)  to install navigator in the Quick start section.