### PR TITLE
Simple smoke test on github actions

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 4
     strategy:
       fail-fast: false
     steps:


### PR DESCRIPTION
This adds some simple smoke testing, until we get real testing in place.

It installs ansible-core and ansible-navigator, and then:
* Runs `ansible-navigator --help`
* Runs some tmux-driven tests, where we actually launch the application and send keys to it to control it, and look for substrings in the resulting screens.

This isn't meant to catch a ton of bugs, but it's meant to be a simple test to ensure the application at least starts and lets us navigate through a few pages. I'm happy to remove it (or keep it and expand the tmux functional testing if we find it useful) in the future, once real tests exist. For now this is meant as a "better than nothing" stopgap.