### PR TITLE
Also search for a share_dir in a venv-specific path

### DIFF
--- a/ansible_navigator/cli.py
+++ b/ansible_navigator/cli.py
@@ -45,9 +45,11 @@ _POTENTIAL_SHARE_DIRS = (
     # System paths
     # On most Linux installs, these would resolve to:
     # ~/.local/share/APP_NAME
-    # /usr/share/APP_NAME
+    # /usr/share/APP_NAME  (or the venv equivalent)
+    # /usr/share/APP_NAME  (or what was specified as the datarootdir when python was built)
     # /usr/local/share/APP_NAME
     os.path.join(sysconfig.get_config_var("userbase"), "share", APP_NAME),
+    os.path.join(sys.prefix, "share", APP_NAME),
     os.path.join(sysconfig.get_config_var("datarootdir"), APP_NAME),
     os.path.join(sysconfig.get_config_var("prefix"), "local", "share", APP_NAME),
 )


### PR DESCRIPTION
When running in a venv, sys.prefix is modified to reflect the venv's
location whereas sysconfig paths are not.  So we need to use sys.prefix
as part of one of the search paths to find the share dir when running in
a venv.

We still check the sysconfig datarootdir path because this can be set by
the user when Python is built.  So outside of a venv it might be
something user-defined instead of sys.prefix/share/.