### PR TITLE
Add run action to support interactive and stdout mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ ansible-navigator doc ansible.netcommon.cli_command
 
 Run and explore a playbook
 ```
-ansible-navigator explore site.yaml -i inventory.yaml
+ansible-navigator run -m interactive site.yaml -i inventory.yaml
 ```
 
 Review and explore and inventory
@@ -60,9 +60,9 @@ Review and explore and inventory
 ansible-navigator inventory -i inventory.yaml
 ```
 
-Run a playbook with classic output
+Run a playbook with classic output (default mode)
 ```
-ansible-navigator playbook site.yaml -i inventory.yaml
+ansible-navigator run -m stdout site.yaml -i inventory.yaml
 ```
 
 
@@ -98,7 +98,7 @@ arrow up, arrow down                    Scroll up/down
 :collections                            Explore installed collections
 :config                                 Explore the current Ansible configuration
 :d, :doc <plugin>                       Show a plugin doc
-:e, :explore <playbook> -i <inventory>  Run a playbook using explore
+:r, :run <playbook> -i <inventory>      Run a playbook using in interactive mode
 :f, :filter <re>                        Filter page lines using a regex
 :h, :help                               This page
 :i, :inventory <inventory>              Explore the current or alternate inventory

--- a/ansible_navigator/action_runner.py
+++ b/ansible_navigator/action_runner.py
@@ -2,7 +2,7 @@
 """
 
 from ansible_navigator.actions import kegexes
-from ansible_navigator.actions import run as run_action
+from ansible_navigator.actions import run_action
 
 from .app import App
 from .steps import Steps

--- a/ansible_navigator/actions/__init__.py
+++ b/ansible_navigator/actions/__init__.py
@@ -8,10 +8,10 @@ from ..app_public import AppPublic
 names = actions.names_factory(__package__)
 
 
-run: Callable[[str, AppPublic, Interaction], Union[None, Interaction]] = actions.call_factory(
-    __package__
-)
+run_action: Callable[
+    [str, AppPublic, Interaction], Union[None, Interaction]
+] = actions.call_factory(__package__)
 kegexes: Callable = actions.kegexes_factory(__package__)
 
 
-__all__ = ["kegexes", "names", "run"]
+__all__ = ["kegexes", "names", "run_action"]

--- a/ansible_navigator/actions/collections.py
+++ b/ansible_navigator/actions/collections.py
@@ -14,7 +14,7 @@ from typing import List
 from typing import Tuple
 from typing import Union
 
-from . import run as run_action
+from . import run_action
 from . import _actions as actions
 from ..app import App
 from ..app_public import AppPublic

--- a/ansible_navigator/actions/config.py
+++ b/ansible_navigator/actions/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 from typing import List
 from typing import Union
 
-from . import run as run_action
+from . import run_action
 from . import _actions as actions
 from ..app import App
 from ..app_public import AppPublic

--- a/ansible_navigator/actions/inventory.py
+++ b/ansible_navigator/actions/inventory.py
@@ -13,7 +13,7 @@ from typing import Dict
 from typing import List
 from typing import Union
 
-from . import run as run_action
+from . import run_action
 from . import _actions as actions
 
 from ..app import App

--- a/ansible_navigator/actions/run.py
+++ b/ansible_navigator/actions/run.py
@@ -1,4 +1,4 @@
-""" :explore
+""" :run
 """
 import copy
 import curses
@@ -16,10 +16,10 @@ from typing import List
 from typing import Tuple
 from typing import Union
 
-from . import run as run_action
+from . import run_action
 from . import _actions as actions
 
-from ._runner import PlaybookRunner
+from ._runner import CommandRunner
 from ..app import App
 from ..app_public import AppPublic
 
@@ -196,12 +196,12 @@ TASK_LIST_COLUMNS = [
 class Action(App):
 
     # pylint: disable=too-many-instance-attributes
-    """:explore"""
+    """:run"""
 
     KEGEX = r"""
             (?x)
             ^
-            (?P<explore>e(?:xplore)?
+            (?P<run>r(?:un)?
             (\s(?P<playbook>\S+))?
             (\s(?P<params>.*))?)
             |
@@ -212,7 +212,7 @@ class Action(App):
     def __init__(self, args):
         # for display purposes use the 4: of the uuid
         super().__init__(args=args)
-        self._name_at_cli = "explore"
+        self._name_at_cli = "run"
         self._uuid = str(uuid.uuid4())
         self.name = self._name_at_cli + self._uuid[-4:]
         self._logger = logging.getLogger(f"{__name__}.{self._uuid[-4:]}")
@@ -266,7 +266,7 @@ class Action(App):
 
     def run(self, interaction: Interaction, app: AppPublic) -> None:
         # pylint: disable=too-many-branches
-        """run :explore or :load
+        """run :run or :load
 
         :param interaction: The interaction from the user
         :type interaction: Interaction
@@ -277,10 +277,10 @@ class Action(App):
         self._calling_app = app
         self._interaction = interaction
 
-        if interaction.action.match.groupdict()["explore"]:
-            self._subaction_type = "explore"
+        if interaction.action.match.groupdict()["run"]:
+            self._subaction_type = "run"
             self._logger.debug("subaction type is %s", self._subaction_type)
-            initialized = self._init_explore()
+            initialized = self._init_run()
         elif interaction.action.match.groupdict()["load"]:
             self._subaction_type = "load"
             self._logger.debug("subaction type is %s", self._subaction_type)
@@ -310,8 +310,8 @@ class Action(App):
 
             if not self.steps:
                 # if we came from the cli
-                if self._calling_app.args.app in ("explore", "load"):
-                    self._logger.debug("called from cli addining original step to stack")
+                if self._calling_app.args.app in ("run", "load"):
+                    self._logger.debug("called from cli adding original step to stack")
                     self.steps.append(self._plays)
                 elif not self._runner_finished:
                     self._logger.error("Can not step back while playbook in progress, :q! to exit")
@@ -333,8 +333,8 @@ class Action(App):
         interaction.ui.scroll(previous_scroll)
         return None
 
-    def _init_explore(self) -> bool:
-        """in the case of :explore, parse the user input"""
+    def _init_run(self) -> bool:
+        """in the case of :run, parse the user input"""
         playbook = ""
 
         p_from_int = self._interaction.action.match.groupdict().get("playbook")
@@ -380,7 +380,7 @@ class Action(App):
             self._logger.debug("Running with %s=%s %s", key, value, type(value))
 
         self._run_runner()
-        self._logger.info("Explore initialized and playbook started.")
+        self._logger.info("Run initialized and playbook started.")
         return True
 
     def _init_load(self, artifact_file: str) -> bool:
@@ -543,7 +543,7 @@ class Action(App):
 
     def _update_args(self, params: List) -> Union[Namespace, None]:
         """pass the param through the original cli parser
-        as if explore was run from the command line
+        as if run was invoked from the command line
         provide an error callback so the app doesn't sys.exit if the aprsing fails
         """
 
@@ -588,7 +588,7 @@ class Action(App):
 
     def _run_runner(self) -> None:
         """ spin up runner """
-        self.runner = PlaybookRunner(args=self.args, queue=self._queue)
+        self.runner = CommandRunner(args=self.args, queue=self._queue)
         self.runner.run()
         self._runner_finished = False
         self._logger.debug("runner requested to start")
@@ -802,11 +802,11 @@ class Action(App):
 
     def rerun(self) -> None:
         """rerun the current playbook
-        since we're not reinstantiating explore,
+        since we're not reinstantiating run,
         drain the queue, clear the steps, reset the index, etc
         """
         if self.runner.finished:
-            if self._subaction_type == "explore":
+            if self._subaction_type == "run":
                 self._plays.value = []
                 self._plays.index = None
                 self._msg_from_plays = (None, None)

--- a/ansible_navigator/cli.py
+++ b/ansible_navigator/cli.py
@@ -22,7 +22,7 @@ from typing import Union
 
 from curses import wrapper
 
-from .actions.explore import Action as Player
+from .actions.run import Action as Player
 
 from .cli_args import CliArgs
 from .action_runner import ActionRunner
@@ -255,7 +255,7 @@ def parse_and_update(params: List, error_cb: Callable = None) -> Tuple[List[str]
 def run(args: Namespace) -> None:
     """run the appropriate app"""
     try:
-        if args.app == "playbook":
+        if args.app == "run" and args.navigator_mode == "stdout":
             non_ui_app = partial(Player(args).playbook)
             if args.web:
                 WebXtermJs().run(func=non_ui_app)

--- a/ansible_navigator/cli_args.py
+++ b/ansible_navigator/cli_args.py
@@ -54,8 +54,7 @@ class CliArgs:
         self._doc()
         self._inventory()
         self._load()
-        self._explore()
-        self._playbook()
+        self._run()
 
     def _add_subparser(self, name: str, desc: str) -> ArgumentParser:
         return self._subparsers.add_parser(
@@ -73,6 +72,7 @@ class CliArgs:
         self._log_params(self._base_parser)
         self._no_osc4_params(self._base_parser)
         self._web_params(self._base_parser)
+        self._navigator_mode(self._base_parser)
 
     def _collections(self) -> None:
         parser = self._add_subparser("collections", "Explore installed collections")
@@ -144,8 +144,10 @@ class CliArgs:
             dest="ee_image",
         )
 
-    def _explore(self) -> None:
-        parser = self._add_subparser("explore", "Run playbook(s) interactive")
+    def _run(self) -> None:
+        parser = self._add_subparser(
+            "run", "Run Ansible playbook in either interactive or stdout mode"
+        )
         self._playbook_params(parser)
         self._inventory_params(parser)
 
@@ -231,11 +233,6 @@ class CliArgs:
             dest="no_osc4",
         )
 
-    def _playbook(self) -> None:
-        parser = self._add_subparser("playbook", "Run playbook(s)")
-        self._playbook_params(parser)
-        self._inventory_params(parser)
-
     @staticmethod
     def _playbook_params(parser: ArgumentParser) -> None:
         parser.add_argument(
@@ -260,4 +257,16 @@ class CliArgs:
             action="store_true",
             help="Run the application in a browser rather than the current terminal",
             dest="web",
+        )
+
+    @staticmethod
+    def _navigator_mode(parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "-m",
+            "--mode",
+            default="stdout",
+            dest="navigator_mode",
+            choices=["stdout", "interactive"],
+            help="Specify the navigator mode to run",
+            type=str,
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,8 @@ long_description_content_type = text/markdown
 url = https://github.com/ansible/ansible-navigator
 author = Bradley A. Thornton
 author_email = bthornto@redhat.com
-license = 
-license_file = 
+license =
+license_file =
 license_files =
     licenses/LICENSE_asottile_tm_tokenize.all
     licenses/LICENSE.dark_vs.json
@@ -34,7 +34,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    ansible-runner @ git+https://github.com/ansible/ansible-runner.git#egg=ansible-runner-devel
+    ansible-runner @ git+https://github.com/ganeshrn/ansible-runner.git@explorer_changes#egg=ansible-runner-devel
     awxkit
     jinja2
     onigurumacffi

--- a/share/ansible_navigator/markdown/help.md
+++ b/share/ansible_navigator/markdown/help.md
@@ -1,37 +1,37 @@
 ## GENERAL
---------------------------------------------------------------------------------------
-esc                                     Go back
-^f/PgUp                                 Page up
-^b/PgDn                                 Page down
-arrow up, arrow down                    Scroll up/down
-:collections                            Explore installed collections
-:config                                 Explore the current Ansible configuration
-:d, :doc <plugin>                       Show a plugin doc
-:e, :explore <playbook> -i <inventory>  Run a playbook using explore
-:f, :filter <re>                        Filter page lines using a regex
-:h, :help                               This page
-:i, :inventory <inventory>              Explore the current or alternate inventory
-:l, :log                                Review current log file
-:o, :open                               Open current page in the editor
-:o, :open {{ some_key }}                Open file path in a key's value
-:q, :quit                               Quit the application
-:q!, :quit!, ^c                         Force quit while a playbook is running
-:rr, :rerun                             Rerun the playbook
-:s, :save <file>                        Save current plays as an artifact
-:st, :stream                            Watch playbook results real time
-:w, :write <file>                       Write current page to a new file
-:w!, :write! <file>                     Write current page to an existing or new file
-:w>>, :write>> <file>                   Append current page to an existing file
-:w!>>, :write!>> <file>                 Append current page to an existing or new file
+----------------------------------------------------------------------------------------------------
+esc                                                   Go back
+^f/PgUp                                               Page up
+^b/PgDn                                               Page down
+arrow up, arrow down                                  Scroll up/down
+:collections                                          Explore installed collections
+:config                                               Explore the current Ansible configuration
+:d, :doc <plugin>                                     Show a plugin doc
+:r, :run <playbook> -i <inventory> -m interactive     Run a playbook in interactive mode
+:f, :filter <re>                                      Filter page lines using a regex
+:h, :help                                             This page
+:i, :inventory <inventory>                            Explore the current or alternate inventory
+:l, :log                                              Review current log file
+:o, :open                                             Open current page in the editor
+:o, :open {{ some_key }}                              Open file path in a key's value
+:q, :quit                                             Quit the application
+:q!, :quit!, ^c                                       Force quit while a playbook is running
+:rr, :rerun                                           Rerun the playbook
+:s, :save <file>                                      Save current plays as an artifact
+:st, :stream                                          Watch playbook results real time
+:w, :write <file>                                     Write current page to a new file
+:w!, :write! <file>                                   Write current page to an existing or new file
+:w>>, :write>> <file>                                 Append current page to an existing file
+:w!>>, :write!>> <file>                               Append current page to an existing or new file
 
 ## MENUS
---------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
 [0-9]                                   Go to menu item
 :<number>                               Go to menu item
 :{{ n|filter }}                         Template the menu item
 
 ## TASKS
---------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
 [0-9]                                   Go to task number
 :<number>                               Go to task number
 +, -                                    Next/Previous task
@@ -42,7 +42,7 @@ _, :_                                   Toggle hidden keys
 :y, :yaml                               Switch to YAML serialization
 
 ## LINE INPUT
---------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------:q!
 esc                                     Exit line input
 ^A                                      Beginning of line
 ^E                                      End of line

--- a/share/ansible_navigator/markdown/welcome.md
+++ b/share/ansible_navigator/markdown/welcome.md
@@ -1,17 +1,17 @@
 ## Welcome
---------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------
 
 Some things you can try from here:
-- `:config`                                 Explore the current Ansible configuration
-- `:collections`                            Explore installed collections
-- `:doc <plugin>`                           Show a plugin doc
-- `:explore <playbook> -i <inventory>`      Run a playbook with explore
-- `:help`                                   Show the main help page
-- `:inventory <inventory>`                  Explore an inventory
-- `:log`                                    Review the application log
-- `:open`                                   Open current page in the IDE
-- `:quit`                                   Quit the application
-- `:sample_form`                            Prototype curses form rendered
+- `:config`                                             Explore the current Ansible configuration
+- `:collections`                                        Explore installed collections
+- `:doc <plugin>`                                       Show a plugin doc
+- `:run <playbook> -i <inventory> -m interactive`       Run a playbook in interactive mode
+- `:help`                                               Show the main help page
+- `:inventory <inventory>`                              Explore an inventory
+- `:log`                                                Review the application log
+- `:open`                                               Open current page in the IDE
+- `:quit`                                               Quit the application
+- `:sample_form`                                        Prototype curses form rendered
 
 happy automating,
 


### PR DESCRIPTION
*  Add `run` subcommand with interactive and stdout mode
   to invoke playbook
*  Remove `explore` and `playbook` commandline option and
   relevant changes
*  Refactor runner invocation code to use the new `run_command`
   ansible-runner interface
*  Doc updates