### PR TITLE
map del to backspace, as some terms report del when backspace is pushed

### DIFF
--- a/ansible_navigator/ui_framework/form_handler_text.py
+++ b/ansible_navigator/ui_framework/form_handler_text.py
@@ -40,6 +40,10 @@ class FormHandlerText(CursesWindow, Textbox):
     def _do_command(self, char: int) -> int:
         # pylint: disable=too-many-branches
 
+        # in the case the term returns 127 instead of 263
+        if char == curses_ascii.DEL:
+            char = curses.KEY_BACKSPACE
+
         if char == curses.KEY_IC:
             self.insert_mode = not self.insert_mode
             ret = 1


### PR DESCRIPTION
while using the vscode terminal in macos, the backspace is reported as cusrses ascii DEL, this maps it back to backspace prior to letting curses handle it in the final else of the conditional in _do_command