### PR TITLE
Ignore IntelliJ based config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IntelliJ
+.idea/


### PR DESCRIPTION
Ignore `.idea` which is generate by IntelliJ based products like PyCharm.