### PR TITLE
Make multilined string in yaml human readable

### DIFF
--- a/ansible_navigator/ui_framework/ui.py
+++ b/ansible_navigator/ui_framework/ui.py
@@ -39,7 +39,7 @@ from .field_text import FieldText
 from .form_handler_text import FormHandlerText
 from .menu_builder import MenuBuilder
 
-from ..yaml import yaml, Dumper
+from ..yaml import yaml, HumanDumper
 
 STND_KEYS = {
     "^f/PgUp": "page up",
@@ -483,7 +483,7 @@ class UserInterface(CursesWindow):
             return self._colorizer.render(doc=obj, scope=self.xform())
         if self.xform() == "source.yaml":
             string = yaml.dump(
-                obj, default_flow_style=False, Dumper=Dumper, explicit_start=True, sort_keys=True
+                obj, default_flow_style=False, Dumper=HumanDumper, explicit_start=True, sort_keys=True
             )
         elif self.xform() == "source.json":
             string = json.dumps(obj, indent=4, sort_keys=True)

--- a/ansible_navigator/yaml.py
+++ b/ansible_navigator/yaml.py
@@ -1,5 +1,6 @@
 """ load libyaml or pyyaml ldumper """
 # pylint: disable=unused-import
+import re
 import yaml
 
 try:
@@ -11,3 +12,29 @@ try:
     from yaml import CLoader as Loader
 except ImportError:
     from yaml import Loader  # type: ignore
+
+
+class HumanDumper(Dumper):
+
+    def represent_scalar(self, tag, value, style=None):
+        """ Uses a block scalar for a nicer human representation of multiline strings. """
+        if style is None and _is_multiline_string(value):
+            style = '|'
+
+            # Remove leading or trailing newline and convert tabs to spaces
+            # which can cause havoc on yaml blocks
+            value = value.strip().expandtabs()
+
+            # Replace some whitespace chars
+            value = re.sub(r'[\r]', '', value)
+
+        return super(HumanDumper, self).represent_scalar(tag, value, style)
+
+
+# from http://stackoverflow.com/a/15423007/115478
+def _is_multiline_string(value):
+    for c in u"\u000a\u000d\u001c\u001d\u001e\u0085\u2028\u2029":
+        if c in value:
+            return True
+
+    return False

--- a/ansible_navigator/yaml.py
+++ b/ansible_navigator/yaml.py
@@ -28,7 +28,7 @@ class HumanDumper(Dumper):
             # Replace some whitespace chars
             value = re.sub(r'[\r]', '', value)
 
-        return super(HumanDumper, self).represent_scalar(tag, value, style)
+        return super().represent_scalar(tag, value, style)
 
 
 # from http://stackoverflow.com/a/15423007/115478

--- a/tests/tests_yaml.py
+++ b/tests/tests_yaml.py
@@ -1,0 +1,28 @@
+import pytest
+
+import ansible_navigator.yaml as yaml_import
+
+
+@pytest.mark.parametrize('input_val, expected', [
+    ('test string', 'test string\n...\n'),
+    ('test\nstring', '''|-
+  test
+  string
+'''),
+    ('\r\ntest\r\nstring\r\n', '''|-
+  test
+  string
+'''),
+    ('test\n\tstring', '''|-
+  test
+          string
+'''),
+], ids=[
+    'simple string no block',
+    'newline',
+    'leading and trailing newlines',
+    'expand tabs',
+])
+def test_human_dumper(input_val, expected):
+    actual = yaml_import.yaml.dump(input_val, default_flow_style=False, Dumper=yaml_import.HumanDumper)
+    assert actual == expected


### PR DESCRIPTION
2nd attempt of https://github.com/ansible/ansible-navigator/pull/77 that isn't just copied code.

This method now uses a custom dumper instead of mutating the global dumper state that the previous PR had. Also adds a few tests for this scenario.