### PR TITLE
[Docs] add installing ansible to the venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ cd ansible-navigator_demo
 python3 -m venv venv
 source venv/bin/activate
 pip install -U setuptools
+pip install -U ansible
 pip install ../ansible-navigator
 ```
 


### PR DESCRIPTION
Based on the comment here:
https://github.com/ansible/ansible-navigator/issues/53#issuecomment-800242310

updating the venv install instructions to include installing ansible so ``ansible-navigator collections`` works.