### PR TITLE
Hide :sample_form from welcome text

### DIFF
--- a/share/ansible_navigator/markdown/welcome.md
+++ b/share/ansible_navigator/markdown/welcome.md
@@ -11,7 +11,6 @@ Some things you can try from here:
 - `:log`                                    Review the application log
 - `:open`                                   Open current page in the IDE
 - `:quit`                                   Quit the application
-- `:sample_form`                            Prototype curses form rendered
 
 happy automating,
 


### PR DESCRIPTION
As per previous discussion; the decision was to leave the functionality in but remove public references to it, so this just removes the line from the welcome text.