### PR TITLE
Fix premature GHA nix; port smoketests to playbook

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,2 @@
+ignore: |
+  .tox

--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,3 @@
+# Needed for Zuul (CI) to run smoke tests
+git
+tmux

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = ansible-navigator
+name = ansible_navigator
 version = attr: ansible_navigator.__version__
 description = Red Hat Ansible Automation Platform CLI
 long_description = file: README.md

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+ansible-core
 black
 flake8
 pytest-xdist

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,4 +2,5 @@ ansible-core
 black
 flake8
 pytest-xdist
+pytest-cov
 yamllint

--- a/tests/smoketests/roles/assert_substring/meta/main.yml
+++ b/tests/smoketests/roles/assert_substring/meta/main.yml
@@ -1,0 +1,1 @@
+allow_duplicates: true

--- a/tests/smoketests/roles/assert_substring/meta/main.yml
+++ b/tests/smoketests/roles/assert_substring/meta/main.yml
@@ -1,1 +1,2 @@
+---
 allow_duplicates: true

--- a/tests/smoketests/roles/assert_substring/tasks/main.yml
+++ b/tests/smoketests/roles/assert_substring/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Get current output
   command: "tmux capture-pane -t smoke: -S - -E - -p"
   register: current

--- a/tests/smoketests/roles/assert_substring/tasks/main.yml
+++ b/tests/smoketests/roles/assert_substring/tasks/main.yml
@@ -1,0 +1,12 @@
+- name: Get current output
+  command: "tmux capture-pane -t smoke: -S - -E - -p"
+  register: current
+
+- name: Show current output
+  debug:
+    msg: "{{ current.stdout_lines }}"
+
+- name: Ensure that expected substring '{{ expected }}' is in the output
+  assert:
+    that:
+      - expected in current.stdout

--- a/tests/smoketests/roles/send_keys/defaults/main.yml
+++ b/tests/smoketests/roles/send_keys/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 expected: null
 sleep: null
 keys: []

--- a/tests/smoketests/roles/send_keys/defaults/main.yml
+++ b/tests/smoketests/roles/send_keys/defaults/main.yml
@@ -1,0 +1,3 @@
+expected: null
+sleep: null
+keys: []

--- a/tests/smoketests/roles/send_keys/meta/main.yml
+++ b/tests/smoketests/roles/send_keys/meta/main.yml
@@ -1,0 +1,1 @@
+allow_duplicates: true

--- a/tests/smoketests/roles/send_keys/meta/main.yml
+++ b/tests/smoketests/roles/send_keys/meta/main.yml
@@ -1,1 +1,2 @@
+---
 allow_duplicates: true

--- a/tests/smoketests/roles/send_keys/tasks/main.yml
+++ b/tests/smoketests/roles/send_keys/tasks/main.yml
@@ -1,0 +1,16 @@
+- name: "Send keys: {{ keys }}"
+  command:
+    argv: "{{ command_prefix + keys }}"
+  vars:
+    command_prefix: ["tmux", "send-keys", "-t", "smoke:"]
+
+- name: Wait after sending keys
+  pause:
+    seconds: "{{ sleep if sleep is not none else 2 }}"
+
+# Just a shortcut for a common action after sending keys to avoid having to
+# explicitly call the assert_substring role each time.
+- name: Assert expected substring is on the screen
+  when: expected is not none
+  include_role:
+    name: assert_substring

--- a/tests/smoketests/roles/send_keys/tasks/main.yml
+++ b/tests/smoketests/roles/send_keys/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: "Send keys: {{ keys }}"
   command:
     argv: "{{ command_prefix + keys }}"

--- a/tests/smoketests/run.yml
+++ b/tests/smoketests/run.yml
@@ -2,6 +2,7 @@
 - hosts: localhost
   pre_tasks:
     - name: Install system dependencies
+      become: true
       package:
         name:
           - git

--- a/tests/smoketests/run.yml
+++ b/tests/smoketests/run.yml
@@ -15,6 +15,15 @@
 
     - name: Prepare tmux session that we can use for tests
       shell: tmux new-session -d -s smoke
+
+    - name: Run `ansible-navigator --help`
+      command: ansible-navigator --help
+      register: anh
+
+    - assert:
+        that:
+          - '"show this help message and exit" in anh.stdout'
+
   roles:
     # Add where pip drops the entrypoint to our PATH
     - role: send_keys

--- a/tests/smoketests/run.yml
+++ b/tests/smoketests/run.yml
@@ -1,3 +1,4 @@
+---
 - hosts: localhost
   pre_tasks:
     - name: Install system dependencies

--- a/tests/smoketests/run.yml
+++ b/tests/smoketests/run.yml
@@ -1,13 +1,6 @@
 ---
 - hosts: localhost
   pre_tasks:
-    - name: Install system dependencies
-      become: true
-      package:
-        name:
-          - git
-          - tmux
-
     - name: Install ansible-navigator
       pip:
         chdir: "{{ playbook_dir }}/../../"

--- a/tests/smoketests/run.yml
+++ b/tests/smoketests/run.yml
@@ -1,0 +1,79 @@
+- hosts: localhost
+  pre_tasks:
+    - name: Install system dependencies
+      package:
+        name:
+          - git
+          - tmux
+
+    - name: Install ansible-navigator
+      pip:
+        chdir: "{{ playbook_dir }}/../../"
+        name: .
+
+    - name: Prepare tmux session that we can use for tests
+      shell: tmux new-session -d -s smoke
+  roles:
+    # Add where pip drops the entrypoint to our PATH
+    - role: send_keys
+      keys:
+        - export PATH=$PATH:~/.local/bin
+        - Enter
+
+    # Main page
+    - role: send_keys
+      keys:
+        - ansible-navigator
+        - Enter
+      expected: Some things you can try
+
+    # Help page
+    - role: send_keys
+      keys:
+        - :help
+        - Enter
+      expected: Go back
+
+    # Second help page
+    - role: send_keys
+      keys:
+        - PgDn
+      expected: TASKS
+
+    # 'debug' module doc page from help page
+    - role: send_keys
+      keys:
+        - :doc debug
+        - Enter
+      expected: "collection: ansible.builtin"
+
+    # Back to help page -- but we end up back at the top...
+    - role: send_keys
+      keys:
+        - Escape
+      expected: Go back
+
+    # Back to main menu
+    - role: send_keys
+      keys:
+        - Escape
+      expected: Some things you can try
+
+    # Config + filter
+    - role: send_keys
+      keys:
+        - :config
+        - Enter
+      sleep: 4 # Config takes some time to render
+
+    - role: send_keys
+      keys:
+        - :f COW
+        - Enter
+      expected: ANSIBLE_COW_SELECTION
+
+  post_tasks:
+    # Clean up if we make it this far.
+    - name: Kill tmux session
+      command: "tmux kill-session -t smoke:"
+      ignore_errors: true

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.4.2
-envlist = linters
+envlist = linters,py38
 skipsdist = True
 skip_missing_interpreters = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,3 +34,9 @@ exclude = .git,.tox
 [testenv:type]
 commands =
     mypy ansible_navigator share/ansible_navigator/utils
+
+# Note included in the default envlist above since it's destructive
+# (requires tmux, git, runs a bunch of commands, etc.)
+[testenv:smoke]
+commands = ansible-playbook tests/smoketests/run.yml
+allowlist_externals = ansible-playbook

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,10 @@ skip_missing_interpreters = true
 [testenv]
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
+
+
+[testenv:py38]
+description = Run tests in 38
 commands =
     py.test -v
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/851

Change:
- Apparently if these tests are moved to a playbook, they're usable by
  Zuul, now they're a playbook.

Test Plan:
- Tested the playbook several times in a clean CentOS 8 VM.

Signed-off-by: Rick Elrod <rick@elrod.me>