### PR TITLE
Add run action to support interactive and stdout mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ ansible-navigator doc ansible.netcommon.cli_command
 
 Run and explore a playbook
 ```
-ansible-navigator explore site.yaml -i inventory.yaml
+ansible-navigator run -m interactive site.yaml -i inventory.yaml
 ```
 
 Review and explore and inventory
@@ -61,9 +61,9 @@ Review and explore and inventory
 ansible-navigator inventory -i inventory.yaml
 ```
 
-Run a playbook with classic output
+Run a playbook with classic output (default mode)
 ```
-ansible-navigator playbook site.yaml -i inventory.yaml
+ansible-navigator run -m stdout site.yaml -i inventory.yaml
 ```
 
 
@@ -99,7 +99,7 @@ arrow up, arrow down                    Scroll up/down
 :collections                            Explore installed collections
 :config                                 Explore the current Ansible configuration
 :d, :doc <plugin>                       Show a plugin doc
-:e, :explore <playbook> -i <inventory>  Run a playbook using explore
+:r, :run <playbook> -i <inventory>      Run a playbook using in interactive mode
 :f, :filter <re>                        Filter page lines using a regex
 :h, :help                               This page
 :i, :inventory <inventory>              Explore the current or alternate inventory

--- a/ansible_navigator/action_runner.py
+++ b/ansible_navigator/action_runner.py
@@ -2,7 +2,7 @@
 """
 
 from ansible_navigator.actions import kegexes
-from ansible_navigator.actions import run as run_action
+from ansible_navigator.actions import run_action
 
 from .app import App
 from .steps import Steps

--- a/ansible_navigator/actions/__init__.py
+++ b/ansible_navigator/actions/__init__.py
@@ -8,10 +8,10 @@ from ..app_public import AppPublic
 names = actions.names_factory(__package__)
 
 
-run: Callable[[str, AppPublic, Interaction], Union[None, Interaction]] = actions.call_factory(
-    __package__
-)
+run_action: Callable[
+    [str, AppPublic, Interaction], Union[None, Interaction]
+] = actions.call_factory(__package__)
 kegexes: Callable = actions.kegexes_factory(__package__)
 
 
-__all__ = ["kegexes", "names", "run"]
+__all__ = ["kegexes", "names", "run_action"]

--- a/ansible_navigator/actions/collections.py
+++ b/ansible_navigator/actions/collections.py
@@ -14,7 +14,7 @@ from typing import List
 from typing import Tuple
 from typing import Union
 
-from . import run as run_action
+from . import run_action
 from . import _actions as actions
 from ..app import App
 from ..app_public import AppPublic

--- a/ansible_navigator/actions/config.py
+++ b/ansible_navigator/actions/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 from typing import List
 from typing import Union
 
-from . import run as run_action
+from . import run_action
 from . import _actions as actions
 from ..app import App
 from ..app_public import AppPublic

--- a/ansible_navigator/actions/inventory.py
+++ b/ansible_navigator/actions/inventory.py
@@ -13,7 +13,7 @@ from typing import Dict
 from typing import List
 from typing import Union
 
-from . import run as run_action
+from . import run_action
 from . import _actions as actions
 
 from ..app import App

--- a/ansible_navigator/cli.py
+++ b/ansible_navigator/cli.py
@@ -23,7 +23,7 @@ from typing import Union
 
 from curses import wrapper
 
-from .actions.explore import Action as Player
+from .actions.run import Action as Player
 
 from .cli_args import CliArgs
 from .action_runner import ActionRunner
@@ -280,7 +280,7 @@ def parse_and_update(params: List, error_cb: Callable = None) -> Tuple[List[str]
 def run(args: Namespace) -> None:
     """run the appropriate app"""
     try:
-        if args.app == "playbook":
+        if args.app == "run" and args.navigator_mode == "stdout":
             non_ui_app = partial(Player(args).playbook)
             if args.web:
                 WebXtermJs().run(func=non_ui_app)

--- a/ansible_navigator/cli_args.py
+++ b/ansible_navigator/cli_args.py
@@ -54,8 +54,7 @@ class CliArgs:
         self._doc()
         self._inventory()
         self._load()
-        self._explore()
-        self._playbook()
+        self._run()
 
     def _add_subparser(self, name: str, desc: str) -> ArgumentParser:
         return self._subparsers.add_parser(
@@ -73,6 +72,7 @@ class CliArgs:
         self._log_params(self._base_parser)
         self._no_osc4_params(self._base_parser)
         self._web_params(self._base_parser)
+        self._navigator_mode(self._base_parser)
 
     def _collections(self) -> None:
         parser = self._add_subparser("collections", "Explore installed collections")
@@ -144,8 +144,10 @@ class CliArgs:
             dest="ee_image",
         )
 
-    def _explore(self) -> None:
-        parser = self._add_subparser("explore", "Run playbook(s) interactive")
+    def _run(self) -> None:
+        parser = self._add_subparser(
+            "run", "Run Ansible playbook in either interactive or stdout mode"
+        )
         self._playbook_params(parser)
         self._inventory_params(parser)
 
@@ -231,11 +233,6 @@ class CliArgs:
             dest="no_osc4",
         )
 
-    def _playbook(self) -> None:
-        parser = self._add_subparser("playbook", "Run playbook(s)")
-        self._playbook_params(parser)
-        self._inventory_params(parser)
-
     @staticmethod
     def _playbook_params(parser: ArgumentParser) -> None:
         parser.add_argument(
@@ -260,4 +257,16 @@ class CliArgs:
             action="store_true",
             help="Run the application in a browser rather than the current terminal",
             dest="web",
+        )
+
+    @staticmethod
+    def _navigator_mode(parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "-m",
+            "--mode",
+            default="stdout",
+            dest="navigator_mode",
+            choices=["stdout", "interactive"],
+            help="Specify the navigator mode to run",
+            type=str,
         )

--- a/lint_and_check.sh
+++ b/lint_and_check.sh
@@ -1,5 +1,5 @@
-black ansible_navigator
-black share/ansible_navigator/utils
+black -l100 ansible_navigator
+black -l100 share/ansible_navigator/utils
 mypy ansible_navigator share/ansible_navigator/utils
 pylint ./ansible_navigator/*.* ./ansible_navigator/actions ./share/ansible_navigator/utils ./ansible_navigator/ui_framework
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    ansible-runner @ git+https://github.com/ansible/ansible-runner.git#egg=ansible-runner-devel
+     ansible-runner @ git+https://github.com/ganeshrn/ansible-runner.git@explorer_changes#egg=ansible-runner-devel
     awxkit
     jinja2
     onigurumacffi

--- a/share/ansible_navigator/markdown/help.md
+++ b/share/ansible_navigator/markdown/help.md
@@ -1,28 +1,28 @@
 ## GENERAL
---------------------------------------------------------------------------------------
-esc                                     Go back
-^f/PgUp                                 Page up
-^b/PgDn                                 Page down
-arrow up, arrow down                    Scroll up/down
-:collections                            Explore installed collections
-:config                                 Explore the current Ansible configuration
-:d, :doc <plugin>                       Show a plugin doc
-:e, :explore <playbook> -i <inventory>  Run a playbook using explore
-:f, :filter <re>                        Filter page lines using a regex
-:h, :help                               This page
-:i, :inventory <inventory>              Explore the current or alternate inventory
-:l, :log                                Review current log file
-:o, :open                               Open current page in the editor
-:o, :open {{ some_key }}                Open file path in a key's value
-:q, :quit                               Quit the application
-:q!, :quit!, ^c                         Force quit while a playbook is running
-:rr, :rerun                             Rerun the playbook
-:s, :save <file>                        Save current plays as an artifact
-:st, :stream                            Watch playbook results real time
-:w, :write <file>                       Write current page to a new file
-:w!, :write! <file>                     Write current page to an existing or new file
-:w>>, :write>> <file>                   Append current page to an existing file
-:w!>>, :write!>> <file>                 Append current page to an existing or new file
+----------------------------------------------------------------------------------------------------
+esc                                                   Go back
+^f/PgUp                                               Page up
+^b/PgDn                                               Page down
+arrow up, arrow down                                  Scroll up/down
+:collections                                          Explore installed collections
+:config                                               Explore the current Ansible configuration
+:d, :doc <plugin>                                     Show a plugin doc
+:r, :run <playbook> -i <inventory> -m interactive     Run a playbook in interactive mode
+:f, :filter <re>                                      Filter page lines using a regex
+:h, :help                                             This page
+:i, :inventory <inventory>                            Explore the current or alternate inventory
+:l, :log                                              Review current log file
+:o, :open                                             Open current page in the editor
+:o, :open {{ some_key }}                              Open file path in a key's value
+:q, :quit                                             Quit the application
+:q!, :quit!, ^c                                       Force quit while a playbook is running
+:rr, :rerun                                           Rerun the playbook
+:s, :save <file>                                      Save current plays as an artifact
+:st, :stream                                          Watch playbook results real time
+:w, :write <file>                                     Write current page to a new file
+:w!, :write! <file>                                   Write current page to an existing or new file
+:w>>, :write>> <file>                                 Append current page to an existing file
+:w!>>, :write!>> <file>                               Append current page to an existing or new file
 
 ## MENUS
 --------------------------------------------------------------------------------------

--- a/share/ansible_navigator/markdown/welcome.md
+++ b/share/ansible_navigator/markdown/welcome.md
@@ -1,16 +1,16 @@
 ## Welcome
---------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
 
 Some things you can try from here:
-- `:config`                                 Explore the current Ansible configuration
-- `:collections`                            Explore installed collections
-- `:doc <plugin>`                           Show a plugin doc
-- `:explore <playbook> -i <inventory>`      Run a playbook with explore
-- `:help`                                   Show the main help page
-- `:inventory <inventory>`                  Explore an inventory
-- `:log`                                    Review the application log
-- `:open`                                   Open current page in the IDE
-- `:quit`                                   Quit the application
+- `:config`                                               Explore the current Ansible configuration
+- `:collections`                                          Explore installed collections
+- `:doc <plugin>`                                         Show a plugin doc
+- `:r, :run <playbook> -i <inventory> -m interactive`     Run a playbook in interactive mode
+- `:help`                                                 Show the main help page
+- `:inventory <inventory>`                                Explore an inventory
+- `:log`                                                  Review the application log
+- `:open`                                                 Open current page in the IDE
+- `:quit`                                                 Quit the application
 
 happy automating,
 


### PR DESCRIPTION
*  Add `run` subcommand with interactive and stdout mode
   to invoke playbook
*  Remove `explore` and `playbook` command line option and
   relevant changes
*  Refactor runner invocation code to use the new `run_command`
   ansible-runner interface
*  Doc updates