### PR TITLE
Add support for tox -epy38

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 black
 flake8
 pytest-xdist
+pytest-cov
 yamllint

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# NOTE(pabelanger): Default to pip3, when possible this is becaue python2
+# support is EOL.
+PIP=$(command -v pip3) || PIP=$(command -v pip2)
+
+# NOTE(pabelanger): Tox on centos-7 is old, so upgrade it across all distros
+# to the latest version
+# NOTE(pabelanger): Cap zipp<0.6.0 due to python2.7 issue with more-iterrtools
+# https://github.com/jaraco/zipp/issues/14
+sudo $PIP install -U tox "configparser<5" "zipp<0.6.0;python_version=='2.7'"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.4.2
-envlist = linters
+envlist = linters,py3
 skipsdist = True
 skip_missing_interpreters = true
 


### PR DESCRIPTION
This adds support to run tox jobs in zuul, along with upgrading tox to
the latest version.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>