### PR TITLE
Use ansible-runner from devel instead of fork

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    ansible-runner @ git+https://github.com/ganeshrn/ansible-runner.git@explorer_changes#egg=ansible-runner-devel
+    ansible-runner @ git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner-devel
     awxkit
     jinja2
     onigurumacffi


### PR DESCRIPTION
Change:
- Necessary changes have landed in the official repo, so use that
  instead of the fork we were using previously.

Signed-off-by: Rick Elrod <rick@elrod.me>