### PR TITLE
Fix single inventory source form prompt

### DIFF
--- a/ansible_navigator/actions/run.py
+++ b/ansible_navigator/actions/run.py
@@ -462,7 +462,7 @@ class Action(App):
         }
         form_dict["fields"].append(form_field)
 
-        if hasattr(new_args, "inventory"):
+        if hasattr(new_args, "inventory") and new_args.inventory:
             for idx, inv in enumerate(new_args.inventory):
                 form_field = {
                     "name": f"inv_{idx}",


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible-navigator/issues/120

If inventory source is not provided as for input within the user
form