### PR TITLE
Add support for inventory subcommand stdout mode

### DIFF
--- a/ansible_navigator/cli.py
+++ b/ansible_navigator/cli.py
@@ -285,7 +285,7 @@ def parse_and_update(params: List, error_cb: Callable = None) -> Tuple[List[str]
 def run(args: Namespace) -> None:
     """run the appropriate app"""
     try:
-        if args.app in ["run", "config"] and args.mode == "stdout":
+        if args.app in ["run", "config", "inventory"] and args.mode == "stdout":
             try:
                 app_action = __import__(
                     f"actions.{args.app}", globals(), fromlist=["Action"], level=1

--- a/ansible_navigator/runner/api.py
+++ b/ansible_navigator/runner/api.py
@@ -12,7 +12,7 @@ from typing import List
 from typing import Dict
 
 from ansible_runner import Runner  # type: ignore
-from ansible_runner import run_command_async, run_command, get_ansible_config
+from ansible_runner import run_command_async, run_command, get_ansible_config, get_inventory
 
 
 class BaseRunner:
@@ -202,6 +202,7 @@ class CommandRunner(CommandBaseRunner):
 
 
 class AnsibleCfgRunner(BaseRunner):
+    # pylint: disable=too-many-arguments
     """abstraction for ansible-config command-line"""
 
     def fetch_ansible_config(
@@ -227,4 +228,52 @@ class AnsibleCfgRunner(BaseRunner):
         """
         return get_ansible_config(
             action, config_file=config_file, only_changed=only_changed, **self._runner_args
+        )
+
+
+class InventoryRunner(BaseRunner):
+    # pylint: disable=too-many-arguments
+    """abstraction for ansible-inventory command-line"""
+
+    def fetch_inventory(
+        self,
+        action: str,
+        inventories: List,
+        response_format: Optional[str] = None,
+        host: Optional[str] = None,
+        playbook_dir: Optional[str] = None,
+        vault_ids: Optional[str] = None,
+        vault_password_file: Optional[str] = None,
+    ) -> Tuple[str, str]:
+        """Run ansible-inventory command and get the inventory related details
+
+        Args:
+            action (str): Valid values are one of ``graph``, ``host``, ``list``
+                          ``graph`` create inventory graph, ``host`` returns specific
+                          host info and works as inventory script and ``list`` output
+                          all hosts info and also works as inventory script.
+            inventories (List): List of inventory host path.
+            response_format (Optional[str], optional): The output format for response. Valid values
+                                                       can be one of ``json``, ``yaml``, ``toml``.
+                                                       If ``action`` is ``graph`` only allowed
+                                                       value is ``json``.
+            host (Optional[str], optional): When ``action`` is set to ``host`` this parameter is
+                                            used to get the host specific information..
+            playbook_dir (Optional[str], optional): This parameter is used to sets the relative
+                                                    path for the inventory.
+            vault_ids (Optional[str], optional): The vault identity to use.
+            vault_password_file (Optional[str], optional): The vault identity to use.
+
+        Returns:
+            Tuple[str, str]: Returns a tuple of response and error string (if any).
+        """
+        return get_inventory(
+            action,
+            inventories=inventories,
+            response_format=response_format,
+            host=host,
+            playbook_dir=playbook_dir,
+            vault_ids=vault_ids,
+            vault_password_file=vault_password_file,
+            **self._runner_args
         )


### PR DESCRIPTION
*  Add support to run `ansible-inventory` command in
   pass-through mode to work within local and execution
   environment.
*  Refactor inventory action plugin to use new runner API's
   for interactive and stdout mode