### PR TITLE
Simplify logic for reparsing command line

### DIFF
--- a/ansible_navigator/actions/run.py
+++ b/ansible_navigator/actions/run.py
@@ -375,7 +375,7 @@ class Action(App):
                 if field["name"].startswith("inv_") and field["value"] != "":
                     new_cmd.extend(["-i", field["value"]])
             if populated_form["fields"]["cmdline"]["value"]:
-                new_cmd.append(populated_form["fields"]["cmdline"]["value"])
+                new_cmd.extend(populated_form["fields"]["cmdline"]["value"].split())
 
             # Parse as if provided from the cmdline
             new_args = self._update_args(new_cmd)

--- a/ansible_navigator/actions/run.py
+++ b/ansible_navigator/actions/run.py
@@ -2,6 +2,7 @@
 """
 import copy
 import curses
+import datetime
 import json
 import logging
 import os
@@ -34,9 +35,7 @@ from ..ui_framework import dict_to_form
 from ..ui_framework.form_utils import form_to_dict
 
 
-from ..utils import check_for_ansible
 from ..utils import human_time
-from ..utils import set_ansible_envar
 
 
 RESULT_TO_COLOR = [
@@ -217,7 +216,6 @@ class Action(App):
         self.args: Namespace
         self._interaction: Interaction
         self._calling_app: AppPublic
-        self._parser_error: str
         self._subaction_type: str
 
         self._msg_from_plays = (None, None)
@@ -235,15 +233,6 @@ class Action(App):
             select_func=self._task_list_for_play,
         )
 
-    def parser_error(self, message: str) -> Tuple[None, None]:
-        """callback for parser error
-
-        :param message: A message from the parser
-        :type message: str
-        """
-        self._parser_error = message
-        return None, None
-
     def run_stdout(self) -> None:
         """Run in oldschool mode, just stdout
 
@@ -257,7 +246,7 @@ class Action(App):
             self._dequeue()
             if self.runner.finished:
                 if self.args.artifact:
-                    self.write_artifact(self.args.artifact)
+                    self.write_artifact()
                 self._logger.debug("runner finished")
                 break
 
@@ -330,51 +319,69 @@ class Action(App):
         interaction.ui.scroll(previous_scroll)
         return None
 
+    # pylint: disable=too-many-branches
     def _init_run(self) -> bool:
         """in the case of :run, parse the user input"""
-        playbook = ""
 
+        # Use the provided playbook, or the previously specified playbook
         p_from_int = self._interaction.action.match.groupdict().get("playbook")
         if p_from_int:
-            self._logger.debug("Using playbook provided in interaction")
-            playbook = os.path.abspath(os.path.expanduser(p_from_int))
+            self._logger.debug("Using playbook provided by user")
+            playbook = p_from_int
         elif getattr(self._calling_app.args, "playbook", None):
             self._logger.debug("Using playbook from calling app")
             playbook = self._calling_app.args.playbook
+        else:
+            playbook = ""
 
-        params = self._interaction.action.match.groupdict().get("params")
-        if params:
-            self._logger.debug("Using params provided in interaction")
-            params = [self._name_at_cli] + [playbook] + params.split()
-            new_args = self._update_args(params)
+        # if we have a playbook, use params, inventory, etc
+        if playbook:
+            # Use the provided params, or inventory and cmdline previously provided
+            params = []
+            user_provided_params = self._interaction.action.match.groupdict().get("params")
+            if user_provided_params:
+                self._logger.debug("Using params provided by user")
+                params.extend(user_provided_params.split())
+            elif self._calling_app.args.app == "run":
+                self._logger.debug("Calling app was run, reusing inv + cmdline from calling app")
+                for inventory in self._calling_app.args.inventory:
+                    params.extend(["-i", inventory])
+                params += self._calling_app.args.cmdline
+            else:
+                self._logger.debug("Params set to [], params not provided, or calling app not run")
+
+            new_cmd = [self._name_at_cli] + [playbook] + params
+            self._logger.debug("Parsing: %s", " ".join(new_cmd))
+
+            # Parse as if provided from the cmdline
+            new_args = self._update_args(new_cmd)
             if new_args is None:
                 return False
-        else:
-            self._logger.debug("Using params from calling app")
-            new_args = copy.copy(self._calling_app.args)
+            self.args = new_args
 
+        # Ensure the playbook and inventory are valid
         playbook_valid = os.path.exists(playbook)
-        inventory_valid = bool(getattr(new_args, "inventory", ())) and all(
-            (os.path.exists(inv) for inv in getattr(new_args, "inventory", ()))
-        )
+        inventory_valid = all((os.path.exists(inv) for inv in self.args.inventory))
 
-        if playbook_valid and inventory_valid:
-            new_args.playbook = playbook
-        else:
-            populated_form = self._prompt_for_playbook(new_args, playbook)
+        if not all((playbook_valid, inventory_valid)):
+
+            populated_form = self._prompt_for_playbook()
             if populated_form["cancelled"]:
                 return False
-            new_args.playbook = populated_form["fields"]["playbook"]["value"]
-            new_args.inventory = [
-                field["value"]
-                for field in populated_form["fields"].values()
-                if field["name"].startswith("inv_") and field["value"] != ""
-            ]
-            new_args.cmdline = populated_form["fields"]["cmdline"]["value"].split()
 
-        self.args = new_args
-        for key, value in vars(self.args).items():
-            self._logger.debug("Running with %s=%s %s", key, value, type(value))
+            new_cmd = [self._name_at_cli]
+            new_cmd.append(populated_form["fields"]["playbook"]["value"])
+            for field in populated_form["fields"].values():
+                if field["name"].startswith("inv_") and field["value"] != "":
+                    new_cmd.extend(["-i", field["value"]])
+            if populated_form["fields"]["cmdline"]["value"]:
+                new_cmd.append(populated_form["fields"]["cmdline"]["value"])
+
+            # Parse as if provided from the cmdline
+            new_args = self._update_args(new_cmd)
+            if new_args is None:
+                return False
+            self.args = new_args
 
         self._run_runner()
         self._logger.info("Run initialized and playbook started.")
@@ -443,7 +450,7 @@ class Action(App):
         populated_form = form_to_dict(form, key_on_name=True)
         return populated_form
 
-    def _prompt_for_playbook(self, new_args: Namespace, playbook: str) -> Dict[Any, Any]:
+    def _prompt_for_playbook(self) -> Dict[Any, Any]:
         """prepopulate a form to confirm the playbook details"""
 
         self._logger.debug("Inventory/Playbook not set, provided, or valid, prompting")
@@ -454,15 +461,15 @@ class Action(App):
         }
         form_field = {
             "name": "playbook",
-            "pre_populate": playbook,
+            "pre_populate": self.args.playbook,
             "prompt": "Path to playbook",
             "type": "text_input",
             "validator": {"name": "valid_file_path"},
         }
         form_dict["fields"].append(form_field)
 
-        if hasattr(new_args, "inventory") and new_args.inventory:
-            for idx, inv in enumerate(new_args.inventory):
+        if self.args.inventory:
+            for idx, inv in enumerate(self.args.inventory):
                 form_field = {
                     "name": f"inv_{idx}",
                     "pre_populate": inv,
@@ -482,7 +489,7 @@ class Action(App):
 
         form_field = {
             "name": "cmdline",
-            "pre_populate": " ".join(new_args.cmdline),
+            "pre_populate": " ".join(self.args.cmdline),
             "prompt": "Additional command line paramters",
             "type": "text_input",
             "validator": {"name": "none"},
@@ -539,38 +546,10 @@ class Action(App):
         as if run was invoked from the command line
         provide an error callback so the app doesn't sys.exit if the aprsing fails
         """
+        args = super()._update_args(params)
 
-        try:
-            msgs, new_args = self._calling_app.args.parse_and_update(
-                params=params, error_cb=self.parser_error
-            )
-        except TypeError:
-            self._logger.error("While attempting to parse %s:", " ".join(params))
-            self._logger.error(self._parser_error)
+        if args is None:
             return None
-
-        for msg in msgs:
-            self._logger.debug(msg)
-
-        args = copy.copy(self._calling_app.args)
-        for key, value in vars(new_args).items():
-            arg_value = getattr(args, key, None)
-            if arg_value != value:
-                self._logger.debug(
-                    "Overriding previous cli param '%s:%s' with '%s:%s'", key, arg_value, key, value
-                )
-                setattr(args, key, value)
-
-        if not hasattr(args, "requires_ansible") or args.requires_ansible:
-            if not args.execution_environment:
-                success, msg = check_for_ansible()
-                if success:
-                    self._logger.debug(msg)
-                else:
-                    self._logger.critical(msg)
-                    return None
-            set_ansible_envar()
-
         if not hasattr(args, "playbook"):
             self._logger.error(
                 "No playbook specified or previous provided when starting application"
@@ -712,8 +691,7 @@ class Action(App):
                 self.runner.cancelled = True
                 while not self.runner.finished:
                     pass
-                if hasattr(self.args, "artifact"):
-                    self.write_artifact(self.args.artifact)
+                self.write_artifact()
                 return True
             self._logger.warning("Quit requested but playbook running, try q! or quit!")
             return False
@@ -761,8 +739,7 @@ class Action(App):
                 # self._interaction.ui.disable_refresh()
                 self._logger.debug("runner finished")
                 self._logger.info("Playbook complete")
-                if hasattr(self.args, "artifact"):
-                    self.write_artifact(self.args.artifact)
+                self.write_artifact()
                 self._runner_finished = True
 
     def _get_status(self) -> Tuple[str, int]:
@@ -791,23 +768,33 @@ class Action(App):
         status, status_color = self._get_status()
         self._interaction.ui.update_status(status, status_color)
 
-    def write_artifact(self, filename: str) -> None:
+    def write_artifact(self, filename: Optional[str] = None) -> None:
         """Write the artifact
 
         :param filename: The file to write to
         :type filename: str
         """
-        status, status_color = self._get_status()
-        with open(filename, "w") as outfile:
-            artifact = {
-                "version": "1.0.0",
-                "plays": self._plays.value,
-                "stdout": self.stdout,
-                "status": status,
-                "status_color": status_color,
-            }
-            json.dump(artifact, outfile, indent=4)
-        self._logger.info("Saved artifact as %s", filename)
+
+        if self.args.playbook_artifact or filename is not None:
+            status, status_color = self._get_status()
+            ts_utc = datetime.datetime.now(tz=datetime.timezone.utc)
+            if filename is None:
+                filename = self.args.playbook_artifact.format(
+                    playbook_dir=os.path.dirname(self.args.playbook),
+                    playbook_name=os.path.splitext(os.path.basename(self.args.playbook))[0],
+                    ts_utc=ts_utc,
+                )
+
+            with open(filename, "w") as outfile:
+                artifact = {
+                    "version": "1.0.0",
+                    "plays": self._plays.value,
+                    "stdout": self.stdout,
+                    "status": status,
+                    "status_color": status_color,
+                }
+                json.dump(artifact, outfile, indent=4)
+            self._logger.info("Saved artifact as %s", filename)
 
     def rerun(self) -> None:
         """rerun the current playbook

--- a/ansible_navigator/cli.py
+++ b/ansible_navigator/cli.py
@@ -242,6 +242,10 @@ def parse_and_update(params: List, error_cb: Callable = None) -> Tuple[List[str]
     if args.app == "load" and not os.path.exists(args.value):
         parser.error(f"The file specified with load could not be found. {args.load}")
 
+    # don't expand "" (the default)
+    if hasattr(args, "playbook") and args.playbook:
+        args.playbook = os.path.abspath(os.path.expanduser(args.playbook))
+
     if hasattr(args, "inventory"):
         # The default argparse value is [Sentinel] for default detection purposes
         # at this point it's been set to a user value so we can remove any Sentinels

--- a/ansible_navigator/cli.py
+++ b/ansible_navigator/cli.py
@@ -252,15 +252,9 @@ def parse_and_update(params: List, error_cb: Callable = None) -> Tuple[List[str]
         if not args.inventory and args.app == "inventory":
             parser.error("an inventory is required when using the inventory explorer")
 
-    if hasattr(args, "artifact"):
-        # Would like to do this when importing config values in update_args()
-        args.artifact = args.artifact.format(
-            playbook_dir=os.path.dirname(args.playbook),
-            playbook_name=os.path.splitext(os.path.basename(args.playbook))[0],
-        )
-
     if not args.app:
         args.app = "welcome"
+        args.mode = "interactive"
         args.value = None
 
     share_dir = _get_share_dir()
@@ -278,6 +272,10 @@ def parse_and_update(params: List, error_cb: Callable = None) -> Tuple[List[str]
     pre_logger_msgs += msgs
 
     args.original_command = params
+    args.parse_and_update = parse_and_update
+
+    for key, value in sorted(vars(args).items()):
+        pre_logger_msgs.append(f"Running with {key} as {value} {type(value)}")
 
     return pre_logger_msgs, args
 
@@ -313,7 +311,6 @@ def main():
     # pylint: disable=too-many-branches
 
     pre_logger_msgs, args = parse_and_update(sys.argv[1:])
-    args.parse_and_update = parse_and_update
 
     setup_logger(args)
     for msg in pre_logger_msgs:
@@ -331,9 +328,6 @@ def main():
                 logger.critical(msg)
                 error_and_exit_early(msg)
         set_ansible_envar()
-
-    for key, value in sorted(vars(args).items()):
-        logger.debug("Running with '%s' as '%s' %s", key, value, type(value))
 
     run(args)
 

--- a/ansible_navigator/cli_args.py
+++ b/ansible_navigator/cli_args.py
@@ -267,14 +267,18 @@ class CliArgs:
     @staticmethod
     def _playbook_params(parser: ArgumentParser) -> None:
         parser.add_argument(
-            "playbook", nargs="?", help="The name of the playbook(s) to run", type=_abs_user_path
+            "playbook",
+            nargs="?",
+            help="The name of the playbook(s) to run",
+            type=_abs_user_path,
+            default=Sentinel,
         )
         parser.add_argument(
-            "-a",
-            "--artifact",
+            "--pa",
+            "--playbook-artifact",
             help="Specify the artifact file name for playbook results",
             default=Sentinel,
-            dest="artifact",
+            dest="playbook_artifact",
         )
         parser.set_defaults(requires_ansible=True)
 

--- a/ansible_navigator/config.py
+++ b/ansible_navigator/config.py
@@ -46,14 +46,14 @@ _DEFAULTS = {
         },
         "mode": "interactive",
         "no-osc4": False,
-        "playbook-artifact": "{playbook_dir}/{playbook_name}_artifact.json",
+        "playbook": "",
+        "playbook-artifact": "{playbook_dir}/{playbook_name}-artifact-{ts_utc}.json",
     },
 }
 
 # This maps argparse destination variables to config paths
 ROOT = "ansible-navigator"
 ARGPARSE_TO_CONFIG = {
-    "artifact": [ROOT, "playbook-artifact"],
     "container_engine": [ROOT, "container-engine"],
     "editor_command": [ROOT, "editor", "command"],
     "editor_console": [ROOT, "editor", "console"],
@@ -64,6 +64,8 @@ ARGPARSE_TO_CONFIG = {
     "logfile": [ROOT, "log", "file"],
     "loglevel": [ROOT, "log", "level"],
     "mode": [ROOT, "mode"],
+    "playbook": [ROOT, "playbook"],
+    "playbook_artifact": [ROOT, "playbook-artifact"],
     "no_osc4": [ROOT, "no-osc4"],
     "type": [ROOT, "doc-plugin-type"],
 }

--- a/share/ansible_navigator/markdown/help.md
+++ b/share/ansible_navigator/markdown/help.md
@@ -10,7 +10,7 @@ arrow up, arrow down                                  Scroll up/down
 :r, :run <playbook> -i <inventory>                    Run a playbook in interactive mode
 :f, :filter <re>                                      Filter page lines using a regex
 :h, :help                                             This page
-:i, :inventory <inventory>                            Explore the current or alternate inventory
+:i -i <inventory>, :inventory -i <inventory>          Explore the current or alternate inventory
 :l, :log                                              Review current log file
 :o, :open                                             Open current page in the editor
 :o, :open {{ some_key }}                              Open file path in a key's value

--- a/share/ansible_navigator/markdown/welcome.md
+++ b/share/ansible_navigator/markdown/welcome.md
@@ -7,7 +7,7 @@ Some things you can try from here:
 - `:doc <plugin>`                                         Show a plugin doc
 - `:run <playbook> -i <inventory>`                        Run a playbook in interactive mode
 - `:help`                                                 Show the main help page
-- `:inventory <inventory>`                                Explore an inventory
+- `:inventory -i <inventory>`                             Explore an inventory
 - `:log`                                                  Review the application log
 - `:open`                                                 Open current page in the IDE
 - `:quit`                                                 Quit the application


### PR DESCRIPTION
- Fixes #124, set :welcome to be interactive
- Move artifact file logic into run and add timestamp (issue #62)
- Update self.args in run always so artifact file uses current playbook name
- Add support for playbook in config
- Move re-argparse logic into base class for common use in inventory and run
- If using a form to prompt, run form back through arg parse to update args so if the user jumps to another action they are correct
- move the addition of parse_and_update into parse_and_update so when it's called from an action we will always have a complete args
- :inventory now requires -i just like the command line so it will pass through argparse correctly