### PR TITLE
Add configuration file path setting using env variable

### DIFF
--- a/ansible_navigator/cli.py
+++ b/ansible_navigator/cli.py
@@ -23,6 +23,7 @@ from .config import NavigatorConfig
 from .action_runner import ActionRunner
 
 from .utils import check_for_ansible
+from .utils import env_var_is_file_path
 from .utils import error_and_exit_early
 from .utils import flatten_list
 from .utils import get_and_check_collection_doc_cache
@@ -174,28 +175,32 @@ def setup_config() -> Tuple[List[str], NavigatorConfig]:
     If it's found but empty or not well formed, bail out.
     """
     pre_logger_msgs = []
-    found_config = False
+    config_path = None
+    # Check if the conf path is set via an env var
+    cfg_env_var = "ANSIBLE_NAVIGATOR_CONFIG"
+    env_config_path, msgs = env_var_is_file_path(cfg_env_var, "config")
+    pre_logger_msgs += msgs
 
-    if os.environ.get("ANSIBLE_NAVIGATOR_CONFIG"):
-        config_path = os.environ.get("ANSIBLE_NAVIGATOR_CONFIG")
-        if config_path and os.path.isfile(config_path) and os.path.exists(config_path):
-            found_config = True
-
-    # Otherwise, try to find it a different way
-    config_path, msgs = get_conf_path(
+    # Check well know locations
+    found_config_path, msgs = get_conf_path(
         "ansible-navigator", allowed_extensions=["yml", "yaml", "json"]
     )
     pre_logger_msgs += msgs
-    if config_path is not None:
-        pre_logger_msgs.append("Found config file at {0}".format(config_path))
-        found_config = True
+
+    # Pick the envar set first, followed by found, followed by leave as none
+    if env_config_path is not None:
+        config_path = env_config_path
+        pre_logger_msgs.append(f"Using config file at {config_path} set by {cfg_env_var}")
+    elif found_config_path is not None:
+        config_path = found_config_path
+        pre_logger_msgs.append(f"Using config file at {config_path} in search path")
     else:
         pre_logger_msgs.append(
-            "Could not find config directory." " Using all default values for configuration."
+            "No valid config file found, using all default values for configuration."
         )
 
     config = {}
-    if found_config:
+    if config_path is not None:
         with open(config_path, "r") as config_fh:
             if config_path.endswith(".json"):
                 try:
@@ -210,15 +215,15 @@ def setup_config() -> Tuple[List[str], NavigatorConfig]:
                     config = yaml.load(config_fh, Loader=SafeLoader)
                 except ScannerError:
                     error_and_exit_early(
-                        "Config file at {0} but it failed to parse it.".format(config_path)
+                        "Config file at {0} but failed to parse it.".format(config_path)
                     )
 
-    if found_config and config and config.get("ansible-navigator"):
+    if config_path and config and config.get("ansible-navigator"):
         # If the config file was found and has the key we expect, log and use it
         pre_logger_msgs.append("Successfully parsed config file")
         return pre_logger_msgs, NavigatorConfig(config)
 
-    if not found_config:
+    if not config_path:
         # If the config file wasn't found, that's still okay. In this case, we
         # instantiate NavigatorConfig with an empty dict.
         return pre_logger_msgs, NavigatorConfig(config)

--- a/ansible_navigator/cli.py
+++ b/ansible_navigator/cli.py
@@ -181,17 +181,29 @@ def setup_config() -> Tuple[List[str], NavigatorConfig]:
     pre_logger_msgs = []
     found_config = False
 
+    if os.environ.get('ANSIBLE_NAVIGATOR_CONFIG'):
+        config_path = os.environ.get('ANSIBLE_NAVIGATOR_CONFIG')
+        if os.path.isfile(config_path) and os.path.exists(config_path):
+            found_config = True
+
     # Otherwise, try to find it a different way
-    config_dir, msgs = get_conf_dir("ansible-navigator.yml")
-    pre_logger_msgs += msgs
-    if config_dir is not None:
-        # Since we give get_conf_dir our config path, it's guaranteed to exist
-        # if config_dir is not None.
-        config_path = os.path.join(config_dir, "ansible-navigator.yml")
-        pre_logger_msgs.append("Found config file at {0}".format(config_path))
-        found_config = True
-    else:
-        pre_logger_msgs.append("Could not find config directory, using all defaults.")
+    if not found_config:
+        found_filename = None
+        for filename in ["ansible-navigator.yml", "ansible-navigator.yaml"]:
+            config_dir, msgs = get_conf_dir(filename)
+            pre_logger_msgs += msgs
+            if config_dir:
+                found_filename = filename
+                break
+
+        if config_dir is not None:
+            # Since we give get_conf_dir our config path, it's guaranteed to exist
+            # if config_dir is not None.
+            config_path = os.path.join(config_dir, found_filename)
+            pre_logger_msgs.append("Found config file at {0}".format(config_path))
+            found_config = True
+        else:
+            pre_logger_msgs.append("Could not find config directory, using all defaults.")
 
     config = {}
     if found_config:

--- a/ansible_navigator/cli.py
+++ b/ansible_navigator/cli.py
@@ -178,7 +178,7 @@ def setup_config() -> Tuple[List[str], NavigatorConfig]:
 
     if os.environ.get("ANSIBLE_NAVIGATOR_CONFIG"):
         config_path = os.environ.get("ANSIBLE_NAVIGATOR_CONFIG")
-        if os.path.isfile(config_path) and os.path.exists(config_path):
+        if config_path and os.path.isfile(config_path) and os.path.exists(config_path):
             found_config = True
 
     # Otherwise, try to find it a different way

--- a/ansible_navigator/cli.py
+++ b/ansible_navigator/cli.py
@@ -181,8 +181,8 @@ def setup_config() -> Tuple[List[str], NavigatorConfig]:
     pre_logger_msgs = []
     found_config = False
 
-    if os.environ.get('ANSIBLE_NAVIGATOR_CONFIG'):
-        config_path = os.environ.get('ANSIBLE_NAVIGATOR_CONFIG')
+    if os.environ.get("ANSIBLE_NAVIGATOR_CONFIG"):
+        config_path = os.environ.get("ANSIBLE_NAVIGATOR_CONFIG")
         if os.path.isfile(config_path) and os.path.exists(config_path):
             found_config = True
 

--- a/ansible_navigator/utils.py
+++ b/ansible_navigator/utils.py
@@ -193,6 +193,27 @@ def check_for_ansible() -> Tuple[bool, str]:
     return True, msg
 
 
+def env_var_is_file_path(env_var: str, kind: str) -> Tuple[Optional[str], List[str]]:
+    """check if a given env var is a vialbe file path, if so return that path"""
+    file_path = None
+    msgs = []
+    candidate_path = os.environ.get(env_var)
+    if candidate_path is None:
+        msgs.append(f"No {kind} file set by {env_var}")
+    else:
+        msgs.append(f"Found a {kind} file at {candidate_path} set by {env_var}")
+        if os.path.isfile(candidate_path) and os.path.exists(candidate_path):
+            file_path = candidate_path
+            msgs.append(f"{kind.capitalize()} file at {file_path} set by {env_var} is viable")
+            exp_path = os.path.abspath(os.path.expanduser(file_path))
+            if exp_path != file_path:
+                msgs.append(f"{kind.capitalize()} resolves to {exp_path}")
+                file_path = exp_path
+        else:
+            msgs.append(f"{env_var} set as {candidate_path} but not valid")
+    return file_path, msgs
+
+
 def _get_config_file(
     path: str, filename: str, allowed_extensions: List, msgs: List
 ) -> Optional[str]:
@@ -209,9 +230,7 @@ def _get_config_file(
     for name in valid_file_names:
         candidate_config_path = os.path.join(path, name)
         if not os.path.exists(candidate_config_path):
-            msgs.append(
-                "Skipping {0} because required file {1} does not exist".format(path, filename)
-            )
+            msgs.append(f"Skipping {path}/{name} because it does not exist")
             continue
         config_files_found.append(candidate_config_path)
 

--- a/ansible_navigator/utils.py
+++ b/ansible_navigator/utils.py
@@ -242,8 +242,8 @@ def get_conf_path(
           We should probably cache the potential paths somewhere, eventually.
     """
 
-    potential_paths = []
-    msgs = []
+    potential_paths: List[str] = []
+    msgs: List[str] = []
 
     # .ansible-navigator of current direcotry
     potential_paths.append(".ansible-navigator")

--- a/ansible_navigator/utils.py
+++ b/ansible_navigator/utils.py
@@ -7,6 +7,7 @@ import importlib.util
 import html
 import os
 import stat
+import sys
 import sysconfig
 
 from distutils.spawn import find_executable
@@ -19,6 +20,7 @@ from typing import Mapping
 from typing import Optional
 from typing import Tuple
 from typing import Union
+from typing import NoReturn
 
 from jinja2 import Environment, TemplateError
 
@@ -191,9 +193,49 @@ def check_for_ansible() -> Tuple[bool, str]:
     return True, msg
 
 
-def get_conf_dir(filename: Optional[str] = None) -> Tuple[Optional[str], List[str]]:
+def _get_config_file(
+    path: str, filename: str, allowed_extensions: List, msgs: List
+) -> Optional[str]:
+    """check if filename is present in given path with allowed
+    extensions. If multiple files are present it throws an error
+    as only a single valid config file can be present in the
+    given path.
     """
-    returns config dir (e.g. /etc/ansible-navigator). First found wins.
+    config_files_found = []
+    config_file = None
+    valid_file_names = [
+        f"{filename}.{allowed_extension}" for allowed_extension in allowed_extensions
+    ]
+    for name in valid_file_names:
+        candidate_config_path = os.path.join(path, name)
+        if not os.path.exists(candidate_config_path):
+            msgs.append(
+                "Skipping {0} because required file {1} does not exist".format(path, filename)
+            )
+            continue
+        config_files_found.append(candidate_config_path)
+
+    if len(config_files_found) > 1:
+        error_msg = "only one file among '{0}' should be present under" " directory '{1}'".format(
+            ", ".join(valid_file_names), path
+        )
+        error_msg += " instead multiple config files" " found '{0}'".format(
+            ", ".join(config_files_found)
+        )
+        error_and_exit_early(error_msg)
+
+    if len(config_files_found) == 1:
+        config_file = config_files_found[0]
+
+    return config_file
+
+
+def get_conf_path(
+    filename: Optional[str] = None, allowed_extensions: Optional[List] = None
+) -> Tuple[Optional[str], List[str]]:
+    """
+    returns config dir (e.g. /etc/ansible-navigator) if filename is None and
+    config file path if filename provided. First found wins.
     If a filename is given, ensures the file exists in the directory.
 
     TODO: This is a pretty expensive function (lots of statting things on disk).
@@ -225,12 +267,21 @@ def get_conf_dir(filename: Optional[str] = None) -> Tuple[Optional[str], List[st
         potential_paths.append(path)
 
     for path in potential_paths:
-        must_exist = os.path.join(path, filename) if filename is not None else path
-        if not os.path.exists(must_exist):
-            msgs.append(
-                "Skipping {0} because required file {1} does not exist".format(path, filename)
-            )
-            continue
+        if allowed_extensions:
+            if not filename:
+                msg = f"allowed_extensions '{allowed_extensions}' requires filename to be set"
+                error_and_exit_early(msg)
+
+            config_path = _get_config_file(path, filename, allowed_extensions, msgs)
+            if config_path is None:
+                continue
+        else:
+            config_path = os.path.join(path, filename) if filename is not None else path
+            if not os.path.exists(config_path):
+                msgs.append(
+                    "Skipping {0} because required file {1} does not exist".format(path, filename)
+                )
+                continue
 
         try:
             perms = os.stat(path)
@@ -240,7 +291,7 @@ def get_conf_dir(filename: Optional[str] = None) -> Tuple[Optional[str], List[st
                     "is world-writable.".format(path)
                 )
                 continue
-            return (path, msgs)
+            return (config_path, msgs)
         except OSError:
             continue
 
@@ -249,19 +300,15 @@ def get_conf_dir(filename: Optional[str] = None) -> Tuple[Optional[str], List[st
 
 def set_ansible_envar() -> None:
     """Set an envar if not set, runner will need this"""
-    ansible_config, msgs = get_conf_dir("ansible.cfg")
+    ansible_config_path, msgs = get_conf_path("ansible.cfg")
 
     for msg in msgs:
         logger.debug(msg)
 
-    if ansible_config is not None:
-        # We'll get the directory back, not the full file path.
-        ansible_config = os.path.join(ansible_config, "ansible.cfg")
-
     # set as env var, since we hand env vars over to runner
-    if ansible_config and not os.getenv("ANSIBLE_CONFIG"):
-        os.environ.setdefault("ANSIBLE_CONFIG", ansible_config)
-        logger.debug("ANSIBLE_CONFIG set to %s", ansible_config)
+    if ansible_config_path and not os.getenv("ANSIBLE_CONFIG"):
+        os.environ.setdefault("ANSIBLE_CONFIG", ansible_config_path)
+        logger.debug("ANSIBLE_CONFIG set to %s", ansible_config_path)
 
 
 def get_and_check_collection_doc_cache(args, collection_doc_cache_fname: str) -> Tuple[List, Dict]:
@@ -298,3 +345,9 @@ def _get_kvs(args, collection_doc_cache_path):
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod.KeyValueStore(collection_doc_cache_path)
+
+
+def error_and_exit_early(msg) -> NoReturn:
+    """get out of here fast"""
+    print(f"\x1b[31m[ERROR]: {msg}\x1b[0m")
+    sys.exit(1)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -14,13 +14,19 @@ Several options in ``ansible-navigator`` can be configured by making use of a
 configuration file. The configuration file can live in one of several places.
 Currently the following paths are checked and the first match is used:
 
+- ``ANSIBLE_NAVIGATOR_CONFIG`` (configuration file path environment variable if set)
 - ``./.ansible-navigator/ansible-navigator.yml`` (project-specific directory)
 - ``[ansible-navigator source code root]/etc/ansible-navigator/ansible-navigator.yml``
 - ``~/.config/ansible-navigator/ansible-navigator.yml``
 - ``/etc/ansible-navigator/ansible-navigator.yml``
 - ``[prefix]/etc/ansible-navigator/ansible-navigator.yml`` (e.g., ``/usr/local/etc/...``)
 
-Here is an example conifguration file which can be copied into one of those paths.
+.. note::
+   The configuration file extension can be either ``.yml`` or ``.yaml``. If files with both
+   extension are present in that case ``.yml`` is given preference over ``.yaml``.
+
+
+Here is an example configuration file which can be copied into one of those paths.
 
 .. literalinclude:: sample-config.yml
    :language: yaml

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -15,18 +15,22 @@ configuration file. The configuration file can live in one of several places.
 Currently the following paths are checked and the first match is used:
 
 - ``ANSIBLE_NAVIGATOR_CONFIG`` (configuration file path environment variable if set)
-- ``./.ansible-navigator/ansible-navigator.yml`` (project-specific directory)
-- ``[ansible-navigator source code root]/etc/ansible-navigator/ansible-navigator.yml``
-- ``~/.config/ansible-navigator/ansible-navigator.yml``
-- ``/etc/ansible-navigator/ansible-navigator.yml``
-- ``[prefix]/etc/ansible-navigator/ansible-navigator.yml`` (e.g., ``/usr/local/etc/...``)
+- ``./.ansible-navigator/<ansible-navigator-filename>`` (project-specific directory)
+- ``[ansible-navigator source code root]/etc/ansible-navigator/<ansible-navigator-filename>``
+- ``~/.config/ansible-navigator/<ansible-navigator-filename>``
+- ``/etc/ansible-navigator/<ansible-navigator-filename>``
+- ``[prefix]/etc/ansible-navigator/<ansible-navigator-filename>`` (e.g., ``/usr/local/etc/...``)
 
 .. note::
-   The configuration file extension can be either ``.yml`` or ``.yaml``. If files with both
-   extension are present in that case ``.yml`` is given preference over ``.yaml``.
+- The configuration file can either be in ``JSON`` or ``YAML`` format.
+- For configuration in ``JSON`` format the file name should be ``ansible-navigator.json``
+- For configuration in ``YAML`` format the file name can be either ``ansible-navigator.yml``
+  or ``ansible-navigator.yaml``.
+- The first found matched directory path (based on order mentioned above) can have only one
+  valid configuration file. If in case more than one configuration files (with different
+  supported extensions) are found it will result in an error to avoid conflict.
 
-
-Here is an example configuration file which can be copied into one of those paths.
+You can copy the example configuration file below into one of those paths to start your ``ansible-navigator`` config file.
 
 .. literalinclude:: sample-config.yml
    :language: yaml

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -91,21 +91,21 @@ def test_fixtures_dir():
 def test_update_args(monkeypatch, test_fixtures_dir, given, argname, expected):
     """test the parse and update function"""
 
-    def get_conf_dir(*_args, **_kwargs):
-        return test_fixtures_dir, []
+    def get_conf_path(*_args, **_kwargs):
+        return os.path.join(test_fixtures_dir, "ansible-navigator.yml"), []
 
-    monkeypatch.setattr(cli, "get_conf_dir", get_conf_dir)
+    monkeypatch.setattr(cli, "get_conf_path", get_conf_path)
     _pre_logger_msgs, args = cli.parse_and_update(given)
     result = vars(args)[argname]
     assert result == expected
 
 
 def test_editor_command_default(monkeypatch):
-    """test editor with defualt"""
+    """test editor with default"""
 
-    def get_conf_dir(*_args, **_kwargs):
+    def get_conf_path(*_args, **_kwargs):
         return None, []
 
-    monkeypatch.setattr(cli, "get_conf_dir", get_conf_dir)
+    monkeypatch.setattr(cli, "get_conf_path", get_conf_path)
     _pre_logger_msgs, args = cli.parse_and_update([])
     assert args.editor_command == "vi +{line_number} {filename}"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,8 +4,9 @@ import os
 import pytest
 import stat
 
-from types import SimpleNamespace
 from typing import List
+from typing import Optional
+from types import SimpleNamespace
 
 import ansible_navigator.utils as utils
 
@@ -82,5 +83,29 @@ def test_get_conf_path_allowed_extension_passed(monkeypatch) -> None:
     )
 
     assert received_config_file_path == expected_config_file_path
-    log_msg = "Skipping .ansible-navigator because required file ansible-navigator does not exist"
+    log_msg = "Skipping .ansible-navigator/ansible-navigator.json because it does not exist"
     assert log_msg in msgs
+
+
+@pytest.mark.parametrize(
+    "set_env, file_path, anticpated_result",
+    [
+        (True, os.path.abspath(__file__), os.path.abspath(__file__)),
+        (True, "", None),
+        (False, None, None),
+    ],
+    ids=[
+        "set and valid",
+        "set and invalid",
+        "not set",
+    ],
+)
+def test_env_var_is_file_path(
+    monkeypatch, set_env: bool, file_path: str, anticpated_result: Optional[str]
+) -> None:
+    """test env var is a file path"""
+    envvar = "ANSIBLE_NAVIGATOR_CONFIG"
+    if set_env:
+        monkeypatch.setenv(envvar, file_path)
+    result = utils.env_var_is_file_path(envvar, "config")
+    assert result[0] == anticpated_result

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,8 +1,11 @@
 """ tests for the utilities in utils
 """
-from typing import List
-
+import os
 import pytest
+import stat
+
+from types import SimpleNamespace
+from typing import List
 
 import ansible_navigator.utils as utils
 
@@ -24,3 +27,60 @@ def test_flatten_list(value: List, anticpated_result: List) -> None:
     """test for flatten list"""
     actual_result = utils.flatten_list(value)
     assert list(actual_result) == anticpated_result
+
+
+def test_get_conf_path_allowed_extension_failed(monkeypatch) -> None:
+    """test get_conf_path"""
+
+    def check_path_exists(arg):
+        if arg in [
+            "/etc/ansible-navigator/ansible-navigator.yaml",
+            "/etc/ansible-navigator/ansible-navigator.yml",
+            "/etc/ansible-navigator/ansible-navigator.json",
+        ]:
+            return True
+        else:
+            return False
+
+    monkeypatch.setattr(os.path, "exists", check_path_exists)
+
+    error_msg = (
+        "only one file among 'ansible-navigator.json, ansible-navigator.yaml,"
+        " ansible-navigator.yml' should be present under directory"
+        " '/etc/ansible-navigator' instead multiple config files found"
+        " '/etc/ansible-navigator/ansible-navigator.json,"
+        " /etc/ansible-navigator/ansible-navigator.yaml,"
+        " /etc/ansible-navigator/ansible-navigator.yml'"
+    )
+    with pytest.raises(SystemExit) as exc:
+        assert utils.get_conf_path("ansible-navigator", allowed_extensions=["json", "yaml", "yml"])
+        assert str(exc) == error_msg
+
+
+def test_get_conf_path_allowed_extension_passed(monkeypatch) -> None:
+    """test get_conf_path"""
+
+    expected_config_file_path = os.path.expanduser(
+        "~/.config/ansible-navigator/ansible-navigator.yaml"
+    )
+
+    def check_path_exists(arg):
+        if arg == expected_config_file_path:
+            return True
+        else:
+            return False
+
+    def get_dir_permission(arg):
+        if arg == os.path.dirname(expected_config_file_path):
+            return SimpleNamespace(**{"st_mode": stat.S_IROTH})
+
+    monkeypatch.setattr(os.path, "exists", check_path_exists)
+    monkeypatch.setattr(os, "stat", get_dir_permission)
+
+    received_config_file_path, msgs = utils.get_conf_path(
+        "ansible-navigator", allowed_extensions=["json", "yaml", "yml"]
+    )
+
+    assert received_config_file_path == expected_config_file_path
+    log_msg = "Skipping .ansible-navigator because required file ansible-navigator does not exist"
+    assert log_msg in msgs

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ skip_missing_interpreters = true
 
 
 [testenv]
+allowlist_externals = cat
+                      rm
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =
@@ -19,7 +21,6 @@ setenv =
 passenv = HOME
 
 [testenv:clean]
-allowlist_externals = rm
 deps = coverage
 skip_install = true
 commands = coverage erase
@@ -34,7 +35,6 @@ commands =
   yamllint -s .
 
 [testenv:report]
-allowlist_externals = cat
 deps = coverage
 skip_install = true
 commands =


### PR DESCRIPTION
*  Add support to set ansible-naviagator configuration
   file path using environment variable `ANSIBLE_NAVIGATOR_CONFIG`
*  Add support to read configuration file from `.yaml` and `.json` extension
* The first found matched directory path (based on order mentioned above) can have only one
  valid configuration file. If in case more than one configuration files (with different
  supported extensions) are found it will result in an error to avoid conflict