### PR TITLE
Add test for inventory subcommnd

### DIFF
--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -1,1 +1,5 @@
+import os
+
 default_container_image = "quay.io/ansible/ansible-runner:devel"
+pexpect_use_poll = True
+pexpect_timeout = 600

--- a/tests/fixtures/ansible-navigator.yml
+++ b/tests/fixtures/ansible-navigator.yml
@@ -1,7 +1,16 @@
+---
 ansible-navigator:
+  container-engine: podman
   editor:
-    command: emacs -nw +{line_number} {filename}
+    command: code -g {filename}:{line_number}
     console: False
-  doc-plugin-type: become
+  execution-environment-image: quay.io/ansible/ansible-runner:devel
+  execution-environment: False
+  inventory-columns:
+    - ansible_network_os
+    - ansible_network_cli_ssh_type
+    - ansible_connection
   log:
-    level: critical
+    file: "./ansible-navigator.log"
+    level: "debug"
+  no-osc4: True

--- a/tests/fixtures/inventory/inventory.yml
+++ b/tests/fixtures/inventory/inventory.yml
@@ -1,0 +1,21 @@
+hosts:
+  children:
+    group01:
+      hosts:
+        host0101:
+          ansible_host: host0101.test.com
+      vars:
+        ansible_become: True
+        ansible_network_os: org.coll.nos
+        ansible_connection: ansible.netcommon.network_cli
+    group02:
+      hosts:
+        host0201:
+          ansible_host: host0201.test.com
+      vars:
+        ansible_become: True
+        ansible_become_pass: test
+    group03:
+      hosts:
+        host0301:
+          ansible_host: host0301.test.com

--- a/tests/fixtures/output/interactive/inventory_list.txt
+++ b/tests/fixtures/output/interactive/inventory_list.txt
@@ -1,0 +1,28 @@
+=  TITLEDESCRIPTION
+0│Browse groups   Explore each inventory group and group members members
+1│Browse hosts    Explore the inventory with a list of all hosts
+^f/PgUp page up ^b/PgDn page down ↑↓ scroll esc back [0-9] goto :help help
+:=0NAME TAXONOMYTYPE
+hostsallgroup
+ungroupedallgroup
+^f/PgUp page up ^b/PgDn page down ↑↓ scroll esc back [0-9] goto :help help
+:=0TAXONOMY    
+group01all▸hosts
+group02  all▸hosts
+2│group03all▸hostsgroup
+^f/PgUp page up ^b/PgDn page down ↑↓ scroll esc back [0-9] goto :help help
+:=0TAXONOMYTYPE ANSIBLE NETWORK ANSIBLE NETWORK ANSIBLE CONNECTI
+host0101 all▸hosts▸grouphost org.coll.nos    None   ansible.netcommo
+
+^f/PgUp page up ^b/PgDn page down ↑↓ scroll esc back [0-9] goto :help help
+:=0[host0101] org.coll.nos                                                         ---
+1│ansible_become: true
+2│ansible_connection: ansible.netcommon.network_cli
+3│ansible_host: host0101.test.com
+4│ansible_network_os: org.coll.nos
+5│group01_foo: group01_bar
+6│host0101_foo: host0101_bar
+7│inventory_hostname: host0101
+^f/PgUp page up    ^b/PgDn page down    ↑↓ scroll    esc back    :help help
+:=quit>
+>

--- a/tests/integration/actions/test_inventory.py
+++ b/tests/integration/actions/test_inventory.py
@@ -1,0 +1,23 @@
+""" inventory integration tests
+"""
+import os
+
+from .._common import execute_command
+
+
+def test_inventory_interactive_inventory_list(test_fixtures_dir, output_fixture):
+    cmdline_arg = [
+        "-m",
+        "ansible_navigator",
+        "inventory",
+        "-i",
+        os.path.join(test_fixtures_dir, "inventory"),
+    ]
+    user_interactions = [":0\r", ":0\r", ":0\r", ":0\r", ":quit\r"]
+    expected_patterns = ["help", "help", "help", "help", "help"]
+    received_output = execute_command(
+        cmdline_arg, user_interactions, expected_patterns, sanitize=True
+    )
+    expected_output = output_fixture("interactive", "inventory_list")
+
+    assert received_output == expected_output

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,12 +1,33 @@
 import pytest
 import os
 
-from ._common import ActionRunTest
+
+EXECUTION_MODES = ["interactive", "stdout"]
 
 
 @pytest.fixture(scope="session")
 def test_fixtures_dir():
     return os.path.join(os.path.dirname(__file__), "..", "fixtures")
+
+
+@pytest.fixture
+def output_fixture():
+    def _method(mode, test_name):
+        if mode not in EXECUTION_MODES:
+            raise ValueError(
+                "Value of {0} can be either one of {1}".format(mode, ", ".join(EXECUTION_MODES))
+            )
+        fixture_dir = os.path.join(os.path.dirname(__file__), "..", "fixtures")
+        fixture_file_path = os.path.join(fixture_dir, "output", mode, f"{test_name}.txt")
+        if not os.path.exists(fixture_file_path):
+            raise ValueError(
+                f"fixture for {test_name} with file path {fixture_file_path} does not exit"
+            )
+
+        with open(fixture_file_path) as fp:
+            return fp.read()
+
+    return _method
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/unit/actions/test_inventory.py
+++ b/tests/unit/actions/test_inventory.py
@@ -1,0 +1,50 @@
+# """ inventory unit tests
+# """
+import curses
+
+from ansible_navigator.actions.inventory import color_menu
+from ansible_navigator.actions.inventory import content_heading
+from ansible_navigator.actions.inventory import filter_content_keys
+
+from ansible_navigator.ui_framework.curses_defs import CursesLinePart
+
+
+def test_color_menu_true():
+    """test color menu for a val set to the default"""
+    assert color_menu(0, "__name", {}) == 10
+    assert color_menu(0, "__taxonomy", {}) == 11
+    assert color_menu(0, "description", {}) == 12
+    assert color_menu(0, "__type", {"__type": ""}) == 12
+    assert color_menu(0, "__type", {"__type": "group"}) == 11
+    assert color_menu(0, "", {"__name": True}) == 14
+
+
+def test_content_heading_true():
+    """test menu generation for a defaulted value"""
+    curses.initscr()
+    curses.start_color()
+    line_length = 100
+    inventory_hostname = "host01"
+    ansible_platform = "test"
+    obj = {
+        "__name": "testhost",
+        "__taxonomy": "all",
+        "__type": "group",
+        "inventory_hostname": inventory_hostname,
+        "ansible_platform": ansible_platform,
+    }
+    heading = content_heading(obj, line_length)
+    assert len(heading) == 1
+    assert len(heading[0]) == 1
+    assert isinstance(heading[0][0], CursesLinePart)
+    assert len(heading[0][0].string) == line_length + 1
+    assert f"[{inventory_hostname}] {ansible_platform}" in heading[0][0].string
+    assert heading[0][0].color == curses.color_pair(curses.COLOR_BLACK)
+    assert heading[0][0].column == 0
+
+
+def test_filter_content_keys() -> None:
+    """test filtering keys"""
+    obj = {"__key": "value", "key": "value"}
+    ret = {"key": "value"}
+    assert filter_content_keys(obj) == ret


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-navigator/pull/136

*  Update integration test common code to emulate user
   UI integration and fetch the terminal output
   for end-to-end testing
*  Add integration tests for inventory subcommnad
*  Add unit test for inventory subcommand