### PR TITLE
Fix py3-only wheel tags

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,3 @@ console_scripts =
 exclude =
     tests*
     testing*
-
-[bdist_wheel]
-universal = True


### PR DESCRIPTION
One thing to notice is that the `universal = 1` option usually requires `1` or `0`, not `True` / `False`.
Also, this project metadata says it's py3-only but marking the wheels as universal adds a `py2.py3`
tag effectively hinting to everyone that the content inside is compatible with Python 2 which is
incorrect.