### PR TITLE
Create a config file and multilayer value setup

### DIFF
--- a/ansible_navigator/app.py
+++ b/ansible_navigator/app.py
@@ -84,7 +84,7 @@ class App:
     def _update_args(self, params: List) -> Union[Namespace, None]:
         """pass the params through the original cli parser
         as if run was invoked from the command line
-        provide an error callback so the app doesn't sys.exit if the aprsing fails
+        provide an error callback so the app doesn't sys.exit if the parsing fails
         """
 
         try:

--- a/ansible_navigator/cli_args.py
+++ b/ansible_navigator/cli_args.py
@@ -8,7 +8,6 @@ from argparse import ArgumentParser
 from argparse import ArgumentTypeError
 from argparse import HelpFormatter
 
-from .config import ARGPARSE_TO_CONFIG
 from .config import NavigatorConfig
 from .utils import Sentinel
 
@@ -52,42 +51,17 @@ class CustomHelpFormatter(HelpFormatter):
             self._dedent()
 
 
-class ArgumentParserDefaultFromConfig(ArgumentParser):
-    """Manually update the help text with a default value from
-    NavigatorConfig, otherwise argparse would simply show Sentinal across
-    the board
-
-    The 'dest' for an argparse param is used for the lookup in the
-    config, therefore, the argparse dest, and config key need to stay
-    in sync
-    """
-
-    def __init__(self, *args, **kwargs):
-        self.navigator_config = NavigatorConfig(ARGPARSE_TO_CONFIG)
-        super().__init__(*args, **kwargs)
-
-    def add_argument(self, *args, **kwargs):
-        """add the default to the help"""
-        arg_dest = kwargs.get("dest")
-        if arg_dest is not None:
-            mapped_to = ARGPARSE_TO_CONFIG.get(arg_dest)
-            if all((mapped_to, kwargs.get("help"))):
-                _config_source, default_value = self.navigator_config.get(mapped_to)
-                if not isinstance(default_value, Sentinel):
-                    kwargs["help"] += f" (default: {default_value})"
-        super().add_argument(*args, **kwargs)
-
-
 class CliArgs:
     """Build the args"""
 
     # pylint: disable=too-few-public-methods
     def __init__(self, app_name: str):
+        self._navigator_config = NavigatorConfig()
 
         self._app_name = app_name
-        self._base_parser = ArgumentParserDefaultFromConfig(add_help=False)
+        self._base_parser = ArgumentParser(add_help=False)
         self._base()
-        self.parser = ArgumentParserDefaultFromConfig(
+        self.parser = ArgumentParser(
             formatter_class=CustomHelpFormatter, parents=[self._base_parser]
         )
         self._subparsers = self.parser.add_subparsers(
@@ -132,99 +106,22 @@ class CliArgs:
         parser = self._add_subparser("doc", "Show a plugin doc")
         self._doc_params(parser)
 
-    @staticmethod
-    def _doc_params(parser: ArgumentParser) -> None:
+    def _doc_params(self, parser: ArgumentParser) -> None:
         parser.add_argument("value", metavar="plugin", help="The name of the plugin", type=str)
-        tipes = (
-            "become",
-            "cache",
-            "callback",
-            "cliconf",
-            "connection",
-            "httpapi",
-            "inventory",
-            "lookup",
-            "netconf",
-            "shell",
-            "vars",
-            "module",
-            "strategy",
-        )
-        parser.add_argument(
-            "-t",
-            "--type",
-            help=f'Choose which plugin type: {{{",".join(tipes)}}}',
-            choices=tipes,
-            default=Sentinel,
-            dest="type",
-            metavar="",
-        )
+
+        self._navigator_config.add_argparse_argument('doc-plugin-type', parser)
         parser.set_defaults(requires_ansible=True)
 
-    @staticmethod
-    def _editor_params(parser: ArgumentParser) -> None:
-        parser.add_argument(
-            "--ecmd",
-            "--editor-command",
-            help="Specify the editor command, filename and line number",
-            default=Sentinel,
-            dest="editor_command",
-        )
-        parser.add_argument(
-            "--econ",
-            "--editor-console",
-            help="Specify if the editor is console based",
-            default=Sentinel,
-            dest="editor_console",
-        )
+    def _editor_params(self, parser: ArgumentParser) -> None:
+        self._navigator_config.add_argparse_argument('editor-command', parser)
+        self._navigator_config.add_argparse_argument('editor-console', parser)
 
-    @staticmethod
-    def _ee_params(parser: ArgumentParser) -> None:
-        parser.add_argument(
-            "--ce",
-            "--container-engine",
-            help="Specify the container engine to run the Execution Environment",
-            choices=["podman", "docker"],
-            default=Sentinel,
-            dest="container_engine",
-        )
-        parser.add_argument(
-            "--ee",
-            "--execution-environment",
-            default=Sentinel,
-            dest="execution_environment",
-            help="Run the playbook in an Execution Environment",
-            type=str2bool,
-        )
-        parser.add_argument(
-            "--eei",
-            "--execution-environment-image",
-            help="Specify the name of the container image containing an Execution Environment",
-            default=Sentinel,
-            dest="execution_environment_image",
-        )
-        parser.add_argument(
-            "--senv",
-            "--set_environment_variable",
-            action="append",
-            default=[Sentinel],
-            dest="set_environment_variable",
-            help="Specify an environment variable and a value to be set within the \
-                  execution enviroment (--senv MY_VAR=42)",
-            nargs="+",
-        )
-        parser.add_argument(
-            "--penv",
-            "--pass_environment_variable",
-            action="append",
-            default=[Sentinel],
-            dest="pass_environment_variable",
-            help=(
-                "Specify an exiting environment variable to be passed through to and set \
-                 within the execution enviroment (--penv MY_VAR)"
-            ),
-            nargs="+",
-        )
+    def _ee_params(self, parser: ArgumentParser) -> None:
+        self._navigator_config.add_argparse_argument('container-engine', parser)
+        self._navigator_config.add_argparse_argument('execution-environment', parser)
+        self._navigator_config.add_argparse_argument('execution-environment-image', parser)
+        self._navigator_config.add_argparse_argument('set-environment-variable', parser)
+        self._navigator_config.add_argparse_argument('pass-environment-variable', parser)
 
     def _run(self) -> None:
         parser = self._add_subparser(
@@ -233,35 +130,15 @@ class CliArgs:
         self._playbook_params(parser)
         self._inventory_params(parser)
 
-    @staticmethod
-    def _inventory_columns(parser: ArgumentParser) -> None:
-        parser.add_argument(
-            "--ic",
-            "--inventory-columns",
-            help=(
-                "Additional columns to be shown in the inventory views,"
-                " comma delimited, eg 'xxx,yyy,zzz'"
-            ),
-            default=Sentinel,
-            dest="inventory_columns",
-        )
+    def _inventory_columns(self, parser: ArgumentParser) -> None:
+        self._navigator_config.add_argparse_argument('inventory-columns', parser)
 
     def _inventory(self) -> None:
         parser = self._add_subparser("inventory", "Explore inventories")
         self._inventory_params(parser)
 
-    @staticmethod
-    def _inventory_params(parser: ArgumentParser) -> None:
-        parser.add_argument(
-            "-i",
-            "--inventory",
-            help="The inventory/inventories to use",
-            action="append",
-            nargs="+",
-            type=_abs_user_path,
-            default=[Sentinel],
-            dest="inventory",
-        )
+    def _inventory_params(self, parser: ArgumentParser) -> None:
+        self._navigator_config.add_argparse_argument('inventory', parser)
 
     def _load(self) -> None:
         parser = self._add_subparser("load", "Load an artifact")
@@ -278,59 +155,17 @@ class CliArgs:
         )
         parser.set_defaults(requires_ansible=False)
 
-    def _log_params(self, parser: ArgumentParser) -> None:  # pylint: disable=no-self-use
-        parser.add_argument(
-            "--lf",
-            "--logfile",
-            default=Sentinel,
-            dest="logfile",
-            help="Specify the application log file location",
-        )
-        parser.add_argument(
-            "--ll",
-            "--loglevel",
-            default=Sentinel,
-            dest="loglevel",
-            choices=["debug", "info", "warning", "error", "critical"],
-            help="Specify the application log level",
-            type=str,
-        )
+    def _log_params(self, parser: ArgumentParser) -> None:
+        self._navigator_config.add_argparse_argument('log-file', parser)
+        self._navigator_config.add_argparse_argument('log-level', parser)
 
-    @staticmethod
-    def _no_osc4_params(parser: ArgumentParser) -> None:
-        parser.add_argument(
-            "--no-osc4",
-            action="store_true",
-            default=Sentinel,
-            help="Disable OSC-4 support (xterm.js color fix)",
-            dest="no_osc4",
-        )
+    def _no_osc4_params(self, parser: ArgumentParser) -> None:
+        self._navigator_config.add_argparse_argument('no-osc4', parser)
 
-    @staticmethod
-    def _playbook_params(parser: ArgumentParser) -> None:
-        parser.add_argument(
-            "playbook",
-            nargs="?",
-            help="The name of the playbook(s) to run",
-            type=_abs_user_path,
-            default=Sentinel,
-        )
-        parser.add_argument(
-            "--pa",
-            "--playbook-artifact",
-            help="Specify the artifact file name for playbook results",
-            default=Sentinel,
-            dest="playbook_artifact",
-        )
+    def _playbook_params(self, parser: ArgumentParser) -> None:
+        self._navigator_config.add_argparse_argument('playbook', parser)
+        self._navigator_config.add_argparse_argument('playbook-artifact', parser)
         parser.set_defaults(requires_ansible=True)
 
-    @staticmethod
-    def _mode(parser: ArgumentParser) -> None:
-        parser.add_argument(
-            "-m",
-            "--mode",
-            default=Sentinel,
-            choices=["stdout", "interactive"],
-            help="Specify the navigator mode to run",
-            type=str,
-        )
+    def _mode(self, parser: ArgumentParser) -> None:
+        self._navigator_config.add_argparse_argument('mode', parser)

--- a/ansible_navigator/config.py
+++ b/ansible_navigator/config.py
@@ -1,23 +1,22 @@
 """
 Configuration subsystem for ansible-navigator
 """
+import json
 import os
+import pkgutil
 
+from argparse import ArgumentParser
 from enum import Enum
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
+from typing import Set
 from typing import Tuple
+from yaml.scanner import ScannerError
 
-from .utils import Sentinel
-
-# TODO: This maybe can/should move to a yaml file in some data (not share) dir
-# at some point in the future. In any case, the structure here should mimic what
-# we'd expect the yaml file to parse to. Every config option should have a
-# default here, ideally.
-#
-# NOTE!!! If you change any default here, update the documentation file in
-#         docs/configuration.rst
+from .utils import Sentinel, Singleton, env_var_is_file_path, get_conf_path
+from .yaml import yaml, SafeLoader
 
 
 def generate_editor_command():
@@ -29,99 +28,349 @@ def generate_editor_command():
     return command
 
 
-_DEFAULTS = {
-    "ansible-navigator": {
-        "container-engine": "podman",
-        "doc-plugin-type": "module",
-        "editor": {
-            "command": generate_editor_command(),
-            "console": True,
-        },
-        "execution-environment": True,
-        "execution-environment-image": "quay.io/ansible/ansible-runner:devel",
-        "inventory": [],
-        "inventory-columns": [],
-        "log": {
-            "file": "./ansible-navigator.log",
-            "level": "info",
-        },
-        "mode": "interactive",
-        "no-osc4": False,
-        "pass-environment-variable": [],
-        "playbook": "",
-        "playbook-artifact": "{playbook_dir}/{playbook_name}-artifact-{ts_utc}.json",
-        "set-environment-variable": {},
-    },
+# Contains default values for config options that cannot be expressed in yaml
+_DEFAULT_OVERRIDES = {
+    'editor-command': generate_editor_command(),
 }
 
-# This maps argparse destination variables to config paths
-ROOT = "ansible-navigator"
-ARGPARSE_TO_CONFIG = {
-    "container_engine": [ROOT, "container-engine"],
-    "editor_command": [ROOT, "editor", "command"],
-    "editor_console": [ROOT, "editor", "console"],
-    "execution_environment_image": [ROOT, "execution-environment-image"],
-    "execution_environment": [ROOT, "execution-environment"],
-    "inventory_columns": [ROOT, "inventory-columns"],
-    "inventory": [ROOT, "inventory"],
-    "logfile": [ROOT, "log", "file"],
-    "loglevel": [ROOT, "log", "level"],
-    "mode": [ROOT, "mode"],
-    "no_osc4": [ROOT, "no-osc4"],
-    "pass_environment_variable": [ROOT, "pass-environment-variable"],
-    "playbook_artifact": [ROOT, "playbook-artifact"],
-    "playbook": [ROOT, "playbook"],
-    "set_environment_variable": [ROOT, "set-environment-variable"],
-    "type": [ROOT, "doc-plugin-type"],
-}
+
+def _to_config_list(value: Any) -> Optional[List[str]]:
+    """convert a config def to a list of strings"""
+    if value is None:
+        return value
+
+    if not isinstance(value, list):
+        value = [str(value)]
+
+    return [str(v) for v in value]
+
+
+def _to_config_str(value: Any) -> str:
+    """convert a config def to string like value"""
+    if value is None:
+        raise ValueError("required value is not set")
+
+    if isinstance(value, list):
+        value = '. '.join(value)
+
+    if not isinstance(value, str):
+        raise ValueError("value is not a string or list of strings")
+
+    value = value.strip()
+    if not value.endswith('.'):
+        value += '.'
+
+    return value
+
+
+def _validate_config_dict(value: Any, mandatory: Set, optional: Set, found: List[str]):
+    """validates a config dict definition and sets all missing optional keys with a default of None"""
+    error_key = " -> ".join(found)
+    if not isinstance(value, dict):
+        raise ValueError(f"{error_key} def is not a dict")
+
+    actual_keys = set(value.keys())
+
+    missing_keys = mandatory.difference(actual_keys)
+    if missing_keys:
+        raise ValueError(f"{error_key} def missing mandatory keys: {', '.join(missing_keys)}")
+
+    extra_keys = actual_keys.difference(mandatory.union(optional))
+    if extra_keys:
+        raise ValueError(f"{error_key} def has extra keys: {', '.join(extra_keys)}")
+
+    missing_optional = optional.difference(actual_keys)
+    for missing in missing_optional:
+        value[missing] = None
+
+
+def _get_navigator_config_path() -> Tuple['NavigatorConfigSource', Optional[str]]:
+    """gets the user defined config file path if available"""
+    config_path = None
+    # Check if the conf path is set via an env var
+    cfg_env_var = "ANSIBLE_NAVIGATOR_CONFIG"
+    env_config_path, _ = env_var_is_file_path(cfg_env_var, "config")
+
+    # Check well know locations
+    found_config_path, _ = get_conf_path(
+        "ansible-navigator", allowed_extensions=["yml", "yaml", "json"]
+    )
+
+    # Pick the envar set first, followed by found, followed by leave as none
+    if env_config_path is not None:
+        return NavigatorConfigSource.ENVIRONMENT, env_config_path
+
+    elif found_config_path is not None:
+        return NavigatorConfigSource.WELL_KNOWN_LOCATION, found_config_path
+
+    else:
+        return NavigatorConfigSource.NOT_FOUND, None
+
+
+def _load_navigator_config(path: str) -> Dict:
+    """loads the user defined config file"""
+    config = {}
+    if path is not None:
+        with open(path.encode('utf-8'), "r") as config_fh:
+            if path.endswith(".json"):
+                try:
+                    config = json.load(config_fh)
+                except (TypeError, json.decoder.JSONDecodeError) as exe:
+                    raise TypeError(f"Invalid JSON config found in file '{path}'. "
+                                    f"Failed with '{exe!s}'") from exe
+            else:
+                try:
+                    config = yaml.load(config_fh, Loader=SafeLoader)
+                except ScannerError as exe:
+                    raise TypeError(f"Invalid YAML config found in file '{path}'. "
+                                    f"Failed with '{exe!s}'") from exe
+
+    return config
+
+
+def _load_config_defs() -> Dict[str, Any]:
+    """loads the config definition file, validates and sets the same default values"""
+    raw_data = pkgutil.get_data('ansible_navigator.data', 'config.yml')
+    config = yaml.load(raw_data.decode('utf-8'), Loader=SafeLoader)
+
+    if not isinstance(config, dict):
+        raise ValueError("builtin config.yml is a properly formed config definition file")
+
+    # TODO: Add deprecated and version_added
+    mandatory_keys = {'description'}
+    optional_keys = {'default', 'choices', 'type', 'elements', 'config', 'env', 'cli'}
+
+    for key, value in config.items():
+        _validate_config_dict(value, mandatory_keys, optional_keys, [key])
+
+        # Set sane defaults for the root keys
+        if value['type'] is None:
+            value['type'] = 'str'
+
+        if key in _DEFAULT_OVERRIDES:
+            value['default'] = _DEFAULT_OVERRIDES[key]
+
+        elif value['default'] is None:
+            if value['type'] == 'list':
+                value['default'] = []
+            elif value['type'] == 'dict':
+                value['default'] = {}
+            else:
+                value['default'] = Sentinel
+
+        if value['config'] is None:
+            value['config'] = []
+
+        if value['env'] is None:
+            value['env'] = []
+
+        if value['cli'] is None:
+            value['cli'] = []
+
+        # Convert description to a string
+        try:
+            value['description'] = _to_config_str(value['description'])
+        except ValueError as e:
+            raise ValueError(f"{key} -> description def is invalid: {e!s}") from None
+
+        value['choices'] = _to_config_list(value['choices'])
+
+        # Validate the type options are valid
+        valid_types = ['bool', 'dict', 'list', 'str']
+        if value['type'] not in valid_types:
+            raise ValueError(f"{key} -> type def {value['type']!s} is invalid: "
+                             f"expecting {', '.join(valid_types)}")
+
+        if value['elements'] and value['elements'] not in valid_types:
+            raise ValueError(f"{key} -> elements def {value['elements']!s} is invalid: "
+                             f"expecting {', '.join(valid_types)}")
+        if value['elements'] is not None and value['type'] != 'list':
+            raise ValueError(f"{key} -> elements def cannot be set when type is not list")
+
+        # Validate the config/env/cli defs
+        config_value = value['config']
+        if not isinstance(config_value, list):
+            raise ValueError(f"{key} -> config def is not a list")
+        for entry in config_value:
+            _validate_config_dict(entry, {'section', 'name'}, set(), [key, 'config'])
+            entry['name'] = _to_config_str(entry['name'])
+            entry['section'] = _to_config_list(entry['section'])
+
+        env_value = value['env']
+        if not isinstance(env_value, list):
+            raise ValueError(f"{key} -> env def is not a list")
+        for entry in env_value:
+            _validate_config_dict(entry, {'name'}, set(), [key, 'env'])
+            entry['name'] = str(entry['name'])
+
+        cli_value = value['cli']
+        if not isinstance(cli_value, list):
+            raise ValueError(f"{key} -> cli def is not a list")
+        for entry in cli_value:
+            _validate_config_dict(entry, {'name'}, set(), [key, 'cli'])
+            entry['name'] = str(entry['name'])
+
+        # Used by argparse to store the arguments to the property with this value
+        value['cli_dest'] = key.lower().replace('-', '_')
+
+    return config
 
 
 class NavigatorConfigSource(Enum):
-    """mapping some enums to log friendly text"""
+    """defines the config path source"""
+    NOT_FOUND = "no config file found"
+    ENVIRONMENT = "ANSIBLE_NAVIGATOR_CONFIG environment value"
+    WELL_KNOWN_LOCATION = "well known folder location"
 
+
+class NavigatorOptionSource(Enum):
+    """defines the config option value source"""
+    NOT_FOUND = "value was not defined in any option"
+    DEFAULT = "default configuration value"
     USER_CFG = "user provided configuration file"
-    ARGPARSE_DEFAULT = "default commandline value"
-    DEFAULT_CFG = "default configuration value"
+    ENVIRONMENT = "user provided environment variable"
+    CLI = "user provided cli argument"
 
 
-class NavigatorConfig:  # pylint: disable=too-few-public-methods
+class _ConfigValue:
+
+    def __init__(self, name: str, definition: Dict[str, Any], config: Dict):
+        self.name = name
+        self._type = definition['type']
+        self._elements = definition['elements']
+        self._config_def = definition['config']
+        self._env_def = definition['env']
+        self._cli_def = definition['cli']
+
+        self._values = {
+            NavigatorOptionSource.DEFAULT: definition['default']
+        }
+        for config_def in self._config_def:
+            keys = config_def['section']
+            keys.append(config_def['name'])
+
+            current_val = config
+            for k in keys:
+                if not isinstance(current_val, dict):
+                    # TODO: Add warning once logging is in place
+                    break
+
+                if k not in current_val:
+                    current_val = Sentinel
+                    break
+
+                current_val = current_val[k]
+
+            if current_val != Sentinel:
+                self._set_value(NavigatorOptionSource.USER_CFG, current_val)
+
+        all_env = os.environ
+        for env_def in self._env_def:
+            if env_def['name'] in all_env:
+                self._set_value(NavigatorOptionSource.ENVIRONMENT, os.environ[env_def['name']])
+                break
+
+    def get_value(self, sources: List[NavigatorOptionSource]) -> Tuple[NavigatorOptionSource, Any]:
+        # Precedence is cli > env > config
+        for source in sources:
+            if source in self._values:
+                return source, self._values[source]
+
+        else:
+            return NavigatorOptionSource.NOT_FOUND, Sentinel
+
+    def _set_value(self, source: NavigatorOptionSource, value: Any):
+        # FIXME: Validate/cast type/elements
+        self._values[source] = value
+
+
+class NavigatorConfig(metaclass=Singleton):
     """
-    A simple wrapper around a dict, with a method that handles defaults nicely.
+    Global Navigator config that reads config values from the config file, environment, and cli arguments.
     """
 
-    def __init__(self, dct: Dict):
-        self.config = dct
+    def __init__(self):
+        self._config_source, self._config_path = _get_navigator_config_path()
+        self._config = _load_navigator_config(self._config_path) if self._config_path else {}
 
-    def get(self, keys: List[str], default: Any = Sentinel) -> Tuple[NavigatorConfigSource, Any]:
+        self._def = _load_config_defs()
+        self._values: Dict[str, _ConfigValue] = {n: _ConfigValue(n, v, self._config) for n, v in self._def.items()}
+
+    def get(self, name: str, default: Any = Sentinel,
+            sources: Optional[List[NavigatorOptionSource]] = None) -> Tuple[NavigatorOptionSource, Any]:
         """
-        Takes a list of keys that correspond to nested keys in config.
+        Gets the value of the config option specified by name.
         If the key is found in the config, return the value.
         Otherwise, if a non-Sentinel default is given, return that.
-        Lastly look to the internal default config [defined above] and pull
-        out the value from there.
+        If after all that the key didn't match or the value wasn't found in
+        the sources specified, throw KeyError.
 
-        If after all that the key didn't match, throw KeyError.
+        :param name: The config option name that corresponds with the option
+            key in config.yml.
+        :type name: str
+        :param default: The default value to use if the name isn't a valid
+            config or the config wasn't defined in the sources specified.
+        :type default: Any
+        :param sources: A list of sources to search in, defaults to all sources.
+        :type sources: Optional[List[NavigatorOptionSource]]
+        :return: The value of the config option specified.
+        :rtype: Tuple[NavigatorOptionSource, Any]
         """
-        current = self.config
-        for key in keys:
-            if isinstance(current, dict) and key in current:
-                current = current[key]
-            else:
-                break
-        else:
-            return NavigatorConfigSource.USER_CFG, current
+        if name not in self._values:
+            if default == Sentinel:
+                raise KeyError(name)
 
-        # If we made it here, the config key wasn't found.
-        if default is not Sentinel:
-            return NavigatorConfigSource.ARGPARSE_DEFAULT, default
+            return default
 
-        current = _DEFAULTS
-        for key in keys:
-            if isinstance(current, dict) and key in current:
-                current = current[key]
-            else:
-                break
-        else:
-            return NavigatorConfigSource.DEFAULT_CFG, current
+        if sources is None:
+            sources = [
+                NavigatorOptionSource.CLI,
+                NavigatorOptionSource.ENVIRONMENT,
+                NavigatorOptionSource.USER_CFG,
+                NavigatorOptionSource.DEFAULT,
+            ]
 
-        raise KeyError(keys)
+        source, value = self._values[name].get_value(sources)
+        if value == Sentinel:
+            if default == Sentinel:
+                raise KeyError(name)
+
+            value = default
+
+        return source, value
+
+    def add_argparse_argument(self, name: str, parser: ArgumentParser):
+        """
+        Gets the argparse definition for the config option specified.
+
+        :param name: The config name to add as an argument.
+        :type name: str
+        :param parser: The argparse parser to add the config argument to
+        :type parser: ArgumentParser
+        """
+        if name not in self._values:
+            raise KeyError(name)
+
+        definition = self._def[name]
+
+        args = [d['name'] for d in definition['cli']]
+        kwargs = {
+            'help': definition['description'],
+            'default': Sentinel,
+            'dest': definition['cli_dest'],
+        }
+        # TODO: add type=path that parses the value as an absolute path (_abs_user_path)
+        # TODO: type to validate the input, e.g. bool == str2bool
+        # TODO: type=dict should be list with KEY=value
+        # TODO: type=list should have nargs="+"
+        # TODO: type=list should maybe have action='append'
+        # TODO: playbook had nargs="?"
+
+        # TODO: better logic for removing dest on positional args
+        if not any([n for n in args if n.startswith('-')]):
+            del kwargs['dest']
+
+        if definition['choices']:
+            kwargs['choices'] = definition['choices']
+
+        parser.add_argument(*args, **kwargs)

--- a/ansible_navigator/data/config.yml
+++ b/ansible_navigator/data/config.yml
@@ -1,0 +1,273 @@
+# FIXME: auto generate docs/configuration.rst
+# NOTE!!! If you change any default here, update the documentation file in
+#         docs/configuration.rst
+
+#config_name:
+#  description: str/list[str] - the description to use for --help/docs
+#  default: any - optional - the default value
+#  choices: list - optional - valid choices for this option
+#  type: str - optional - The type to validate against (str, int, list, dict, bool)
+#  elements: str - optional - When type is list then this is what each element should be
+#  deprecated: todo add deprecation setup to state why and when it will be removed
+#  version_added: todo add a field that states when it was added for docs
+#
+#  Variables options to define it in
+#      Each take a list with the first having the highest priority
+#      Priority of each type: config < env < cli
+#
+#  config:
+#  - section:
+#    - ansible-navigator
+#    - editor
+#    name: str - the name of key in the section to set the value for
+#    deprecated: see above
+#    version_added: see above
+#
+#  env:
+#  - name: ENV_VAR
+#    deprecated: see above
+#    version_added: see above
+#
+#  cli:
+#  - name: --ce
+#    - list[str] of sub commands this is valid for
+#    deprecated: see above
+#    version_added: see above
+#  - name: --container-engine
+#    deprecated: see above
+#    version_added: see above
+
+container-engine:
+  description:
+  - The container engine to run the Execution Environment
+  choices:
+  - docker
+  - podman
+  default: podman
+  type: str
+  config:
+  - section:
+    - ansible-navigator
+    name: container-engine
+  cli:
+  - name: --ce
+  - name: --container-engine
+
+doc-plugin-type:
+  description: Plugin type to display
+  default: module
+  choices:
+  - become
+  - cache
+  - callback
+  - cliconf
+  - connection
+  - httpapi
+  - inventory
+  - lookup
+  - netconf
+  - shell
+  - vars
+  - module
+  - strategy
+  type: str
+  config:
+  - section:
+    - ansible-navigator
+    name: doc-plugin-type
+  cli:
+  - name: -t
+  - name: --type
+
+editor-command:
+  description:
+  - The editor command, filename and linenumber
+  - Defaults to "${EDITOR} {filename}" or "vi +{line_number} {filename}" if EDITOR is not defined
+  type: str
+  config:
+  - section:
+    - ansible-navigator
+    - editor
+    name: command
+  cli:
+  - name: --ecmd
+  - name: --editor-command
+
+editor-console:
+  description:
+  - Specify whether the editor is console based
+  default: True
+  type: bool
+  config:
+  - section:
+    - ansible-navigator
+    - editor
+    name: console
+  cli:
+  - name: --econ
+  - name: --editor-console
+
+execution-environment:
+  description:
+  - Run the playbook in an Execution Environment
+  default: True
+  type: bool
+  config:
+  - section:
+    - ansible-navigator
+    name: execution-environment
+  cli:
+  - name: --ee
+  - name: --execution-environment
+
+execution-environment-image:
+  description:
+  - The name of the container image containing an Execution Environment
+  default: quay.io/ansible/ansible-runner:devel
+  type: str
+  config:
+  - section:
+    - ansible-navigator
+    name: execution-environment-image
+  cli:
+  - name: --eei
+  - name: --execution-environment-image
+
+inventory:
+  description:
+  - The inventory/inventories to use
+  type: list
+  elements: str
+  config:
+  - section:
+    - ansible-navigator
+    name: inventory
+  cli:
+  - name: -i
+  - name: --inventory
+
+inventory-columns:
+  description:
+  - Additional columns to be shown in the inventory views
+  type: list
+  elements: str
+  config:
+  - section:
+    - ansible-navigator
+    name: inventory-columns
+  cli:
+  - name: -ic
+  - name: --inventory-columns
+
+log-file:
+  description:
+  - The application log file location
+  default: ./ansible-navigator.log
+  type: str
+  config:
+  - section:
+    - ansible-navigator
+    - log
+    name: file
+  cli:
+  - name: --lf
+  - name: --logfile
+
+log-level:
+  description:
+  - The application log level
+  choices:
+  - debug
+  - info
+  - warning
+  - error
+  - critical
+  default: info
+  type: str
+  config:
+  - section:
+    - ansible-navigator
+    - log
+    name: level
+  cli:
+  - name: --ll
+  - name: --loglevel
+
+mode:
+  description:
+  - The navigator mode to run
+  choices:
+  - interactive
+  - stdout
+  default: interactive
+  type: str
+  config:
+  - section:
+    - ansible-navigator
+    name: mode
+  cli:
+  - name: -m
+  - name: --mode
+
+no-osc4:
+  description:
+  - Disable OSC-4 support (xterm.js color fix)
+  default: False
+  type: bool
+  config:
+  - section:
+    - ansible-navigator
+    name: no-osc4
+  cli:
+  - name: --no-osc4
+
+pass-environment-variable:
+  description:
+  - A list of existing environment variables to be passed through to and set within the Execution Environment
+  type: list
+  elements: str
+  config:
+  - section:
+    - ansible-navigator
+    name: pass-environment-variable
+  cli:
+  - name: --penv
+  - name: --pass-environment-variable
+
+playbook:
+  description:
+  - The name of the playbook(s) to run
+  type: list
+  elements: str
+  config:
+  - section:
+    - ansible-navigator
+    name: playbook
+  cli:
+  - name: playbook
+
+playbook-artifact:
+  description:
+  - The artifact file name for playbook results
+  default: '{playbook_dir}/{playbook_name}-artifact-{ts_utc}.json'
+  type: str
+  config:
+  - section:
+    - ansible-navigator
+    name: playbook-artifact
+  cli:
+  - name: --pa
+  - name: --playbook-artifact
+
+set-environment-variable:
+  description:
+  - Environment variabels to set within the Execution Environment
+  - When set with the cli args, use the form 'NAME=value' for each environment var
+  type: dict
+  config:
+  - section:
+    - ansible-navigator
+    name: set-environment-variable
+  cli:
+  - name: --senv
+  - name: --set-environment-variable

--- a/ansible_navigator/utils.py
+++ b/ansible_navigator/utils.py
@@ -50,6 +50,16 @@ class Sentinel:  # pylint: disable=too-few-public-methods
         return cls
 
 
+class Singleton(type):
+    __instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls.__instances:
+            cls.__instances[cls] = super().__call__(*args, **kwargs)
+
+        return cls.__instances[cls]
+
+
 def human_time(seconds: int) -> str:
     """convert seconds into human readable
     00d00h00m00s format"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
 
 [options]
 packages = find:
+include_package_data = True
 install_requires =
     ansible-runner @ git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner-devel
     awxkit
@@ -43,6 +44,8 @@ install_requires =
 python_requires = >=3.6.1
 
 [options.data_files]
+# FIXME: There has to be a better way for this
+data = ansible_navigator/data/config.yml
 share/ansible_navigator/grammar =
     share/ansible_navigator/grammar/source.json.json
     share/ansible_navigator/grammar/source.yaml.json


### PR DESCRIPTION
This is a very early draft of moving the config setup away from argparse argument results to a centralised config setup. This supports layered config options and I'm hoping a way to update each option rather than blow away all existing options when the argparser is invoked again interactively.

Needs a lot more work to tidy up and hook into the code but so far the `--help` options for argparse still works.

Fixes https://github.com/ansible/ansible-navigator/issues/150