### PR TITLE
Config subsystem: Better use of enums, add 'apply_to_subsequent_cli' logic and tests

### DIFF
--- a/ansible_navigator/configuration_subsystem/__init__.py
+++ b/ansible_navigator/configuration_subsystem/__init__.py
@@ -1,4 +1,5 @@
 """ configuration subsystem
 """
 from .configurator import Configurator
+from .definitions import Subset
 from .navigator_configuration import NavigatorConfiguration

--- a/ansible_navigator/configuration_subsystem/definitions.py
+++ b/ansible_navigator/configuration_subsystem/definitions.py
@@ -27,6 +27,22 @@ class CliParameters(SimpleNamespace):
     short: Union[None, str] = None
 
 
+class Subset(Enum):
+    """General purpose subset enum to avoid
+    comparsing strings in lists etc, unique use case are noted
+    if this is used outside of the configuration subsystem
+    please move to utils
+    """
+
+    ALL = "everything"
+    NONE = "nothing"
+    SAME_SUBCOMMAND = (
+        "used to determine if an entry should be used when"
+        " applying previous cli comman entries, this indicates"
+        " that it will only be used if the subcommand is the same"
+    )
+
+
 class EntrySource(Enum):
     """Mapping some enums to log friendly text"""
 
@@ -48,18 +64,29 @@ class EntryValue(SimpleNamespace):
 
 class Entry(SimpleNamespace):
     # pylint: disable=too-few-public-methods
-    """One entry in the configuration"""
+    """One entry in the configuration
 
+    apply_to_subsequent_cli: Should this be applied to future clis parsed
+    choice: valid choices for this entry
+    cli_parameters: argparse specific params
+    environment_variable_override: override the defaultenvironment variable
+    name: the reference name for the entry
+    settings_file_path_override: over the defualt settings file path
+    short_description: A short description used for the argparse help
+    subcommand_value: Does the hold the names of the subcommand
+    subcommands: which subcommand should this be used for
+    value: the EntryValue for the entry
+    """
     name: str
     short_description: str
     value: EntryValue
 
+    apply_to_subsequent_cli: Subset = Subset.ALL
     choices: List = []
     cli_parameters: Union[None, CliParameters] = None
     environment_variable_override: Union[None, str] = None
-    internal: bool = False
     settings_file_path_override: Union[None, str] = None
-    subcommands: List[str] = []
+    subcommands: Union[List[str], Subset] = Subset.ALL
     subcommand_value: bool = False
 
     def environment_variable(self, prefix: str) -> str:

--- a/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -4,9 +4,10 @@ import os
 
 from .definitions import ApplicationConfiguration
 from .definitions import CliParameters
-from .definitions import SubCommand
 from .definitions import Entry
 from .definitions import EntryValue
+from .definitions import SubCommand
+from .definitions import Subset
 
 from .navigator_post_processor import NavigatorPostProcessor
 
@@ -53,12 +54,14 @@ NavigatorConfiguration = ApplicationConfiguration(
     entries=[
         Entry(
             name="app",
+            apply_to_subsequent_cli=Subset.NONE,
             short_description="Subcommands",
             subcommand_value=True,
             value=EntryValue(default="welcome"),
         ),
         Entry(
             name="cmdline",
+            apply_to_subsequent_cli=Subset.SAME_SUBCOMMAND,
             short_description="Placeholder for argparse remainder",
             value=EntryValue(default=[]),
         ),

--- a/ansible_navigator/configuration_subsystem/parser.py
+++ b/ansible_navigator/configuration_subsystem/parser.py
@@ -11,6 +11,7 @@ from typing import Tuple
 from typing import Union
 
 from .definitions import ApplicationConfiguration
+from .definitions import Subset
 
 from ..utils import Sentinel
 
@@ -75,7 +76,8 @@ class Parser:
 
     def _configure_base(self) -> None:
         for entry in self._config.entries:
-            if not entry.subcommands:
+            if entry.subcommands is Subset.ALL:
+                # if not entry.subcommands:
                 self._add_parser(self._base_parser, entry)
 
     def _configure_subparsers(self) -> None:
@@ -87,5 +89,5 @@ class Parser:
                 parents=[self._base_parser],
             )
             for entry in self._config.entries:
-                if subcommand.name in entry.subcommands:
+                if isinstance(entry.subcommands, list) and subcommand.name in entry.subcommands:
                     self._add_parser(parser, entry)

--- a/tests/unit/configuration_subsystem/data.py
+++ b/tests/unit/configuration_subsystem/data.py
@@ -4,12 +4,14 @@ Note: Some of these are defined as dictionaries for ease but all should be froze
 before use so they are immutable within the tests
 """
 
+from ansible_navigator.configuration_subsystem.definitions import EntrySource
 
-def d2f(dict):
+
+def d2t(dyct):
     """turn the data dictionary into a frozenset
     so they are immutable
     """
-    return tuple(dict.items())
+    return tuple(dyct.items())
 
 
 BASE_SHORT_CLI = """
@@ -42,7 +44,7 @@ BASE_LONG_CLI = """
 --set-environment-variable E2=V2
 """
 
-BASE_EXPECTED = d2f(
+BASE_EXPECTED = d2t(
     {
         "editor_command": "vim_base",
         "editor_console": True,
@@ -154,6 +156,7 @@ CLI_DATA_RUN = [
 
 
 def cli_data():
+    """turn them all into tuples"""
     aggregated = (
         CLI_DATA_COLLECTIONS  # type: ignore
         + CLI_DATA_CONFIG  # type: ignore
@@ -163,7 +166,7 @@ def cli_data():
         + CLI_DATA_LOAD  # type: ignore
         + CLI_DATA_RUN  # type: ignore
     )
-    frozen = [(cmd, d2f(expected)) for cmd, expected in aggregated]
+    frozen = [(cmd, d2t(expected)) for cmd, expected in aggregated]
     return frozen
 
 
@@ -192,6 +195,6 @@ ENVVAR_DATA = [
 ]
 
 SETTINGS = [
-    ("ansible-navigator_empty.yml", "DEFAULT_CFG"),
-    ("ansible-navigator.yml", "USER_CFG"),
+    ("ansible-navigator_empty.yml", EntrySource.DEFAULT_CFG),
+    ("ansible-navigator.yml", EntrySource.USER_CFG),
 ]

--- a/tests/unit/configuration_subsystem/test_navigator_configuration_previous_cli.py
+++ b/tests/unit/configuration_subsystem/test_navigator_configuration_previous_cli.py
@@ -1,0 +1,241 @@
+""" these test specificaly target variations of reapplying cli parameters
+to subsequent configuration subsystem calls with the same config
+grouped here because they are all similar
+"""
+import os
+
+from copy import deepcopy
+from unittest import mock
+
+from ansible_navigator.configuration_subsystem.definitions import EntrySource
+from ansible_navigator.configuration_subsystem.definitions import Subset
+from ansible_navigator.configuration_subsystem.configurator import Configurator
+from ansible_navigator.configuration_subsystem.definitions import ApplicationConfiguration
+
+from ansible_navigator.configuration_subsystem.navigator_configuration import NavigatorConfiguration
+
+from ansible_navigator.utils import Sentinel
+
+
+def test_apply_previous_cli_all():
+    """Ensure all previous cli parameter are applied when requested"""
+    params = "doc shell --ee False --eei test_image --forks 15"
+    expected = [
+        ("app", "doc"),
+        ("cmdline", ["--forks", "15"]),
+        ("execution_environment", False),
+        ("execution_environment_image", "test_image"),
+        ("plugin_name", "shell"),
+    ]
+
+    application_configuration = deepcopy(NavigatorConfiguration)
+    configurator = Configurator(
+        application_configuration=application_configuration,
+        params=params.split(),
+        save_as_intitial=True,
+    )
+    configurator.configure()
+    assert isinstance(application_configuration.initial, ApplicationConfiguration)
+
+    for expect in expected:
+        assert application_configuration.entry(expect[0]).value.current == expect[1]
+        assert application_configuration.entry(expect[0]).value.source is EntrySource.USER_CLI
+
+    params = "doc"
+    configurator = Configurator(
+        application_configuration=application_configuration,
+        params=params.split(),
+        apply_previous_cli_entries=Subset.ALL,
+    )
+    configurator.configure()
+
+    expected = [
+        ("app", "doc", EntrySource.USER_CLI),
+        ("cmdline", ["--forks", "15"], EntrySource.PREVIOUS_CLI),
+        ("execution_environment", False, EntrySource.PREVIOUS_CLI),
+        ("execution_environment_image", "test_image", EntrySource.PREVIOUS_CLI),
+        ("plugin_name", "shell", EntrySource.PREVIOUS_CLI),
+    ]
+    for expect in expected:
+        assert application_configuration.entry(expect[0]).value.current == expect[1]
+        assert application_configuration.entry(expect[0]).value.source is expect[2]
+
+
+def test_apply_previous_cli_specified():
+    """Ensure only some of the previous cli parameters are applied when requested"""
+    params = "doc shell --ee False --eei test_image --forks 15"
+    application_configuration = deepcopy(NavigatorConfiguration)
+    configurator = Configurator(
+        application_configuration=application_configuration,
+        params=params.split(),
+        save_as_intitial=True,
+    )
+
+    configurator.configure()
+    assert isinstance(application_configuration.initial, ApplicationConfiguration)
+
+    expected = [
+        ("app", "doc"),
+        ("cmdline", ["--forks", "15"]),
+        ("execution_environment", False),
+        ("execution_environment_image", "test_image"),
+    ]
+    for expect in expected:
+        assert application_configuration.entry(expect[0]).value.current == expect[1]
+        assert application_configuration.entry(expect[0]).value.source is EntrySource.USER_CLI
+
+    params = "doc"
+    configurator = Configurator(
+        application_configuration=application_configuration,
+        params=params.split(),
+        apply_previous_cli_entries=["execution_environment", "execution_environment_image"],
+    )
+    configurator.configure()
+
+    expected = [
+        ("app", "doc", EntrySource.USER_CLI),
+        ("cmdline", [], EntrySource.DEFAULT_CFG),
+        ("execution_environment", False, EntrySource.PREVIOUS_CLI),
+        ("execution_environment_image", "test_image", EntrySource.PREVIOUS_CLI),
+    ]
+    for expect in expected:
+        assert application_configuration.entry(expect[0]).value.current == expect[1]
+        assert application_configuration.entry(expect[0]).value.source is expect[2]
+
+
+def test_apply_previous_cli_mixed():
+    """Ensure a mixed config tests pass"""
+
+    params = "doc shell --ee False --eei test_image --forks 15"
+    application_configuration = deepcopy(NavigatorConfiguration)
+
+    configurator = Configurator(
+        application_configuration=application_configuration,
+        params=params.split(),
+        save_as_intitial=True,
+    )
+    with mock.patch.dict(os.environ, {"ANSIBLE_NAVIGATOR_PASS_ENVIRONMENT_VARIABLES": "ENV1,ENV2"}):
+        configurator.configure()
+
+    assert isinstance(application_configuration.initial, ApplicationConfiguration)
+
+    expected = [
+        ("app", "doc", EntrySource.USER_CLI),
+        ("cmdline", ["--forks", "15"], EntrySource.USER_CLI),
+        ("execution_environment", False, EntrySource.USER_CLI),
+        ("execution_environment_image", "test_image", EntrySource.USER_CLI),
+        ("pass_environment_variable", ["ENV1", "ENV2"], EntrySource.ENVIRONMENT_VARIABLE),
+    ]
+    for expect in expected:
+        assert application_configuration.entry(expect[0]).value.current == expect[1]
+        assert application_configuration.entry(expect[0]).value.source is expect[2]
+
+    params = "doc --eei different_image"
+    configurator = Configurator(
+        application_configuration=application_configuration,
+        params=params.split(),
+        apply_previous_cli_entries=Subset.ALL,
+    )
+    with mock.patch.dict(os.environ, {"ANSIBLE_NAVIGATOR_SET_ENVIRONMENT_VARIABLES": "ENV1=VAL1"}):
+        configurator.configure()
+
+    expected = [
+        ("app", "doc", EntrySource.USER_CLI),
+        ("cmdline", ["--forks", "15"], EntrySource.PREVIOUS_CLI),
+        ("execution_environment", False, EntrySource.PREVIOUS_CLI),
+        ("execution_environment_image", "different_image", EntrySource.USER_CLI),
+        ("pass_environment_variable", [], EntrySource.DEFAULT_CFG),
+        ("set_environment_variable", {"ENV1": "VAL1"}, EntrySource.ENVIRONMENT_VARIABLE),
+    ]
+    for expect in expected:
+        assert application_configuration.entry(expect[0]).value.current == expect[1]
+        assert application_configuration.entry(expect[0]).value.source is expect[2]
+
+
+def test_apply_previous_cli_cmdline_not_applied():
+    """Ensure cmdline is not carried forward"""
+    params = "run /tmp/site.yml --ee False --forks 15"
+    application_configuration = deepcopy(NavigatorConfiguration)
+    configurator = Configurator(
+        application_configuration=application_configuration,
+        params=params.split(),
+        save_as_intitial=True,
+    )
+
+    configurator.configure()
+
+    assert isinstance(application_configuration.initial, ApplicationConfiguration)
+
+    expected = [
+        ("app", "run"),
+        ("cmdline", ["--forks", "15"]),
+        ("execution_environment", False),
+        ("playbook", "/tmp/site.yml"),
+    ]
+
+    for expect in expected:
+        assert application_configuration.entry(expect[0]).value.current == expect[1]
+        assert application_configuration.entry(expect[0]).value.source is EntrySource.USER_CLI
+
+    params = "doc"
+    configurator = Configurator(
+        application_configuration=application_configuration,
+        params=params.split(),
+        apply_previous_cli_entries=Subset.ALL,
+    )
+    configurator.configure()
+
+    expected = [
+        ("app", "doc", EntrySource.USER_CLI),
+        ("cmdline", [], EntrySource.DEFAULT_CFG),
+        ("execution_environment", False, EntrySource.PREVIOUS_CLI),
+        ("playbook", "/tmp/site.yml", EntrySource.PREVIOUS_CLI),
+    ]
+
+    for expect in expected:
+        assert application_configuration.entry(expect[0]).value.current == expect[1]
+        assert application_configuration.entry(expect[0]).value.source is expect[2]
+
+
+def test_apply_previous_cli_none():
+    """Ensure nothing is carried forward"""
+    params = "run /tmp/site.yml --ee False --forks 15"
+    application_configuration = deepcopy(NavigatorConfiguration)
+    configurator = Configurator(
+        application_configuration=application_configuration,
+        params=params.split(),
+        save_as_intitial=True,
+    )
+
+    configurator.configure()
+
+    assert isinstance(application_configuration.initial, ApplicationConfiguration)
+
+    expected = [
+        ("app", "run"),
+        ("cmdline", ["--forks", "15"]),
+        ("playbook", "/tmp/site.yml"),
+        ("execution_environment", False),
+    ]
+    for expect in expected:
+        assert application_configuration.entry(expect[0]).value.current == expect[1]
+        assert application_configuration.entry(expect[0]).value.source is EntrySource.USER_CLI
+
+    params = "doc"
+    configurator = Configurator(
+        application_configuration=application_configuration,
+        params=params.split(),
+        apply_previous_cli_entries=Subset.NONE,
+    )
+    configurator.configure()
+
+    expected = [
+        ("app", "doc", EntrySource.USER_CLI),
+        ("cmdline", [], EntrySource.DEFAULT_CFG),
+        ("playbook", Sentinel, EntrySource.DEFAULT_CFG),
+        ("execution_environment", True, EntrySource.DEFAULT_CFG),
+    ]
+
+    for expect in expected:
+        assert application_configuration.entry(expect[0]).value.current == expect[1]
+        assert application_configuration.entry(expect[0]).value.source is expect[2]

--- a/tests/unit/configuration_subsystem/test_sample_configurations.py
+++ b/tests/unit/configuration_subsystem/test_sample_configurations.py
@@ -18,10 +18,12 @@ from ansible_navigator.configuration_subsystem.definitions import SubCommand
 
 from ansible_navigator.configuration_subsystem.parser import Parser
 
+# pylint: disable=protected-access
+
 
 def test_cmdline_source_not_set():
     """Ensure a Config without a subparse entry fails"""
-    TestConfig = ApplicationConfiguration(
+    test_config = ApplicationConfiguration(
         application_name="test_config1",
         post_processor=NavigatorPostProcessor(),
         subcommands=[
@@ -35,7 +37,7 @@ def test_cmdline_source_not_set():
             ),
         ],
     )
-    configurator = Configurator(params=[], application_configuration=TestConfig)
+    configurator = Configurator(params=[], application_configuration=test_config)
     configurator._post_process()
     assert "Completed post processing for cmdline" in configurator._messages[0][1]
     assert configurator._errors == []
@@ -43,7 +45,7 @@ def test_cmdline_source_not_set():
 
 def test_no_subcommand():
     """Ensure a Config without a subparse entry fails"""
-    TestConfig = ApplicationConfiguration(
+    test_config = ApplicationConfiguration(
         application_name="test_config1",
         post_processor=None,
         subcommands=[
@@ -52,12 +54,12 @@ def test_no_subcommand():
         entries=[],
     )
     with pytest.raises(ValueError, match="No entry with subparser value defined"):
-        Configurator(params=[], application_configuration=TestConfig).configure()
+        Configurator(params=[], application_configuration=test_config).configure()
 
 
 def test_many_subcommand():
     """Ensure a Config without a subparse entry fails"""
-    TestConfig = ApplicationConfiguration(
+    test_config = ApplicationConfiguration(
         application_name="test_config1",
         post_processor=None,
         subcommands=[
@@ -79,12 +81,12 @@ def test_many_subcommand():
         ],
     )
     with pytest.raises(ValueError, match="Multiple entries with subparser value defined"):
-        Configurator(params=[], application_configuration=TestConfig).configure()
+        Configurator(params=[], application_configuration=test_config).configure()
 
 
 def test_invalid_choice_not_set():
     """Ensure a Config without a subparse entry fails"""
-    TestConfig = ApplicationConfiguration(
+    test_config = ApplicationConfiguration(
         application_name="test_config1",
         post_processor=None,
         subcommands=[
@@ -105,12 +107,12 @@ def test_invalid_choice_not_set():
         ],
     )
     with pytest.raises(ValueError, match="Current source not set for e1"):
-        TestConfig.entry("e1").invalid_choice
+        test_config.entry("e1").invalid_choice  # pylint: disable=expression-not-assigned
 
 
 def test_cutom_nargs_for_postional():
     """Ensure a nargs for a positional are carried forward"""
-    TestConfig = ApplicationConfiguration(
+    test_config = ApplicationConfiguration(
         application_name="test_config1",
         post_processor=None,
         subcommands=[
@@ -128,40 +130,9 @@ def test_cutom_nargs_for_postional():
                 cli_parameters=CliParameters(positional=True, nargs=3),
                 short_description="ex1",
                 value=EntryValue(),
+                subcommands=["subcommand1"],
             ),
         ],
     )
-    parser = Parser(TestConfig)
-    entry = [action for action in parser.parser._actions if action.dest == "e1"]
-    assert entry[0].nargs == 3
-
-
-def test_apply_cli_source_not_set():
-    """Ensure a Config iterates correctly"""
-    TestConfig = ApplicationConfiguration(
-        application_name="test_config1",
-        post_processor=NavigatorPostProcessor(),
-        subcommands=[
-            SubCommand(name="subcommand1", description="subcommand1"),
-        ],
-        entries=[
-            Entry(
-                name="e1",
-                short_description="e1",
-                value=EntryValue(),
-            ),
-            Entry(
-                name="e2",
-                short_description="e2",
-                value=EntryValue(),
-            ),
-        ],
-        initial=True,
-    )
-
-    configurator = Configurator(
-        params=[], application_configuration=TestConfig, apply_previous_cli_entries=["all"]
-    )
-    configurator._apply_previous_cli_to_current()
-    assert configurator._messages == []
-    assert configurator._errors == []
+    parser = Parser(test_config)
+    assert parser.parser._actions[1].choices["subcommand1"]._actions[1].nargs == 3

--- a/tests/unit/configuration_subsystem/utils.py
+++ b/tests/unit/configuration_subsystem/utils.py
@@ -1,7 +1,6 @@
 """ utility func used by adjacent tests
 """
 import os
-from copy import deepcopy
 
 from typing import Dict
 from typing import List
@@ -15,6 +14,7 @@ from ansible_navigator.configuration_subsystem.definitions import ApplicationCon
 from ansible_navigator.configuration_subsystem.definitions import Entry
 from ansible_navigator.configuration_subsystem.definitions import Message
 
+from ansible_navigator.configuration_subsystem.navigator_configuration import NavigatorConfiguration
 
 from ansible_navigator.yaml import yaml
 from ansible_navigator.yaml import Loader
@@ -25,6 +25,8 @@ TEST_FIXTURE_DIR = os.path.join(FIXTURES_DIR, "unit", "configuration_subsystem")
 
 
 class GenerateConfigResponse(NamedTuple):
+    """obj for generate_config_response"""
+
     messages: List[Message]
     errors: List[str]
     application_configuration: ApplicationConfiguration
@@ -48,10 +50,6 @@ def _generate_config(params=None, setting_file_name=None) -> GenerateConfigRespo
         settings_file_path = ""
         settings_contents = {}
 
-    from ansible_navigator.configuration_subsystem.navigator_configuration import (
-        NavigatorConfiguration,
-    )
-
     application_configuration = NavigatorConfiguration
     configurator = Configurator(
         application_configuration=application_configuration,
@@ -69,6 +67,7 @@ def _generate_config(params=None, setting_file_name=None) -> GenerateConfigRespo
 
 @pytest.fixture(name="generate_config")
 def fixture_generate_config():
+    """generate a config"""
     return _generate_config
 
 


### PR DESCRIPTION
An entry can now be flagged to only be carried forward is the subcommand is the same
Cleaned up the use of the enums
added tests