### PR TITLE
Centralize enums in configuration subsystem

### DIFF
--- a/ansible_navigator/configuration_subsystem/__init__.py
+++ b/ansible_navigator/configuration_subsystem/__init__.py
@@ -1,5 +1,5 @@
 """ configuration subsystem
 """
 from .configurator import Configurator
-from .definitions import Subset
+from .definitions import Constants
 from .navigator_configuration import NavigatorConfiguration

--- a/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -4,10 +4,10 @@ import os
 
 from .definitions import ApplicationConfiguration
 from .definitions import CliParameters
+from .definitions import Constants as C
 from .definitions import Entry
 from .definitions import EntryValue
 from .definitions import SubCommand
-from .definitions import Subset
 
 from .navigator_post_processor import NavigatorPostProcessor
 
@@ -54,16 +54,16 @@ NavigatorConfiguration = ApplicationConfiguration(
     entries=[
         Entry(
             name="app",
-            apply_to_subsequent_cli=Subset.NONE,
+            apply_to_subsequent_cli=C.NONE,
             short_description="Subcommands",
             subcommand_value=True,
             value=EntryValue(default="welcome"),
         ),
         Entry(
             name="cmdline",
-            apply_to_subsequent_cli=Subset.SAME_SUBCOMMAND,
+            apply_to_subsequent_cli=C.SAME_SUBCOMMAND,
             short_description="Placeholder for argparse remainder",
-            value=EntryValue(default=[]),
+            value=EntryValue(),
         ),
         Entry(
             name="container_engine",

--- a/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -3,15 +3,14 @@
 from typing import List
 from typing import Tuple
 
+from .definitions import Constants as C
 from .definitions import Entry
-from .definitions import EntrySource
 from .definitions import ApplicationConfiguration
 from .definitions import Message
 
 from ..utils import abs_user_path
 from ..utils import flatten_list
 from ..utils import str2bool
-from ..utils import Sentinel
 
 
 def _post_processor(func):
@@ -50,7 +49,7 @@ class NavigatorPostProcessor:
         """Post process cmdline"""
         messages: List[Message] = []
         errors: List[str] = []
-        if isinstance(entry.value.source, EntrySource):
+        if isinstance(entry.value.source, C):
             if entry.value.source.name == "ENVIRONMENT_VARIABLE":
                 entry.value.current = entry.value.current.split()
         return messages, errors
@@ -75,13 +74,11 @@ class NavigatorPostProcessor:
         """Post process inventory"""
         messages: List[Message] = []
         errors: List[str] = []
-        if config.app == "inventory" and entry.value.current is Sentinel:
+        if config.app == "inventory" and entry.value.current is C.NOT_SET:
             msg = "An inventory is required when using the inventory subcommand"
             errors.append(msg)
             return messages, errors
-        if entry.value.current is Sentinel:
-            entry.value.current = []
-        else:
+        if entry.value.current is not C.NOT_SET:
             flattened = flatten_list(entry.value.current)
             entry.value.current = []
             for inv_entry in flattened:
@@ -102,9 +99,7 @@ class NavigatorPostProcessor:
         """Post process inventory_columns"""
         messages: List[Message] = []
         errors: List[str] = []
-        if entry.value.current is Sentinel:
-            entry.value.current = []
-        else:
+        if entry.value.current is not C.NOT_SET:
             entry.value.current = flatten_list(entry.value.current)
             messages.append(
                 Message(log_level="debug", message="Completed inventory-column post processing")
@@ -137,9 +132,7 @@ class NavigatorPostProcessor:
         """Post process pass_environment_variable"""
         messages: List[Message] = []
         errors: List[str] = []
-        if entry.value.current is Sentinel:
-            entry.value.current = []
-        else:
+        if entry.value.current is not C.NOT_SET:
             entry.value.current = flatten_list(entry.value.current)
         return messages, errors
 
@@ -163,11 +156,9 @@ class NavigatorPostProcessor:
         """Post process set_environment_variable"""
         messages: List[Message] = []
         errors: List[str] = []
-        if entry.value.current is Sentinel:
-            entry.value.current = {}
-        elif isinstance(entry.value.source, EntrySource) and entry.value.source.name in [
-            "ENVIRONMENT_VARIABLE",
-            "USER_CLI",
+        if entry.value.source in [
+            C.ENVIRONMENT_VARIABLE,
+            C.USER_CLI,
         ]:
             flattened = flatten_list(entry.value.current)
             set_envs = {}

--- a/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -49,9 +49,8 @@ class NavigatorPostProcessor:
         """Post process cmdline"""
         messages: List[Message] = []
         errors: List[str] = []
-        if isinstance(entry.value.source, C):
-            if entry.value.source.name == "ENVIRONMENT_VARIABLE":
-                entry.value.current = entry.value.current.split()
+        if entry.value.source is C.ENVIRONMENT_VARIABLE:
+            entry.value.current = entry.value.current.split()
         return messages, errors
 
     @_post_processor

--- a/ansible_navigator/configuration_subsystem/parser.py
+++ b/ansible_navigator/configuration_subsystem/parser.py
@@ -11,9 +11,7 @@ from typing import Tuple
 from typing import Union
 
 from .definitions import ApplicationConfiguration
-from .definitions import Subset
-
-from ..utils import Sentinel
+from .definitions import Constants as C
 
 
 class Parser:
@@ -33,7 +31,7 @@ class Parser:
         """Generate an argparse argument"""
         kwargs = {}
         kwargs["help"] = entry.short_description
-        if entry.value.default is not Sentinel:
+        if entry.value.default is not C.NOT_SET:
             kwargs["help"] += f" (default: {entry.value.default})"
         kwargs["default"] = SUPPRESS
         kwargs["metavar"] = ""
@@ -76,7 +74,7 @@ class Parser:
 
     def _configure_base(self) -> None:
         for entry in self._config.entries:
-            if entry.subcommands is Subset.ALL:
+            if entry.subcommands is C.ALL:
                 self._add_parser(self._base_parser, entry)
 
     def _configure_subparsers(self) -> None:

--- a/tests/unit/configuration_subsystem/data.py
+++ b/tests/unit/configuration_subsystem/data.py
@@ -4,7 +4,7 @@ Note: Some of these are defined as dictionaries for ease but all should be froze
 before use so they are immutable within the tests
 """
 
-from ansible_navigator.configuration_subsystem.definitions import EntrySource
+from ansible_navigator.configuration_subsystem.definitions import Constants as C
 
 
 def d2t(dyct):
@@ -195,6 +195,6 @@ ENVVAR_DATA = [
 ]
 
 SETTINGS = [
-    ("ansible-navigator_empty.yml", EntrySource.DEFAULT_CFG),
-    ("ansible-navigator.yml", EntrySource.USER_CFG),
+    ("ansible-navigator_empty.yml", "empty"),
+    ("ansible-navigator.yml", "full"),
 ]

--- a/tests/unit/configuration_subsystem/test_navigator_configuration_entries_sanity.py
+++ b/tests/unit/configuration_subsystem/test_navigator_configuration_entries_sanity.py
@@ -1,0 +1,76 @@
+""" perform some sanity and sytax checking of the navigator configuration
+"""
+from collections import Counter
+
+import pytest
+
+from ansible_navigator.configuration_subsystem.definitions import Constants as C
+from ansible_navigator.configuration_subsystem.navigator_configuration import NavigatorConfiguration
+
+from .utils import id_for_name
+
+
+def test_entries_no_duplicate_names():
+    """Ensure no name is duplicated"""
+    values = Counter([entry.name for entry in NavigatorConfiguration.entries])
+    assert not any(k for (k, v) in values.items() if v > 1)
+
+
+def test_entries_no_duplicate_shorts():
+    """Ensure no short is duplicated"""
+    values = Counter(
+        [
+            entry.cli_parameters.short
+            for entry in NavigatorConfiguration.entries
+            if entry.cli_parameters is not None
+        ]
+    )
+    assert not any(k for (k, v) in values.items() if v > 1)
+
+
+def test_entries_alphbetical():
+    """Ensure entries are alphabetical"""
+    values = [entry.name for entry in NavigatorConfiguration.entries]
+    assert values == sorted(values)
+
+
+@pytest.mark.parametrize("entry", NavigatorConfiguration.entries, ids=id_for_name)
+def test_entries_no_dash_in_name(entry):
+    """Ensure no names contain a -"""
+    assert "-" not in entry.name
+
+
+@pytest.mark.parametrize("entry", NavigatorConfiguration.entries, ids=id_for_name)
+def test_entries_no_dash_in_environment_variable(entry):
+    """Ensure no environment variable has a dash"""
+    assert "-" not in entry.environment_variable("ansible_navigator")
+
+
+@pytest.mark.parametrize("entry", NavigatorConfiguration.entries, ids=id_for_name)
+def test_entries_no_short_long_if_postional(entry):
+    """Ensure no postional argument has a short or long set"""
+    if hasattr(entry, "cli_arguments") and entry.cli_parameters.positional:
+        assert entry.short is None
+        assert entry.long_override is None
+
+
+@pytest.mark.parametrize("entry", NavigatorConfiguration.entries, ids=id_for_name)
+def test_entries_no_underscore_in_path(entry):
+    """Ensure no long override has an _"""
+    if entry.settings_file_path_override is not None:
+        assert "_" not in entry.settings_file_path_override
+
+
+@pytest.mark.parametrize("entry", NavigatorConfiguration.entries, ids=id_for_name)
+def test_entries_no_current_set(entry):
+    """Ensure no entry has a current value set prior to configuration"""
+    assert entry.value.current is C.NOT_SET
+
+
+@pytest.mark.parametrize("entry", NavigatorConfiguration.entries, ids=id_for_name)
+def test_entries_default_value(entry):
+    """Ensure entry has a default value not set or a common type"""
+    if isinstance(entry.value.default, C):
+        assert entry.value.default is C.NOT_SET
+    else:
+        assert isinstance(entry.value.default, (bool, int, str, dict, list))

--- a/tests/unit/configuration_subsystem/test_navigator_configuration_previous_cli.py
+++ b/tests/unit/configuration_subsystem/test_navigator_configuration_previous_cli.py
@@ -11,15 +11,12 @@ from ansible_navigator.configuration_subsystem.configurator import Configurator
 
 from ansible_navigator.configuration_subsystem.definitions import ApplicationConfiguration
 from ansible_navigator.configuration_subsystem.definitions import CliParameters
+from ansible_navigator.configuration_subsystem.definitions import Constants as C
 from ansible_navigator.configuration_subsystem.definitions import Entry
-from ansible_navigator.configuration_subsystem.definitions import EntrySource
 from ansible_navigator.configuration_subsystem.definitions import EntryValue
 from ansible_navigator.configuration_subsystem.definitions import SubCommand
-from ansible_navigator.configuration_subsystem.definitions import Subset
 
 from ansible_navigator.configuration_subsystem.navigator_configuration import NavigatorConfiguration
-
-from ansible_navigator.utils import Sentinel
 
 
 def test_apply_previous_cli_all():
@@ -44,22 +41,22 @@ def test_apply_previous_cli_all():
 
     for expect in expected:
         assert application_configuration.entry(expect[0]).value.current == expect[1]
-        assert application_configuration.entry(expect[0]).value.source is EntrySource.USER_CLI
+        assert application_configuration.entry(expect[0]).value.source is C.USER_CLI
 
     params = "doc"
     configurator = Configurator(
         application_configuration=application_configuration,
         params=params.split(),
-        apply_previous_cli_entries=Subset.ALL,
+        apply_previous_cli_entries=C.ALL,
     )
     configurator.configure()
 
     expected = [
-        ("app", "doc", EntrySource.USER_CLI),
-        ("cmdline", ["--forks", "15"], EntrySource.PREVIOUS_CLI),
-        ("execution_environment", False, EntrySource.PREVIOUS_CLI),
-        ("execution_environment_image", "test_image", EntrySource.PREVIOUS_CLI),
-        ("plugin_name", "shell", EntrySource.PREVIOUS_CLI),
+        ("app", "doc", C.USER_CLI),
+        ("cmdline", ["--forks", "15"], C.PREVIOUS_CLI),
+        ("execution_environment", False, C.PREVIOUS_CLI),
+        ("execution_environment_image", "test_image", C.PREVIOUS_CLI),
+        ("plugin_name", "shell", C.PREVIOUS_CLI),
     ]
     for expect in expected:
         assert application_configuration.entry(expect[0]).value.current == expect[1]
@@ -87,7 +84,7 @@ def test_apply_previous_cli_specified():
     ]
     for expect in expected:
         assert application_configuration.entry(expect[0]).value.current == expect[1]
-        assert application_configuration.entry(expect[0]).value.source is EntrySource.USER_CLI
+        assert application_configuration.entry(expect[0]).value.source is C.USER_CLI
 
     params = "doc"
     configurator = Configurator(
@@ -98,10 +95,10 @@ def test_apply_previous_cli_specified():
     configurator.configure()
 
     expected = [
-        ("app", "doc", EntrySource.USER_CLI),
-        ("cmdline", [], EntrySource.DEFAULT_CFG),
-        ("execution_environment", False, EntrySource.PREVIOUS_CLI),
-        ("execution_environment_image", "test_image", EntrySource.PREVIOUS_CLI),
+        ("app", "doc", C.USER_CLI),
+        ("cmdline", C.NOT_SET, C.NOT_SET),
+        ("execution_environment", False, C.PREVIOUS_CLI),
+        ("execution_environment_image", "test_image", C.PREVIOUS_CLI),
     ]
     for expect in expected:
         assert application_configuration.entry(expect[0]).value.current == expect[1]
@@ -125,11 +122,11 @@ def test_apply_previous_cli_mixed():
     assert isinstance(application_configuration.initial, ApplicationConfiguration)
 
     expected = [
-        ("app", "doc", EntrySource.USER_CLI),
-        ("cmdline", ["--forks", "15"], EntrySource.USER_CLI),
-        ("execution_environment", False, EntrySource.USER_CLI),
-        ("execution_environment_image", "test_image", EntrySource.USER_CLI),
-        ("pass_environment_variable", ["ENV1", "ENV2"], EntrySource.ENVIRONMENT_VARIABLE),
+        ("app", "doc", C.USER_CLI),
+        ("cmdline", ["--forks", "15"], C.USER_CLI),
+        ("execution_environment", False, C.USER_CLI),
+        ("execution_environment_image", "test_image", C.USER_CLI),
+        ("pass_environment_variable", ["ENV1", "ENV2"], C.ENVIRONMENT_VARIABLE),
     ]
     for expect in expected:
         assert application_configuration.entry(expect[0]).value.current == expect[1]
@@ -139,18 +136,18 @@ def test_apply_previous_cli_mixed():
     configurator = Configurator(
         application_configuration=application_configuration,
         params=params.split(),
-        apply_previous_cli_entries=Subset.ALL,
+        apply_previous_cli_entries=C.ALL,
     )
     with mock.patch.dict(os.environ, {"ANSIBLE_NAVIGATOR_SET_ENVIRONMENT_VARIABLES": "ENV1=VAL1"}):
         configurator.configure()
 
     expected = [
-        ("app", "doc", EntrySource.USER_CLI),
-        ("cmdline", ["--forks", "15"], EntrySource.PREVIOUS_CLI),
-        ("execution_environment", False, EntrySource.PREVIOUS_CLI),
-        ("execution_environment_image", "different_image", EntrySource.USER_CLI),
-        ("pass_environment_variable", [], EntrySource.DEFAULT_CFG),
-        ("set_environment_variable", {"ENV1": "VAL1"}, EntrySource.ENVIRONMENT_VARIABLE),
+        ("app", "doc", C.USER_CLI),
+        ("cmdline", ["--forks", "15"], C.PREVIOUS_CLI),
+        ("execution_environment", False, C.PREVIOUS_CLI),
+        ("execution_environment_image", "different_image", C.USER_CLI),
+        ("pass_environment_variable", C.NOT_SET, C.NOT_SET),
+        ("set_environment_variable", {"ENV1": "VAL1"}, C.ENVIRONMENT_VARIABLE),
     ]
     for expect in expected:
         assert application_configuration.entry(expect[0]).value.current == expect[1]
@@ -180,21 +177,21 @@ def test_apply_previous_cli_cmdline_not_applied():
 
     for expect in expected:
         assert application_configuration.entry(expect[0]).value.current == expect[1]
-        assert application_configuration.entry(expect[0]).value.source is EntrySource.USER_CLI
+        assert application_configuration.entry(expect[0]).value.source is C.USER_CLI
 
     params = "doc"
     configurator = Configurator(
         application_configuration=application_configuration,
         params=params.split(),
-        apply_previous_cli_entries=Subset.ALL,
+        apply_previous_cli_entries=C.ALL,
     )
     configurator.configure()
 
     expected = [
-        ("app", "doc", EntrySource.USER_CLI),
-        ("cmdline", [], EntrySource.DEFAULT_CFG),
-        ("execution_environment", False, EntrySource.PREVIOUS_CLI),
-        ("playbook", "/tmp/site.yml", EntrySource.PREVIOUS_CLI),
+        ("app", "doc", C.USER_CLI),
+        ("cmdline", C.NOT_SET, C.NOT_SET),
+        ("execution_environment", False, C.PREVIOUS_CLI),
+        ("playbook", "/tmp/site.yml", C.PREVIOUS_CLI),
     ]
 
     for expect in expected:
@@ -224,21 +221,21 @@ def test_apply_previous_cli_none():
     ]
     for expect in expected:
         assert application_configuration.entry(expect[0]).value.current == expect[1]
-        assert application_configuration.entry(expect[0]).value.source is EntrySource.USER_CLI
+        assert application_configuration.entry(expect[0]).value.source is C.USER_CLI
 
     params = "doc"
     configurator = Configurator(
         application_configuration=application_configuration,
         params=params.split(),
-        apply_previous_cli_entries=Subset.NONE,
+        apply_previous_cli_entries=C.NONE,
     )
     configurator.configure()
 
     expected = [
-        ("app", "doc", EntrySource.USER_CLI),
-        ("cmdline", [], EntrySource.DEFAULT_CFG),
-        ("playbook", Sentinel, EntrySource.DEFAULT_CFG),
-        ("execution_environment", True, EntrySource.DEFAULT_CFG),
+        ("app", "doc", C.USER_CLI),
+        ("cmdline", C.NOT_SET, C.NOT_SET),
+        ("playbook", C.NOT_SET, C.NOT_SET),
+        ("execution_environment", True, C.DEFAULT_CFG),
     ]
 
     for expect in expected:
@@ -264,7 +261,7 @@ def test_apply_cli_subset_none():
             ),
             Entry(
                 name="z",
-                apply_to_subsequent_cli=Subset.NONE,
+                apply_to_subsequent_cli=C.NONE,
                 cli_parameters=CliParameters(short="-z"),
                 short_description="the z paramter",
                 value=EntryValue(),
@@ -284,16 +281,16 @@ def test_apply_cli_subset_none():
     ]
     for expect in expected:
         assert test_config.entry(expect[0]).value.current == expect[1]
-        assert test_config.entry(expect[0]).value.source is EntrySource.USER_CLI
+        assert test_config.entry(expect[0]).value.source is C.USER_CLI
 
     configurator = Configurator(
-        params=["run"], application_configuration=test_config, apply_previous_cli_entries=Subset.ALL
+        params=["run"], application_configuration=test_config, apply_previous_cli_entries=C.ALL
     )
     configurator.configure()
 
     expected = [
-        ("subcommand", "run", EntrySource.USER_CLI),
-        ("z", Sentinel, EntrySource.DEFAULT_CFG),
+        ("subcommand", "run", C.USER_CLI),
+        ("z", C.NOT_SET, C.NOT_SET),
     ]
     for expect in expected:
         assert test_config.entry(expect[0]).value.current == expect[1]

--- a/tests/unit/configuration_subsystem/test_sample_configurations.py
+++ b/tests/unit/configuration_subsystem/test_sample_configurations.py
@@ -85,7 +85,7 @@ def test_many_subcommand():
 
 
 def test_invalid_choice_not_set():
-    """Ensure a Config without a subparse entry fails"""
+    """Ensure an error is raised for no choice"""
     test_config = ApplicationConfiguration(
         application_name="test_config1",
         post_processor=None,

--- a/tests/unit/configuration_subsystem/utils.py
+++ b/tests/unit/configuration_subsystem/utils.py
@@ -1,6 +1,7 @@
 """ utility func used by adjacent tests
 """
 import os
+from copy import deepcopy
 
 from typing import Dict
 from typing import List
@@ -50,7 +51,8 @@ def _generate_config(params=None, setting_file_name=None) -> GenerateConfigRespo
         settings_file_path = ""
         settings_contents = {}
 
-    application_configuration = NavigatorConfiguration
+    # deepcopy here to ensure we do not modify the original
+    application_configuration = deepcopy(NavigatorConfiguration)
     configurator = Configurator(
         application_configuration=application_configuration,
         params=params,


### PR DESCRIPTION
switch from use of Sentinel to Constant.NOT_SET
only set a default value if a default value was specified, otherwise leave NOT_SET
purge current configuration each time configurator.configure is run
organize test files better so they are grouped by like tests

