### PR TITLE
add pytest duration, move cli options to toml

### DIFF
--- a/artifact.json
+++ b/artifact.json
@@ -1,0 +1,7 @@
+{
+    "version": "1.0.0",
+    "plays": [],
+    "stdout": [],
+    "status": "failed",
+    "status_color": 9
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,16 @@ line-length = 100
     [tool.pylint.format]
     max-line-length = 100
 
+[tool.pytest.ini_options]
+addopts = """
+ -vvvv
+--durations=100
+--cov {[base]pkg_name}
+--cov share
+--cov-report term-missing
+--cov-branch
+"""
+testpaths = [
+    "tests"
+]
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =
     /bin/bash -c 'grep -FInrq "UPDATE_FIXTURES = True" ./tests && exit 1 || exit 0'
-    py.test -vvvv --cov {[base]pkg_name} --cov share --cov-report term-missing --cov-branch
+    py.test
 setenv =
     TERM = xterm
 passenv = HOME


### PR DESCRIPTION
fixes #90 

it's a little noise but I would rather have this info when we need it