### PR TITLE
update readme quickstart with correct filepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ python3 -m venv venv
 source venv/bin/activate
 pip install -U setuptools
 pip install -U ansible
-pip install ../ansible-navigator
+pip install ../ansible_navigator
 ```
 
 RHEL8/Centos8 prerequisites:

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ mkdir ansible-navigator_demo
 cd ansible-navigator_demo
 python3 -m venv venv
 source venv/bin/activate
+cd ..
 pip install -U setuptools
 pip install -U ansible
-pip install ../ansible_navigator
+pip install .
 ```
 
 RHEL8/Centos8 prerequisites:


### PR DESCRIPTION
path to install location is incorrect. added 2 steps to properly start the install since the setup.py is at the top level and no longer housed in `ansible_navigator`. 

edit: rewrite install since location moved