### PR TITLE
rm unneeded awxkit from setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ classifiers =
 packages = find:
 install_requires =
     ansible-runner @ git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner-devel
-    awxkit
     jinja2
     onigurumacffi
     pyyaml


### PR DESCRIPTION
Fixes #207 

Since controller integration has been removed for now, awxkit is no longer a dep