### PR TITLE
[:run, docs] example settings yaml and ISO timestamp for playbook artifact

### DIFF
--- a/ansible_navigator/actions/run.py
+++ b/ansible_navigator/actions/run.py
@@ -745,7 +745,7 @@ class Action(App):
             filename = filename.format(
                 playbook_dir=os.path.dirname(self._args.playbook),
                 playbook_name=os.path.splitext(os.path.basename(self._args.playbook))[0],
-                ts_utc=datetime.datetime.now(tz=datetime.timezone.utc),
+                ts_utc=datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
             )
             self._logger.debug("Formatted artifact file name set to %s", filename)
             filename = abs_user_path(filename)

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -36,7 +36,7 @@ You can copy the example settings file below into one of those paths to start yo
   start-settings-sample
 .. code-block:: yaml
 
-    # ---
+    ---
     ansible-navigator:
     #   app: run
     #   collection-doc-cache-path: /tmp/cache.db

--- a/utilities/doc_updater.py
+++ b/utilities/doc_updater.py
@@ -228,7 +228,7 @@ def _update_sample_settings(args: Namespace, filename: str):
     """update the settings sample"""
     with open(args.ss) as fhand:
         settings = fhand.read().splitlines()
-    not_commented = ["ansible-navigator:", "logging:", "level:"]
+    not_commented = ["---", "ansible-navigator:", "logging:", "level:"]
     for idx, line in enumerate(settings):
         if not any(nc in line for nc in not_commented):
             settings[idx] = "    # " + line


### PR DESCRIPTION
depends-on: https://github.com/ansible/ansible-navigator/pull/257

Fixes #228 
Fixes #227 

Clearing out daily issues :)

Don't comment out the --- in the example yaml file
Switch to a proper ISO8601 formatted timestamp in the playbook artifact
