### PR TITLE
[docs] fix typo in plugin-type docs

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -321,7 +321,7 @@ The following table describes all available settings.
     - Specify the plugin type, 'become', 'cache', 'callback', 'cliconf', 'connection', 'httpapi', 'inventory', 'lookup', 'module', 'netconf', 'shell', 'strategy' or 'vars'
     - | **Choices:** 'become', 'cache', 'callback', 'cliconf', 'connection', 'httpapi', 'inventory', 'lookup', 'module', 'netconf', 'shell', 'strategy' or 'vars'
       | **Default:** module
-      | **CLI:** `-t` or `----type`
+      | **CLI:** `-t` or `--type`
       | **ENV:** ANSIBLE_NAVIGATOR_PLUGIN_TYPE
       | **Settings file:**
 


### PR DESCRIPTION
depends-on: https://github.com/ansible/ansible-navigator/pull/257

changed ----type to --type

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>