### PR TITLE
[docs] restore dash to example settings file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.linting.pylintEnabled": true
+}

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -36,7 +36,7 @@ You can copy the example settings file below into one of those paths to start yo
   start-settings-sample
 .. code-block:: yaml
 
-    # ---
+    ---
     ansible-navigator:
     #   app: run
     #   collection-doc-cache-path: /tmp/cache.db

--- a/utilities/doc_updater.py
+++ b/utilities/doc_updater.py
@@ -231,7 +231,7 @@ def _update_sample_settings(args: Namespace, filename: str):
     """update the settings sample"""
     with open(args.ss) as fhand:
         settings = fhand.read().splitlines()
-    not_commented = ["ansible-navigator:", "logging:", "level:"]
+    not_commented = ["---", "ansible-navigator:", "logging:", "level:"]
     for idx, line in enumerate(settings):
         if not any(nc in line for nc in not_commented):
             settings[idx] = "    # " + line


### PR DESCRIPTION
the examples settings yaml file was not valid w/o the ---, restore it

fixes #228 
replaces 50% of #230 
approved by @relrod bwo #230