### PR TITLE
[tests] Allow setting of xdist cpu count

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,6 @@ commands =
     /bin/bash -c 'grep -FInrq "UPDATE_FIXTURES = True" ./tests && exit 1 || exit 0'
     /bin/bash -c 'podman pull {[base]default_ee} || docker pull {[base]default_ee}'
     /bin/bash -c 'py.test -vvvv -n `python -c "import multiprocessing; import os; print(int(os.environ.get(\"XDIST_CPU\") or multiprocessing.cpu_count()/4))"` --dist=loadfile --maxfail=15 --durations=100 --cov ansible_navigator --cov share --cov-report term-missing --cov-branch --showlocals'
-    ; /bin/bash -c 'py.test -vvvv -n 1 --dist=loadfile --maxfail=15 --durations=100 --cov ansible_navigator --cov share --cov-report term-missing --cov-branch --showlocals'
     python3 utilities/doc_updater.py --diff
 setenv =
     TERM = xterm-256color

--- a/tox.ini
+++ b/tox.ini
@@ -22,12 +22,14 @@ deps = -r{toxinidir}/requirements.txt
 commands =
     /bin/bash -c 'grep -FInrq "UPDATE_FIXTURES = True" ./tests && exit 1 || exit 0'
     /bin/bash -c 'podman pull {[base]default_ee} || docker pull {[base]default_ee}'
-    /bin/bash -c 'py.test -vvvv -n `python -c "import multiprocessing; print(int(multiprocessing.cpu_count()/2))"` --dist=loadfile --maxfail=15 --durations=100 --cov ansible_navigator --cov share --cov-report term-missing --cov-branch --showlocals'
+    /bin/bash -c 'py.test -vvvv -n `python -c "import multiprocessing; import os; print(int(os.environ.get(\"XDIST_CPU\") or multiprocessing.cpu_count()/4))"` --dist=loadfile --maxfail=15 --durations=100 --cov ansible_navigator --cov share --cov-report term-missing --cov-branch --showlocals'
+    ; /bin/bash -c 'py.test -vvvv -n 1 --dist=loadfile --maxfail=15 --durations=100 --cov ansible_navigator --cov share --cov-report term-missing --cov-branch --showlocals'
     python3 utilities/doc_updater.py --diff
 setenv =
     TERM = xterm-256color
 passenv = HOME
           USER
+          XDIST_CPU
 
 [testenv:clean]
 deps = coverage


### PR DESCRIPTION
fixes #272 

This allow the user to set XDIST_CPU for the desired number of CPUs to use for pytest-xdist.  
