### PR TITLE
[tests] tmux session improvements

### DIFF
--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -242,6 +242,13 @@ class TmuxSession:
                             break
 
             if ok_to_return:
+                screens = [showing]
+                while True:
+                    screens.append(self._pane.capture_pane())
+                    if len(screens) >= 5 and all(elem == screens[-1] for elem in screens[-5:]):
+                        showing = screens[-1]
+                        break
+                    time.sleep(0.1)
                 break
 
             elapsed = timer() - start_time

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -263,7 +263,9 @@ class TmuxSession:
 
                 tstamp = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
                 # taint the screen output w/ timestamp so it's never a valid fixture
-                alerts = [f"******** ERROR: TMUX '{err_message}' TIMEOUT @ {elapsed}s @ {tstamp} ********"]
+                alerts = [
+                    f"******** ERROR: TMUX '{err_message}' TIMEOUT @ {elapsed}s @ {tstamp} ********"
+                ]
                 alerts.append(f"******** Captured to: {timeout_capture_path}")
                 showing = alerts + showing
                 with open(timeout_capture_path, "w") as filehandle:

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -156,7 +156,7 @@ class TmuxSession:
         value,
         search_within_response: Union[None, List, str] = None,
         ignore_within_response=None,
-        timeout=120,
+        timeout=300,
     ):
         """interact with the tmux session
         :param value: send to screen

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -249,6 +249,7 @@ class TmuxSession:
                     if len(screens) >= 5 and all(elem == screens[-1] for elem in screens[-5:]):
                         showing = screens[-1]
                         break
+                    elapsed = timer() - start_time
                     if elapsed > timeout:
                         err_message = "5 LIKE SCREENS"
                         break

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -221,6 +221,7 @@ class TmuxSession:
         timeout_capture_path = os.path.join(self._test_log_dir, "showing_timeout.txt")
 
         ok_to_return = False
+        err_message = "RESPONSE"
         while True:
 
             showing = self._pane.capture_pane()
@@ -248,6 +249,9 @@ class TmuxSession:
                     if len(screens) >= 5 and all(elem == screens[-1] for elem in screens[-5:]):
                         showing = screens[-1]
                         break
+                    if elapsed > timeout:
+                        err_message = "5 LIKE SCREENS"
+                        break
                     time.sleep(0.1)
                 break
 
@@ -258,7 +262,7 @@ class TmuxSession:
 
                 tstamp = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
                 # taint the screen output w/ timestamp so it's never a valid fixture
-                alerts = [f"******** ERROR: TMUX RESPONSE TIMEOUT @ {elapsed}s @ {tstamp} ********"]
+                alerts = [f"******** ERROR: TMUX '{err_message}' TIMEOUT @ {elapsed}s @ {tstamp} ********"]
                 alerts.append(f"******** Captured to: {timeout_capture_path}")
                 showing = alerts + showing
                 with open(timeout_capture_path, "w") as filehandle:

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -156,7 +156,7 @@ class TmuxSession:
         value,
         search_within_response: Union[None, List, str] = None,
         ignore_within_response=None,
-        timeout=60,
+        timeout=120,
     ):
         """interact with the tmux session
         :param value: send to screen

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps = -r{toxinidir}/requirements.txt
 commands =
     /bin/bash -c 'grep -FInrq "UPDATE_FIXTURES = True" ./tests && exit 1 || exit 0'
     /bin/bash -c 'podman pull {[base]default_ee} || docker pull {[base]default_ee}'
-    /bin/bash -c 'py.test -vvvv -n `python -c "import multiprocessing; import os; print(int(os.environ.get(\"XDIST_CPU\") or multiprocessing.cpu_count()/4))"` --dist=loadfile --maxfail=15 --durations=100 --cov ansible_navigator --cov share --cov-report term-missing --cov-branch --showlocals'
+    /bin/bash -c 'py.test -vvvv -n `python -c "import multiprocessing; import os; print(int(os.environ.get(\"XDIST_CPU\") or multiprocessing.cpu_count()))"` --dist=loadfile --maxfail=15 --durations=100 --cov ansible_navigator --cov share --cov-report term-missing --cov-branch --showlocals'
     python3 utilities/doc_updater.py --diff
 setenv =
     TERM = xterm-256color


### PR DESCRIPTION
- add a loop that ensures the tmux screen is the same for 5 captures before returning
- remove CPU throttle for tox.ini
- tested many times without intermittent failure
- this does add a couple minutes to the total test time, but some stability and consistency will be welcome