### PR TITLE
[help] Add choices to argparse help string

### DIFF
--- a/ansible_navigator/configuration_subsystem/parser.py
+++ b/ansible_navigator/configuration_subsystem/parser.py
@@ -13,6 +13,8 @@ from typing import Union
 from .definitions import ApplicationConfiguration
 from .definitions import Constants as C
 
+from ..utils import oxfordcomma
+
 
 class Parser:
     """Build the args"""
@@ -30,9 +32,14 @@ class Parser:
     def generate_argument(entry) -> Tuple[Any, Union[Any, str, None], Dict[str, Any]]:
         """Generate an argparse argument"""
         kwargs = {}
-        kwargs["help"] = entry.short_description
+        help_strings = [entry.short_description]
+        if entry.choices:
+            lower_choices = (str(choice).lower() for choice in entry.choices)
+            help_strings.append(f"(choices: {oxfordcomma(lower_choices, 'or')})")
         if entry.value.default is not C.NOT_SET:
-            kwargs["help"] += f" (default: {entry.value.default})"
+            help_strings.append(f"(default: '{str(entry.value.default).lower()}')")
+        kwargs["help"] = " ".join(help_strings)
+
         kwargs["default"] = SUPPRESS
 
         if entry.cli_parameters.positional:


### PR DESCRIPTION
Fixes #295 

- not using argparse choices since choice validation is handled in configurator


here's an examples of how the formatting looks:
```
optional arguments:
  -h, --help            show this help message and exit
  --ce CONTAINER_ENGINE, --container-engine CONTAINER_ENGINE
                        Specify the container engine (choices: 'podman' or 'docker') (default: 'podman')
  --ecmd EDITOR_COMMAND, --editor-command EDITOR_COMMAND
                        Specify the editor comamnd (default: 'vi +{line_number} {filename}')
  --econ EDITOR_CONSOLE, --editor-console EDITOR_CONSOLE
                        Specify if the editor is console based (choices: 'true' or 'false') (default: 'true')
  --ee EXECUTION_ENVIRONMENT, --execution-environment EXECUTION_ENVIRONMENT
                        Enable or disable the use of an execution environment (choices: 'true' or 'false') (default: 'true')
```

The help formatting could still use some work, but at least this will make the choices available