### PR TITLE
[configuration] Expand env vars in inventory path

### DIFF
--- a/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -149,7 +149,7 @@ class NavigatorPostProcessor:
                     entry.value.current.append(inv_entry)
                 else:
                     # file path
-                    entry.value.current.append(abs_user_path(inv_entry))
+                    entry.value.current.append(abs_user_path(os.path.expandvars(inv_entry)))
         return messages, errors
 
     @staticmethod

--- a/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -149,7 +149,7 @@ class NavigatorPostProcessor:
                     entry.value.current.append(inv_entry)
                 else:
                     # file path
-                    entry.value.current.append(abs_user_path(os.path.expandvars(inv_entry)))
+                    entry.value.current.append(abs_user_path(inv_entry))
         return messages, errors
 
     @staticmethod

--- a/ansible_navigator/utils.py
+++ b/ansible_navigator/utils.py
@@ -34,7 +34,7 @@ class LogMessage(NamedTuple):
 
 def abs_user_path(fpath: str) -> str:
     """Resolve a path"""
-    return os.path.abspath(os.path.expanduser(fpath))
+    return os.path.abspath(os.path.expanduser(os.path.expandvars(fpath)))
 
 
 def check_for_ansible() -> Tuple[bool, str]:


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>
If the inventory path in settings file had an env var, it was not being expanded, which also resulted in `abs_user_path()` prepending pwd to it.