### PR TITLE
Remove .tox check in VIRTUAL_ENV for tmux

### DIFF
--- a/ansible_navigator/runner/api.py
+++ b/ansible_navigator/runner/api.py
@@ -85,7 +85,6 @@ class BaseRunner:
         self.status: Optional[str] = None
         self._logger = logging.getLogger(__name__)
         self._runner_args: Dict = {}
-        self._runner_artifact_dir: Optional[str] = None
         if self._ee:
             self._runner_args.update(
                 {

--- a/ansible_navigator/runner/api.py
+++ b/ansible_navigator/runner/api.py
@@ -85,6 +85,7 @@ class BaseRunner:
         self.status: Optional[str] = None
         self._logger = logging.getLogger(__name__)
         self._runner_args: Dict = {}
+        self._runner_artifact_dir: Optional[str] = None
         if self._ee:
             self._runner_args.update(
                 {

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -64,7 +64,7 @@ class TmuxSession:
         # expect inside of tmux, so we can't depend on it. We *must* determine
         # it before we enter tmux. Do this before we switch to bash
         venv_path = os.environ.get("VIRTUAL_ENV")
-        if venv_path is None or ".tox" not in venv_path:
+        if venv_path is None:
             raise AssertionError(
                 "VIRTUAL_ENV environment variable was not set but tox should have set it."
             )


### PR DESCRIPTION
*  While running testcase locally the user enabled
   virtual env set the enviornment variable `VIRTUAL_ENV`
   required for intial tmux session and the check for `.tox`
   in not required in that case.
*  In CI run since virtual enviornment is enabled by `tox`
   the `.tox` will always be presnet in the `VIRTUAL_ENV` path
   and hence the check is not required