### PR TITLE
[cli] Where applicable, add an epilog to each subcommand indicating the mapped ansible command parameters are supported

### DIFF
--- a/ansible_navigator/configuration_subsystem/definitions.py
+++ b/ansible_navigator/configuration_subsystem/definitions.py
@@ -124,6 +124,7 @@ class SubCommand(SimpleNamespace):
 
     name: str
     description: str
+    epilog: Union[None, str] = None
 
 
 class ApplicationConfiguration(SimpleNamespace):

--- a/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -95,12 +95,48 @@ class Internals(SimpleNamespace):
 
 navigator_subcommds = [
     SubCommand(name="collections", description="Explore available collections"),
-    SubCommand(name="config", description="Explore the current ansible configuration"),
-    SubCommand(name="doc", description="Review documentation for a module or plugin"),
+    SubCommand(
+        name="config",
+        description="Explore the current ansible configuration",
+        epilog=(
+            "Note: With '--mode stdout', 'ansible-navigator config' additionally supports"
+            " the same parameters as the 'ansible-config' command."
+            " For more information about these, try "
+            " 'ansible-navigator config --help-config --mode stdout'"
+        ),
+    ),
+    SubCommand(
+        name="doc",
+        description="Review documentation for a module or plugin",
+        epilog=(
+            "Note: With '--mode stdout', 'ansible-navigator doc' additionally supports"
+            " the same parameters as the 'ansible-doc' command."
+            " For more information about these, try "
+            " 'ansible-navigator doc --help-doc --mode stdout'"
+        ),
+    ),
     SubCommand(name="ee-details", description="Explore execution environment details"),
-    SubCommand(name="inventory", description="Explore an inventory"),
+    SubCommand(
+        name="inventory",
+        description="Explore an inventory",
+        epilog=(
+            "Note: With '--mode stdout', 'ansible-navigator inventory' additionally supports"
+            " the same parameters as the 'ansible-inventory' command."
+            " For more information about these, try "
+            " 'ansible-navigator inventory --help-inventory --mode stdout'"
+        ),
+    ),
     SubCommand(name="replay", description="Explore a previous run using a playbook artifact"),
-    SubCommand(name="run", description="Run a playbook"),
+    SubCommand(
+        name="run",
+        description="Run a playbook",
+        epilog=(
+            "Note: 'ansible-navigator run' additionally supports"
+            " the same parameters as the 'ansible-playbook' command."
+            " For more information about these, try "
+            " 'ansible-navigator run --help-playbook --mode stdout'"
+        ),
+    ),
     SubCommand(name="welcome", description="Start at the welcome page"),
 ]
 

--- a/ansible_navigator/configuration_subsystem/parser.py
+++ b/ansible_navigator/configuration_subsystem/parser.py
@@ -94,6 +94,7 @@ class Parser:
         for subcommand in self._config.subcommands:
             parser = self._subparsers.add_parser(
                 subcommand.name,
+                epilog=subcommand.epilog,
                 help=subcommand.description,
                 description=f"{subcommand.name}: {subcommand.description}",
                 parents=[self._base_parser],


### PR DESCRIPTION
Fixes #260

```
(venv) ➜  ansible-navigator git:(pass-through) python -m ansible_navigator doc --help                
usage: __main__.py doc [-h] [--ce CONTAINER_ENGINE] [--ecmd EDITOR_COMMAND] [--econ EDITOR_CONSOLE] [--ee EXECUTION_ENVIRONMENT] [--eei EXECUTION_ENVIRONMENT_IMAGE] [--la LOG_APPEND] [--lf LOG_FILE]
                       [--ll LOG_LEVEL] [-m MODE] [--osc4 OSC4] [--penv PASS_ENVIRONMENT_VARIABLE [PASS_ENVIRONMENT_VARIABLE ...]] [--senv SET_ENVIRONMENT_VARIABLE [SET_ENVIRONMENT_VARIABLE ...]] [--hd]
                       [-t PLUGIN_TYPE]
                       [plugin_name]

doc: Review documentation for a module or plugin

positional arguments:
  plugin_name           Specify the plugin name

optional arguments:
  -h, --help            show this help message and exit
  --ce CONTAINER_ENGINE, --container-engine CONTAINER_ENGINE
                        Specify the container engine (choices: 'podman' or 'docker') (default: 'podman')
  --ecmd EDITOR_COMMAND, --editor-command EDITOR_COMMAND
                        Specify the editor comamnd (default: 'vi +{line_number} {filename}')
  --econ EDITOR_CONSOLE, --editor-console EDITOR_CONSOLE
                        Specify if the editor is console based (choices: 'true' or 'false') (default: 'true')
  --ee EXECUTION_ENVIRONMENT, --execution-environment EXECUTION_ENVIRONMENT
                        Enable or disable the use of an execution environment (choices: 'true' or 'false') (default: 'true')
  --eei EXECUTION_ENVIRONMENT_IMAGE, --execution-environment-image EXECUTION_ENVIRONMENT_IMAGE
                        Specify the name of the execution environment image (default: 'quay.io/ansible/ansible-runner:devel')
  --la LOG_APPEND, --log-append LOG_APPEND
                        Specify if log messages should be appended to an existing log file, otherwise a new log file will be created per session (default: 'true')
  --lf LOG_FILE, --log-file LOG_FILE
                        Specify the full path for the ansible-navigator log file (default: '/users/bthornto/github/ansible-navigator/ansible-navigator.log')
  --ll LOG_LEVEL, --log-level LOG_LEVEL
                        Specify the ansible-navigator log level (choices: 'debug', 'info', 'warning', 'error' or 'critical') (default: 'warning')
  -m MODE, --mode MODE  Specify the user-interface mode (choices: 'stdout' or 'interactive') (default: 'interactive')
  --osc4 OSC4, --osc4 OSC4
                        Enable or disable terminal color changing support with OSC 4 (choices: 'true' or 'false') (default: 'true')
  --penv PASS_ENVIRONMENT_VARIABLE [PASS_ENVIRONMENT_VARIABLE ...], --pass-environment-variable PASS_ENVIRONMENT_VARIABLE [PASS_ENVIRONMENT_VARIABLE ...]
                        Specify an exiting environment variable to be passed through to and set within the execution enviroment (--penv MY_VAR)
  --senv SET_ENVIRONMENT_VARIABLE [SET_ENVIRONMENT_VARIABLE ...], --set-environment-variable SET_ENVIRONMENT_VARIABLE [SET_ENVIRONMENT_VARIABLE ...]
                        Specify an environment variable and a value to be set within the execution enviroment (--senv MY_VAR=42)
  --hd, --help-doc      Help options for ansible-doc command in stdout mode (choices: 'true' or 'false') (default: 'false')
  -t PLUGIN_TYPE, --type PLUGIN_TYPE
                        Specify the plugin type, 'become', 'cache', 'callback', 'cliconf', 'connection', 'httpapi', 'inventory', 'lookup', 'module', 'netconf', 'shell', 'strategy' or 'vars' (choices:
                        'become', 'cache', 'callback', 'cliconf', 'connection', 'httpapi', 'inventory', 'lookup', 'module', 'netconf', 'shell', 'strategy' or 'vars') (default: 'module')

Note: With '--mode stdout', 'ansible-navigator doc' additionally supports the same parameters as the 'ansible-doc' command. For more information about these, try 'ansible-navigator doc --help-doc --mode
stdout'
```
