### PR TITLE
stop loading emacs swap files as actions

### DIFF
--- a/ansible_navigator/actions/_actions.py
+++ b/ansible_navigator/actions/_actions.py
@@ -36,7 +36,9 @@ def _import(package: str, action: str) -> None:
 def _import_all(package: str) -> None:
     """Import all actions in a package"""
     files = resources.contents(package)  # type: ignore
-    actions = [f[:-3] for f in files if f.endswith(".py") and f[0] != "_"]
+    actions = [
+        f[:-3] for f in files if f.endswith(".py") and f[0] != "_" and not f.startswith(".#")
+    ]
     for action in actions:
         _import(package, action)
 


### PR DESCRIPTION
Change:
- Otherwise every time an action is edited, navigator crashes if it is
  open. This is because emacs will save files as .#something.py which
  matched the filter previously.

Test Plan:
- Edited an action with emacs with navigator opened, and stopped getting
  crashes.

Signed-off-by: Rick Elrod <rick@elrod.me>