### PR TITLE
[cli] Add `--version` and split collection doc cache version from app

### DIFF
--- a/ansible_navigator/_version.py
+++ b/ansible_navigator/_version.py
@@ -1,3 +1,19 @@
 """ version
+
+Note: 
+
+__version__:
+
+indicates the version of the ansible_navigator applications
+
+__version_collection_doc_cache__:
+
+indicates the version of the schema of the collection doc cache
+this is checked during initialization, if the version of the cache
+differes from below, the cache will be rebuilt.  This should be
+incremented when the schema changes and need not correspond to the
+application version, although keeping the major in sync is probably
+not a bad idea to minimize the amount of stale docs in the user's cache
 """
 __version__ = "0.6.2"
+__version_collection_doc_cache__ = "1.0"

--- a/ansible_navigator/_version.py
+++ b/ansible_navigator/_version.py
@@ -1,6 +1,6 @@
 """ version
 
-Note: 
+Note:
 
 __version__:
 

--- a/ansible_navigator/configuration_subsystem/parser.py
+++ b/ansible_navigator/configuration_subsystem/parser.py
@@ -16,6 +16,7 @@ from .definitions import Constants as C
 from ..utils import oxfordcomma
 from .._version import __version__
 
+
 class Parser:
     """Build the args"""
 
@@ -86,7 +87,9 @@ class Parser:
         )
 
     def _configure_base(self) -> None:
-        self._base_parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + __version__)
+        self._base_parser.add_argument(
+            "-v", "--version", action="version", version="%(prog)s " + __version__
+        )
 
         for entry in self._config.entries:
             if entry.subcommands is C.ALL:

--- a/ansible_navigator/configuration_subsystem/parser.py
+++ b/ansible_navigator/configuration_subsystem/parser.py
@@ -14,7 +14,7 @@ from .definitions import ApplicationConfiguration
 from .definitions import Constants as C
 
 from ..utils import oxfordcomma
-
+from .._version import __version__
 
 class Parser:
     """Build the args"""
@@ -86,6 +86,8 @@ class Parser:
         )
 
     def _configure_base(self) -> None:
+        self._base_parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + __version__)
+
         for entry in self._config.entries:
             if entry.subcommands is C.ALL:
                 self._add_parser(self._base_parser, entry)

--- a/ansible_navigator/initialization.py
+++ b/ansible_navigator/initialization.py
@@ -21,7 +21,7 @@ from .utils import find_configuration_directory_or_file_path
 from .utils import ExitMessage
 from .utils import ExitPrefix
 from .utils import LogMessage
-from ._version import __version__ as VERSION
+from ._version import __version_collection_doc_cache__ as VERSION_CDC
 
 
 def error_and_exit_early(exit_messages: List[ExitMessage]) -> NoReturn:
@@ -118,13 +118,13 @@ def get_and_check_collection_doc_cache(
         cache_version = None
     message = f"Collection doc cache: 'current version' is '{cache_version}'"
     messages.append(LogMessage(level=logging.DEBUG, message=message))
-    if cache_version is None or cache_version != VERSION:
+    if cache_version is None or cache_version != VERSION_CDC:
         message = "Collection doc cache: version was empty or incorrect, rebuilding"
         messages.append(LogMessage(level=logging.INFO, message=message))
         collection_cache.close()
         os.remove(collection_doc_cache_path)
         collection_cache.__init__(collection_doc_cache_path)
-        collection_cache["version"] = VERSION
+        collection_cache["version"] = VERSION_CDC
         cache_version = collection_cache["version"]
         message = f"Collection doc cache: 'current version' is '{cache_version}'"
         messages.append(LogMessage(level=logging.INFO, message=message))

--- a/tests/unit/configuration_subsystem/test_sample_configurations.py
+++ b/tests/unit/configuration_subsystem/test_sample_configurations.py
@@ -135,4 +135,4 @@ def test_cutom_nargs_for_postional():
         ],
     )
     parser = Parser(test_config)
-    assert parser.parser._actions[1].choices["subcommand1"]._actions[1].nargs == 3
+    assert parser.parser._actions[2].choices["subcommand1"]._actions[2].nargs == 3


### PR DESCRIPTION
Fixes #313 
Fixes #314 

The version should be injected by the CI based on the repo tag eventually, so separating the collection doc cache schema version from the application version will eliminate the need for the application version to live in the code base

tests:
```
(venv) ➜  ansible-navigator git:(version) ansible-navigator --version           
ansible-navigator 0.6.2

10521101957.974 DEBUG 'ansible_navigator.main' Collection doc cache: 'current version' is '0.6.2'
210521101957.974 INFO 'ansible_navigator.main' Collection doc cache: version was empty or incorrect, rebuilding
210521101957.974 INFO 'ansible_navigator.main' Collection doc cache: 'current version' is '1.0'
```
