### PR TITLE
[settings] Simplify settings locations

### DIFF
--- a/ansible_navigator/initialization.py
+++ b/ansible_navigator/initialization.py
@@ -17,7 +17,7 @@ from .configuration_subsystem import Configurator
 from .configuration_subsystem import Constants as C
 
 from .utils import environment_variable_is_file_path
-from .utils import find_configuration_directory_or_file_path
+from .utils import find_settings_file
 from .utils import ExitMessage
 from .utils import ExitPrefix
 from .utils import LogMessage
@@ -52,10 +52,9 @@ def find_config() -> Tuple[List[LogMessage], List[ExitMessage], Union[None, str]
     if exit_messages:
         return messages, exit_messages, config_path
 
-    # Check well know locations
-    new_messages, new_exit_messages, found_config_path = find_configuration_directory_or_file_path(
-        "ansible-navigator", allowed_extensions=["yml", "yaml", "json"]
-    )
+    # Find the setting file
+    new_messages, new_exit_messages, found_config_path = find_settings_file()
+
     messages.extend(new_messages)
     exit_messages.extend(new_exit_messages)
     if exit_messages:
@@ -64,14 +63,14 @@ def find_config() -> Tuple[List[LogMessage], List[ExitMessage], Union[None, str]
     # Pick the envar set first, followed by found, followed by leave as none
     if env_config_path is not None:
         config_path = env_config_path
-        message = f"Using config file at {config_path} set by {cfg_env_var}"
+        message = f"Using settings file at {config_path} set by {cfg_env_var}"
         messages.append(LogMessage(level=logging.DEBUG, message=message))
     elif found_config_path is not None:
         config_path = found_config_path
-        message = f"Using config file at {config_path} in search path"
+        message = f"Using settings file at {config_path} in search path"
         messages.append(LogMessage(level=logging.DEBUG, message=message))
     else:
-        message = "No valid config file found, using all default values for configuration."
+        message = "No valid settings file found, using all default values for settings."
         messages.append(LogMessage(level=logging.DEBUG, message=message))
     return messages, exit_messages, config_path
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -20,7 +20,7 @@ Currently the following are checked and the first match is used:
 
 .. note::
     - The settings file can be in ``JSON`` or ``YAML`` format.
-    - For settings in ``JSON`` format the extention must be ``.json``
+    - For settings in ``JSON`` format the extention must be ``.json``.
     - For settings in ``YAML`` format the extention must be ``.yml`` or ``.yaml``.
     - The project and home directories can only contain one settings file each.
       If more than one settings file is found in either directory, it will result in an error.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -16,7 +16,7 @@ Currently the following are checked and the first match is used:
 
 - ``ANSIBLE_NAVIGATOR_CONFIG`` (settings file path environment variable if set)
 - ``./ansible-navigator.<ext>`` (project directory)
-- ``~/.ansible-navigator.<ext>``(home directory)
+- ``~/.ansible-navigator.<ext>`` (home directory)
 
 .. note::
     - The settings file can be in ``JSON`` or ``YAML`` format.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -11,24 +11,19 @@ The ansible-navigator settings file
 ========================================
 
 Several options in ``ansible-navigator`` can be configured by making use of a
-settings file. The settings file can live in one of several places.
-Currently the following paths are checked and the first match is used:
+settings file. The settings file can live in one of two places.
+Currently the following are checked and the first match is used:
 
 - ``ANSIBLE_NAVIGATOR_CONFIG`` (settings file path environment variable if set)
-- ``./.ansible-navigator/<ansible-navigator-filename>`` (project-specific directory)
-- ``[ansible-navigator source code root]/etc/ansible-navigator/<ansible-navigator-filename>``
-- ``~/.config/ansible-navigator/<ansible-navigator-filename>``
-- ``/etc/ansible-navigator/<ansible-navigator-filename>``
-- ``[prefix]/etc/ansible-navigator/<ansible-navigator-filename>`` (e.g., ``/usr/local/etc/...``)
+- ``./ansible-navigator.<ext>`` (project directory)
+- ``~/.ansible-navigator.<ext>``(home directory)
 
 .. note::
-    - The settings file can either be in ``JSON`` or ``YAML`` format.
-    - For settings in ``JSON`` format the file name should be ``ansible-navigator.json``
-    - For settings in ``YAML`` format the file name can be either ``ansible-navigator.yml``
-      or ``ansible-navigator.yaml``.
-    - The first found matched directory path (based on order mentioned above) can have only one
-      valid settings file. If in case more than one settings files (with different
-      supported extensions) are found it will result in an error to avoid conflict.
+    - The settings file can be in ``JSON`` or ``YAML`` format.
+    - For settings in ``JSON`` format the extention must be ``.json``
+    - For settings in ``YAML`` format the extention must be ``.yml`` or ``.yaml``.
+    - The project and home directories can only contain one settings file each.
+      If more than one settings file is found in either directory, it will result in an error.
 
 You can copy the example settings file below into one of those paths to start your ``ansible-navigator`` settings file.
 

--- a/tests/smoketests/scenarios/test_user_config.yml
+++ b/tests/smoketests/scenarios/test_user_config.yml
@@ -2,15 +2,10 @@
 - name: Ensure config file gets picked up from ~/.config
   hosts: localhost
   pre_tasks:
-    - name: Create ~/.config/ansible-navigator
-      file:
-        path: ~/.config/ansible-navigator
-        state: directory
-      register: fileres
 
     - copy:
         src: "{{ playbook_dir }}/smoke-config.yml"
-        dest: "{{ fileres.path }}/ansible-navigator.yml"
+        dest: "~/.ansible-navigator.yml"
 
     - include_role:
         name: tmux/setup
@@ -68,5 +63,5 @@
 
     - name: Remove config file
       file:
-        path: ~/.config/ansible-navigator
+        path: ~/.ansible-navigator.yml
         state: absent


### PR DESCRIPTION
Look in CWD for `ansible-navigator` using `.yml` `.yaml` and `.json`
Look in ~ for `.ansible-navigator` using `.yml` `.yaml` and `.json`

merging of home onto cwd can come at a later date
system wide settings are no longer available

Fixes #293 