### PR TITLE
[:run] enable artifact creation with mode stdout

### DIFF
--- a/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -329,7 +329,8 @@ NavigatorConfiguration = ApplicationConfiguration(
             cli_parameters=CliParameters(short="--pae"),
             settings_file_path_override="playbook-artifact.enable",
             short_description="Enable or disable the creation of artifacts for"
-            " completed playbooks",
+            " completed playbooks. Note: not compatible with '--mode stdout' when playbooks"
+            " require user input",
             subcommands=["run"],
             value=EntryValue(default=True),
         ),

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -533,7 +533,7 @@ The following table describes all available settings.
               playbook:
 
   * - playbook-artifact-enable
-    - Enable or disable the creation of artifacts for completed playbooks
+    - Enable or disable the creation of artifacts for completed playbooks. Note: not compatible with '--mode stdout' when playbooks require user input
     - | **Choices:** 'True' or 'False'
       | **Default:** True
       | **CLI:** `--pae` or `--playbook-artifact-enable`


### PR DESCRIPTION
when artifact creation is enabled, collect events and print stdout.

this suggests if mode=stdout and playbook_artifact_enable=True, playbook prompts will not work, this has been noted in the help.

Fixes: #238 

tested locally
