### PR TITLE
[doc] support --list and --list_files with --mode stdout

### DIFF
--- a/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -394,8 +394,15 @@ class NavigatorPostProcessor:
         """Post process plugin_name"""
         messages: List[LogMessage] = []
         exit_messages: List[ExitMessage] = []
-        if all((config.app == "doc", entry.value.current is C.NOT_SET, config.help_doc is False, config.mode != 'stdout')):
-            exit_msg = "An plugin name is required when using the doc subcommand"
+        if all(
+            (
+                config.app == "doc",
+                entry.value.current is C.NOT_SET,
+                config.help_doc is False,
+                config.mode != "stdout",
+            )
+        ):
+            exit_msg = "A plugin name is required when using the doc subcommand"
             exit_messages.append(ExitMessage(message=exit_msg))
             exit_msg = "Try again with 'doc <plugin_name>'"
             exit_messages.append(ExitMessage(message=exit_msg, prefix=ExitPrefix.HINT))

--- a/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -394,7 +394,7 @@ class NavigatorPostProcessor:
         """Post process plugin_name"""
         messages: List[LogMessage] = []
         exit_messages: List[ExitMessage] = []
-        if all((config.app == "doc", entry.value.current is C.NOT_SET, config.help_doc is False)):
+        if all((config.app == "doc", entry.value.current is C.NOT_SET, config.help_doc is False, config.mode != 'stdout')):
             exit_msg = "An plugin name is required when using the doc subcommand"
             exit_messages.append(ExitMessage(message=exit_msg))
             exit_msg = "Try again with 'doc <plugin_name>'"

--- a/tests/unit/configuration_subsystem/test_invalid_params.py
+++ b/tests/unit/configuration_subsystem/test_invalid_params.py
@@ -63,7 +63,7 @@ def test_fail_log_file_dir(_mf1, _mf2, generate_config):
 def test_doc_no_plugin_name(_mocked_func, generate_config):
     """Ensure an error is created doc is used without plugin_name"""
     response = generate_config(params=["doc"])
-    exit_msg = "An plugin name is required when using the doc subcommand"
+    exit_msg = "A plugin name is required when using the doc subcommand"
     assert exit_msg in [exit_msg.message for exit_msg in response.exit_messages]
 
 


### PR DESCRIPTION
@cidrblock It looks like the interactive code path behaves pretty differently (no doc validation for example), so I made plugin name optional for stdout mode only. Thoughts?