### PR TITLE
Display navigator version only with --version

### DIFF
--- a/ansible_navigator/configuration_subsystem/parser.py
+++ b/ansible_navigator/configuration_subsystem/parser.py
@@ -88,7 +88,7 @@ class Parser:
 
     def _configure_base(self) -> None:
         self._base_parser.add_argument(
-            "-v", "--version", action="version", version="%(prog)s " + __version__
+            "--version", action="version", version="%(prog)s " + __version__
         )
 
         for entry in self._config.entries:


### PR DESCRIPTION
Having "-v" as an option to display ansible-navigator version conflicts
with verbose modes ('-v', '-vv', '-vvv') for playbook run in stdout
mode.

This patch only allows "--version" to display navigator version.

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>