### PR TITLE
[:images] Param support for `:images`

### DIFF
--- a/share/ansible_navigator/markdown/help.md
+++ b/share/ansible_navigator/markdown/help.md
@@ -11,7 +11,7 @@ arrow up, arrow down                                  Scroll up/down
 :r, :run <playbook> -i <inventory>                    Run a playbook in interactive mode
 :f, :filter <re>                                      Filter page lines using a regex
 :h, :help                                             This page
-:images                                               Explore execution environment images
+:im, images                                           Explore execution environment images
 :i -i <inventory>, :inventory -i <inventory>          Explore the current or alternate inventory
 :l, :log                                              Review current log file
 :o, :open                                             Open current page in the editor


### PR DESCRIPTION
Fixes #366

- also catch errors from the inspector
- add short entry `:im`
- change to bright blue, blue was too dark