### PR TITLE
[settings] split cmdline if a string

### DIFF
--- a/ansible-navigator.yml
+++ b/ansible-navigator.yml
@@ -1,0 +1,3 @@
+ansible-navigator:
+  ansible:
+    cmdline: --forks 15

--- a/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -3,6 +3,7 @@
 import importlib
 import logging
 import os
+import shlex
 import shutil
 
 from pathlib import Path
@@ -84,8 +85,8 @@ class NavigatorPostProcessor:
         """Post process cmdline"""
         messages: List[LogMessage] = []
         exit_messages: List[ExitMessage] = []
-        if entry.value.source is C.ENVIRONMENT_VARIABLE:
-            entry.value.current = entry.value.current.split()
+        if isinstance(entry.value.current, str):
+            entry.value.current = shlex.split(entry.value.current)
         return messages, exit_messages
 
     @staticmethod


### PR DESCRIPTION
Fixes: #381 

- from the shell, cmdline is split via sys.argv
- from envvar. is a sting
- from settings file, is a string
- from a form, a list is sent to config subsystem

In the case cmdline is a string, shlex split it

tested locally from cli, env var, settings file, : prompt and form