### PR TITLE
Fix run action issue when verbose flag passed

### DIFF
--- a/ansible_navigator/runner/api.py
+++ b/ansible_navigator/runner/api.py
@@ -209,7 +209,7 @@ class CommandBaseRunner(BaseRunner):
     def generate_run_command_args(self) -> None:
         """generate arguments required to be passed to ansible-runner"""
         if self._playbook:
-            self._cmdline.append(self._playbook)
+            self._cmdline.insert(0, self._playbook)
 
         for inv in self._inventory:
             self._cmdline.extend(["-i", inv])


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible-navigator/issues/412

*  Ensure playbook is passed as first index in `cmdline` args
   which ensure ansible-runner correctly identifies playbook
   path and mount it within execution enviornemnt