### PR TITLE
Add another path to share-dir search

### DIFF
--- a/ansible_navigator/utils.py
+++ b/ansible_navigator/utils.py
@@ -293,7 +293,7 @@ def get_share_directory(app_name) -> Tuple[List[LogMessage], List[ExitMessage], 
     messages.append(LogMessage(level=logging.DEBUG, message=message.format("not found")))
 
     # /Library/Python/x.y/share/APP_NAME  (common on macOS)
-    datadir = sysconfig.get_paths().get('data')
+    datadir = sysconfig.get_paths().get("data")
     message = "Share directory {0} (datadir)"
     if datadir is not None:
         share_directory = os.path.join(datadir, "share", app_name)

--- a/ansible_navigator/utils.py
+++ b/ansible_navigator/utils.py
@@ -292,6 +292,16 @@ def get_share_directory(app_name) -> Tuple[List[LogMessage], List[ExitMessage], 
             return messages, exit_messages, share_directory
     messages.append(LogMessage(level=logging.DEBUG, message=message.format("not found")))
 
+    # /Library/Python/x.y/share/APP_NAME  (common on macOS)
+    datadir = sysconfig.get_paths().get('data')
+    message = "Share directory {0} (datadir)"
+    if datadir is not None:
+        share_directory = os.path.join(datadir, "share", app_name)
+        if os.path.exists(share_directory):
+            messages.append(LogMessage(level=logging.DEBUG, message=message.format("found")))
+            return messages, exit_messages, share_directory
+    messages.append(LogMessage(level=logging.DEBUG, message=message.format("not found")))
+
     # /usr/local/share/APP_NAME
     prefix = sysconfig.get_config_var("prefix")
     message = "Share directory {0} (prefix)"

--- a/ansible_navigator/utils.py
+++ b/ansible_navigator/utils.py
@@ -244,6 +244,7 @@ def flatten_list(lyst) -> List:
 
 
 def get_share_directory(app_name) -> Tuple[List[LogMessage], List[ExitMessage], Union[None, str]]:
+    # pylint: disable=too-many-return-statements
     """
     returns datadir (e.g. /usr/share/ansible_nagivator) to use for the
     ansible-launcher data files. First found wins.


### PR DESCRIPTION
Change:
- This is mostly for macOS users who install ansible-navigator globally
  and end up with a broken share path.

Test Plan:
- cidrblock tested it :D

Tickets:
- Fixes #433
- Fixes #261

Signed-off-by: Rick Elrod <rick@elrod.me>