### PR TITLE
[ui] Avoid traceback when TERM=vt100

### DIFF
--- a/ansible_navigator/ui_framework/form_handler_text.py
+++ b/ansible_navigator/ui_framework/form_handler_text.py
@@ -86,7 +86,7 @@ class FormHandlerText(CursesWindow, Textbox):
         else:
             self.win.move(0, 0)
 
-        curses.curs_set(1)
+        self._curs_set(1)
         while True:
             char = self.win.getch()
 
@@ -98,7 +98,7 @@ class FormHandlerText(CursesWindow, Textbox):
             if cmd_res == -1:
                 return "", char
             self.win.refresh()
-        curses.curs_set(0)
+        self._curs_set(0)
         line = self.gather().strip()
         if line:
             self.input_line_cache.append(line)

--- a/ansible_navigator/ui_framework/ui.py
+++ b/ansible_navigator/ui_framework/ui.py
@@ -350,7 +350,7 @@ class UserInterface(CursesWindow):
             if char == curses.KEY_RESIZE:
                 break
         self.restore_refresh()
-        curses.curs_set(0)
+        self._curs_set(0)
         return user_input
 
     def _display(


### PR DESCRIPTION
Fixes #444 

Based on limited testing with TERM=vt100, this allowed navigator to work, although with 0 colors