### PR TITLE
[tests] add mypy type stub deps

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,10 +1,12 @@
 ansible-core
 black
 flake8
+libtmux
 lxml
 mypy
 pylint
 pytest-cov
 pytest-xdist
+types-dataclasses
+types-PyYAML
 yamllint
-libtmux


### PR DESCRIPTION
Change:
- This is now required with newer mypy, it seems.

Test Plan:
- `tox -re type`

Signed-off-by: Rick Elrod <rick@elrod.me>