### PR TITLE
[ui] vscode trash fix, the appearance of clear

### DIFF
--- a/ansible_navigator/cli.py
+++ b/ansible_navigator/cli.py
@@ -21,6 +21,7 @@ from .initialization import error_and_exit_early
 from .utils import ExitMessage
 from .utils import ExitPrefix
 from .utils import LogMessage
+from .utils import clear_screen
 
 APP_NAME = "ansible-navigator"
 PKG_NAME = "ansible_navigator"
@@ -78,6 +79,7 @@ def run(args: ApplicationConfiguration) -> int:
         if args.mode == "stdout":
             return_code = run_action_stdout(args.app.replace("-", "_"), args)
             return return_code
+        clear_screen()
         wrapper(ActionRunner(args=args).run)
         return 0
     except KeyboardInterrupt:

--- a/ansible_navigator/utils.py
+++ b/ansible_navigator/utils.py
@@ -133,6 +133,21 @@ def check_for_ansible() -> Tuple[List[LogMessage], List[ExitMessage]]:
     return messages, exit_messages
 
 
+def clear_screen() -> None:
+    """print blank lines on the screen, preserving scrollback
+
+    Note: In certain cases, xterm.js based terminals show stdout
+    under the initial curses output, this was found with vscode
+
+    Rather than issueing "clear" print blank lines to preserve
+    the users' scrollback buffer
+    """
+    affected_terminals = ["vscode"]
+    if os.environ.get("TERM_PROGRAM") in affected_terminals:
+        for _line in range(shutil.get_terminal_size().lines):
+            print()
+
+
 def dispatch(obj, replacements):
     """make the replacement based on type
 

--- a/ansible_navigator/utils.py
+++ b/ansible_navigator/utils.py
@@ -139,8 +139,8 @@ def clear_screen() -> None:
     Note: In certain cases, xterm.js based terminals show stdout
     under the initial curses output, this was found with vscode
 
-    Rather than issueing "clear" print blank lines to preserve
-    the users' scrollback buffer
+    Rather than issueing `clear`, print blank lines to preserve
+    the user's scrollback buffer
     """
     affected_terminals = ["vscode"]
     if os.environ.get("TERM_PROGRAM") in affected_terminals:


### PR DESCRIPTION
Print a screen of blank lines for vscode (and others as they arise) to prevent bleed through of pre curses stdout/stderr in the TUI

![image](https://user-images.githubusercontent.com/18386516/121922363-c2f43880-ccee-11eb-9d6f-7721d877975f.png)
