### PR TITLE
Add runner return code in stdout mode

### DIFF
--- a/ansible_navigator/actions/collections.py
+++ b/ansible_navigator/actions/collections.py
@@ -323,7 +323,7 @@ class Action(App):
             f"Invoke runner with executable_cmd: {python_exec_path}" + f" and kwargs: {kwargs}"
         )
         _runner = CommandRunner(executable_cmd=python_exec_path, **kwargs)
-        output, error = _runner.run()
+        output, error, _ = _runner.run()
 
         if error:
             msg = f"Error while running catalog collection script: {error}"

--- a/ansible_navigator/actions/config.py
+++ b/ansible_navigator/actions/config.py
@@ -140,11 +140,14 @@ class Action(App):
         self._prepare_to_exit(interaction)
         return None
 
-    def run_stdout(self) -> int:
+    def run_stdout(self) -> Union[None, int]:
         """Run in oldschool mode, just stdout"""
         self._logger.debug("config requested in stdout mode")
-        _, _, ret_code = self._run_runner()
-        return ret_code
+        response = self._run_runner()
+        if response:
+            _, _, ret_code = response
+            return ret_code
+        return None
 
     def _take_step(self) -> None:
         """take one step"""
@@ -199,7 +202,6 @@ class Action(App):
         # pylint: disable=too-many-branches
         # pylint: disable=too-many-statements
         """spin up runner"""
-        stdout_return = (None, None, None)
 
         if isinstance(self._args.set_environment_variable, dict):
             set_envvars = {**self._args.set_environment_variable}
@@ -278,8 +280,8 @@ class Action(App):
 
             self._runner = CommandRunner(executable_cmd=ansible_config_path, **kwargs)
             stdout_return = self._runner.run()
-
-        return stdout_return
+            return stdout_return
+        return (None, None, None)
 
     def _parse_and_merge(self, list_output, dump_output) -> None:
         """yaml load the list, and parse the dump

--- a/ansible_navigator/actions/doc.py
+++ b/ansible_navigator/actions/doc.py
@@ -121,21 +121,21 @@ class Action(App):
         self._prepare_to_exit(interaction)
         return next_interaction
 
-    def run_stdout(self) -> int:
+    def run_stdout(self) -> Union[None, int]:
         """Run in oldschool mode, just stdout"""
         self._plugin_name = self._args.plugin_name
         self._plugin_type = self._args.plugin_type
         self._logger.debug("doc requested in stdout mode")
-        _, _, ret_code = self._run_runner()
-        return ret_code
+        response = self._run_runner()
+        if response:
+            _, _, ret_code = response
+            return ret_code
+        return None
 
-    def _run_runner(self) -> Union[dict, Tuple[str, str, int]]:
+    def _run_runner(self) -> Union[None, dict, Tuple[str, str, int]]:
         # pylint: disable=too-many-branches
         # pylint: disable=no-else-return
         """spin up runner"""
-
-        plugin_doc_response: Optional[Dict[Any, Any]] = None
-        stdout_return = (None, None, None)
 
         if isinstance(self._args.set_environment_variable, dict):
             set_envvars = {**self._args.set_environment_variable}

--- a/ansible_navigator/actions/doc.py
+++ b/ansible_navigator/actions/doc.py
@@ -8,6 +8,7 @@ import shutil
 
 from typing import Any
 from typing import Dict
+from typing import Tuple
 from typing import Optional
 from typing import Union
 from . import _actions as actions
@@ -125,14 +126,16 @@ class Action(App):
         self._plugin_name = self._args.plugin_name
         self._plugin_type = self._args.plugin_type
         self._logger.debug("doc requested in stdout mode")
-        self._run_runner()
-        return 1 if self._runner.status == "failed" else 0
+        _, _, ret_code = self._run_runner()
+        return ret_code
 
-    def _run_runner(self) -> Union[dict, None]:
+    def _run_runner(self) -> Union[dict, Tuple[str, str, int]]:
         # pylint: disable=too-many-branches
+        # pylint: disable=no-else-return
         """spin up runner"""
 
         plugin_doc_response: Optional[Dict[Any, Any]] = None
+        stdout_return = (None, None, None)
 
         if isinstance(self._args.set_environment_variable, dict):
             set_envvars = {**self._args.set_environment_variable}
@@ -182,6 +185,7 @@ class Action(App):
                 self._logger.error(msg)
 
             plugin_doc_response = self._extract_plugin_doc(plugin_doc, plugin_doc_err)
+            return plugin_doc_response
         else:
             kwargs.update({"host_cwd": os.getcwd()})
             if self._args.execution_environment:
@@ -189,8 +193,9 @@ class Action(App):
             else:
                 exec_path = shutil.which("ansible-doc")
                 if exec_path is None:
-                    self._logger.error("no ansible-doc command found in path")
-                    return None
+                    msg = "'ansible-doc' executable not found"
+                    self._logger.error(msg)
+                    raise RuntimeError(msg)
                 ansible_doc_path = exec_path
 
             pass_through_arg = []
@@ -209,9 +214,8 @@ class Action(App):
             kwargs.update({"cmdline": pass_through_arg})
 
             self._runner = CommandRunner(executable_cmd=ansible_doc_path, **kwargs)
-            self._runner.run()
-
-        return plugin_doc_response
+            stdout_return = self._runner.run()
+            return stdout_return
 
     def _extract_plugin_doc(
         self, out: Union[Dict[Any, Any], str], err: Union[Dict[Any, Any], str]

--- a/ansible_navigator/actions/images.py
+++ b/ansible_navigator/actions/images.py
@@ -364,7 +364,7 @@ class Action(App):
             f"Invoke runner with executable_cmd: {python_exec_path}" + f" and kwargs: {kwargs}"
         )
         _runner = CommandRunner(executable_cmd=python_exec_path, **kwargs)
-        output, error = _runner.run()
+        output, error, _ = _runner.run()
         if not error:
             parsed = self._parse(output)
             self._images.selected["general"] = {

--- a/ansible_navigator/actions/inventory.py
+++ b/ansible_navigator/actions/inventory.py
@@ -9,7 +9,6 @@ import shutil
 from typing import Any
 from typing import Dict
 from typing import List
-from typing import Optional
 from typing import Tuple
 from typing import Union
 

--- a/ansible_navigator/actions/inventory.py
+++ b/ansible_navigator/actions/inventory.py
@@ -429,10 +429,11 @@ class Action(App):
         self._set_inventories_mtime()
         return
 
-    def _collect_inventory_details(self) -> Optional[Tuple]:
+    def _collect_inventory_details(
+        self,
+    ) -> Tuple[Union[None, str], Union[None, str], Union[None, int]]:
 
         # pylint:disable=too-many-branches
-        stdout_return = (None, None, None)
 
         if isinstance(self._args.set_environment_variable, dict):
             set_envvars = {**self._args.set_environment_variable}
@@ -507,8 +508,9 @@ class Action(App):
 
             self._runner = CommandRunner(executable_cmd=ansible_inventory_path, **kwargs)
             stdout_return = self._runner.run()
+            return stdout_return
 
-        return stdout_return
+        return (None, None, None)
 
     def _extract_inventory(self, stdout: str, stderr: str) -> None:
         try:

--- a/ansible_navigator/runner/api.py
+++ b/ansible_navigator/runner/api.py
@@ -282,12 +282,12 @@ class CommandRunner(CommandBaseRunner):
     # pylint: disable=too-many-instance-attributes
     """a runner wrapper"""
 
-    def run(self) -> Tuple[str, str]:
+    def run(self) -> Tuple[str, str, int]:
         """run"""
 
         self.generate_run_command_args()
-        out, err = run_command(**self._runner_args)
-        return out, err
+        out, err, ret_code = run_command(**self._runner_args)
+        return out, err, ret_code
 
 
 class AnsibleCfgRunner(BaseRunner):

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    ansible-runner==2.0.0a5
+    ansible-runner==2.0.0b1
     jinja2
     onigurumacffi
     pyyaml

--- a/tests/integration/test_stdout_exit_codes.py
+++ b/tests/integration/test_stdout_exit_codes.py
@@ -52,7 +52,7 @@ test_datas = (
         action_name="config",
         action_params=(("cmdline", ["foo"]),),
         message="invalid choice: 'foo'",
-        return_code=1,
+        return_code=2,
     ),
     StdoutTest(
         action_name="doc",
@@ -64,7 +64,7 @@ test_datas = (
         action_name="doc",
         action_params=(("cmdline", ["--json"]),),
         message="Incorrect options passed",
-        return_code=1,
+        return_code=5,
     ),
     StdoutTest(
         action_name="inventory",


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible-navigator/issues/401

*  Add support to accept return code from runner API's
*  Modify config, doc, inventory, collection and images
   action to get return code from runner API's
*  Update ansible-runner version to 2.0.0b1 which has
   the corresponding runner changes