### PR TITLE
Update demo screencast for 1RC1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 A text-based user interface (TUI) for the Red Hat Ansible Automation Platform.
 
-[![asciicast](https://asciinema.org/a/gl7uVblC23dxGGTkVOEigDHCl.svg)](https://asciinema.org/a/gl7uVblC23dxGGTkVOEigDHCl)
+A demo of the interface can be found
+[on youtube](https://www.youtube.com/watch?v=J9PBKi8ydi4).
 
 ## Quick start
 


### PR DESCRIPTION
Change:
- This demonstrates 1RC1 by linking to a short, video-only screencast
  that lives on YouTube. In the future, it might be better to have a
  narrated screencast, but I don't have a narrator voice, so someone
  else should do that.

Tickets:
- Fixes #199

Signed-off-by: Rick Elrod <rick@elrod.me>