### PR TITLE
main to 1.1.0a1

### DIFF
--- a/ansible_navigator/_version.py
+++ b/ansible_navigator/_version.py
@@ -15,5 +15,5 @@ incremented when the schema changes and need not correspond to the
 application version, although keeping the major in sync is probably
 not a bad idea to minimize the amount of stale docs in the user's cache
 """
-__version__ = "1.0.0"
+__version__ = "1.1.0a1"
 __version_collection_doc_cache__ = "1.0"


### PR DESCRIPTION
Following the 1.0.0 release, set main to 1.1.0a1 as the next anticipated version.

This can be adjusted as necessary based on changes