### PR TITLE
Add support for container-options

### DIFF
--- a/ansible_navigator/actions/collections.py
+++ b/ansible_navigator/actions/collections.py
@@ -285,6 +285,9 @@ class Action(App):
                 {"container_volume_mounts": self._args.execution_environment_volume_mounts}
             )
 
+        if isinstance(self._args.container_options, list):
+            kwargs.update({"container_options": self._args.container_options})
+
         kwargs.update({"host_cwd": playbook_dir})
 
         self._adjacent_collection_dir = os.path.join(playbook_dir, "collections")

--- a/ansible_navigator/actions/config.py
+++ b/ansible_navigator/actions/config.py
@@ -229,6 +229,9 @@ class Action(App):
                 {"container_volume_mounts": self._args.execution_environment_volume_mounts}
             )
 
+        if isinstance(self._args.container_options, list):
+            kwargs.update({"container_options": self._args.container_options})
+
         if self._args.mode == "interactive":
             self._runner = AnsibleCfgRunner(**kwargs)
             kwargs = {}

--- a/ansible_navigator/actions/doc.py
+++ b/ansible_navigator/actions/doc.py
@@ -162,6 +162,9 @@ class Action(App):
                 {"container_volume_mounts": self._args.execution_environment_volume_mounts}
             )
 
+        if isinstance(self._args.container_options, list):
+            kwargs.update({"container_options": self._args.container_options})
+
         if self._args.mode == "interactive":
             if isinstance(self._args.playbook, str):
                 playbook_dir = os.path.dirname(self._args.playbook)

--- a/ansible_navigator/actions/images.py
+++ b/ansible_navigator/actions/images.py
@@ -366,6 +366,10 @@ class Action(App):
             "execution_environment": True,
             "navigator_mode": "interactive",
         }
+
+        if isinstance(self._args.container_options, list):
+            kwargs.update({"container_options": self._args.container_options})
+
         self._logger.debug(
             f"Invoke runner with executable_cmd: {python_exec_path}" + f" and kwargs: {kwargs}"
         )

--- a/ansible_navigator/actions/inventory.py
+++ b/ansible_navigator/actions/inventory.py
@@ -518,6 +518,9 @@ class Action(App):
                 {"container_volume_mounts": self._args.execution_environment_volume_mounts}
             )
 
+        if isinstance(self._args.container_options, list):
+            kwargs.update({"container_options": self._args.container_options})
+
         if self._args.mode == "interactive":
             self._collect_inventory_details_interactive(kwargs)
         else:

--- a/ansible_navigator/actions/run.py
+++ b/ansible_navigator/actions/run.py
@@ -580,6 +580,9 @@ class Action(App):
                 {"container_volume_mounts": self._args.execution_environment_volume_mounts}
             )
 
+        if isinstance(self._args.container_options, list):
+            kwargs.update({"container_options": self._args.container_options})
+
         if self._args.execution_environment:
             executable_cmd = "ansible-playbook"
         else:

--- a/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -214,6 +214,14 @@ NavigatorConfiguration = ApplicationConfiguration(
             value=EntryValue(default="auto"),
         ),
         Entry(
+            name="container_options",
+            cli_parameters=CliParameters(action="append", nargs="+", short="--co"),
+            environment_variable_override="ansible_navigator_container_options",
+            settings_file_path_override="execution-environment.container-options",
+            short_description="Extra parameters passed to the container engine command",
+            value=EntryValue(),
+        ),
+        Entry(
             name="display_color",
             change_after_initial=False,
             choices=[True, False],

--- a/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -297,6 +297,19 @@ class NavigatorPostProcessor:
             entry.value.current = parsed_volume_mounts
         return messages, exit_messages
 
+    @staticmethod
+    @_post_processor
+    def container_options(entry: Entry, config: ApplicationConfiguration) -> PostProcessorReturn:
+        # pylint: disable=unused-argument
+        """Post process container_options"""
+        messages: List[LogMessage] = []
+        exit_messages: List[ExitMessage] = []
+        if entry.value.source == C.ENVIRONMENT_VARIABLE:
+            entry.value.current = to_list(entry.value.current)
+        if entry.value.current is not C.NOT_SET:
+            entry.value.current = flatten_list(entry.value.current)
+        return messages, exit_messages
+
     @_post_processor
     def help_config(self, entry: Entry, config: ApplicationConfiguration) -> PostProcessorReturn:
         # pylint: disable=unused-argument

--- a/ansible_navigator/runner/api.py
+++ b/ansible_navigator/runner/api.py
@@ -68,8 +68,8 @@ class BaseRunner:
             container_volume_mounts ([list], optional): List of bind mounts in the form
                                                         ``host_dir:/container_dir:labels``.
                                                         Defaults to None.
-            container_options ([str], optional): List of container options to pass to execution
-                                                 engine. Defaults to None.
+            container_options ([list], optional): List of container options to pass to execution
+                                                  engine. Defaults to None.
             container_workdir ([str], optional): The working directory within the container.
                                                  Defaults to None.
             host_cwd ([str], optional): The current local working directory. Defaults to None.

--- a/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
+++ b/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
@@ -40,6 +40,8 @@ ansible-navigator:
     - src: "/test1"
       dest: "/test1"
       label: "Z"
+    container-options:
+    - "--net=host"
   help-config: True
   help-doc: True
   help-inventory: True

--- a/tests/integration/_action_run_test.py
+++ b/tests/integration/_action_run_test.py
@@ -28,6 +28,7 @@ class ActionRunTest:
         self,
         action_name,
         container_engine: Optional[str] = None,
+        container_options: Optional[List] = None,
         execution_environment: Optional[str] = None,
         execution_environment_image: Optional[str] = None,
         host_cwd: Optional[List] = None,
@@ -39,6 +40,7 @@ class ActionRunTest:
     ) -> None:
         self._action_name = action_name
         self._container_engine = container_engine
+        self._container_options = container_options
         self._execution_environment = execution_environment
         self._execution_environment_image = execution_environment_image
         self._set_environment_variable = set_environment_variable
@@ -49,6 +51,7 @@ class ActionRunTest:
         self._timeout = timeout
         self._app_args = {
             "container_engine": self._container_engine,
+            "container_options": self._container_options,
             "execution_environment": self._execution_environment,
             "execution_environment_image": self._execution_environment_image,
             "set_environment_variable": self._set_environment_variable,

--- a/tests/unit/actions/test_run.py
+++ b/tests/unit/actions/test_run.py
@@ -98,6 +98,7 @@ class RunRunnerTstData(NamedTuple):
 
     name: str
     container_engine: Optional[str]
+    container_options: Optional[List]
     execution_environment_image: Optional[str]
     execution_environment: Optional[bool]
     inventory: Optional[List]
@@ -119,6 +120,7 @@ runner_test_data = [
     RunRunnerTstData(
         "Validate args passed to runner API",
         "docker",
+        ["--net=host"],
         "quay.io/ansible/network-ee:latest",
         True,
         ["/test1/inv1", "/test2/inv2"],
@@ -137,6 +139,7 @@ runner_test_data = [
             "executable_cmd": "ansible-playbook",
             "queue": TEST_QUEUE,
             "container_engine": "docker",
+            "container_options": ["--net=host"],
             "execution_environment_image": "quay.io/ansible/network-ee:latest",
             "execution_environment": True,
             "inventory": ["/test1/inv1", "/test2/inv2"],
@@ -166,6 +169,7 @@ def test_runner_args(_mocked_command_runner, caplog, data):
 
     args = deepcopy(NavigatorConfiguration)
     args.entry("container_engine").value.current = data.container_engine
+    args.entry("container_options").value.current = data.container_options
     args.entry("execution_environment_image").value.current = data.execution_environment_image
     args.entry("execution_environment").value.current = data.execution_environment
     args.entry("inventory").value.current = data.inventory

--- a/tests/unit/configuration_subsystem/data.py
+++ b/tests/unit/configuration_subsystem/data.py
@@ -17,6 +17,7 @@ BASE_SHORT_CLI = """
 --rac 10
 --rt 300
 --ce docker
+--co=--net=host
 --dc false
 --ecmd vim_base
 --econ True
@@ -38,6 +39,7 @@ BASE_LONG_CLI = """
 --ansible-runner-rotate-artifacts-count 10
 --ansible-runner-timeout 300
 --container-engine docker
+--container-options=--net=host
 --display-color false
 --editor-command vim_base
 --editor-console True
@@ -60,6 +62,7 @@ BASE_EXPECTED = d2t(
         "ansible_runner_rotate_artifacts_count": 10,
         "ansible_runner_timeout": 300,
         "container_engine": "docker",
+        "container_options": ["--net=host"],
         "display_color": False,
         "editor_command": "vim_base",
         "editor_console": True,
@@ -212,6 +215,7 @@ ENVVAR_DATA = [
     ("collection_doc_cache_path", "/tmp/cache.db", "/tmp/cache.db"),
     ("config", "/tmp/ansible.cfg", "/tmp/ansible.cfg"),
     ("container_engine", "docker", "docker"),
+    ("container_options", "--net=host", ["--net=host"]),
     ("display_color", "yellow is the color of a banana", False),
     ("editor_command", "nano_envvar", "nano_envvar"),
     ("editor_console", "false", False),


### PR DESCRIPTION
This adds support for `container-options` so that ansible-navigator
can pass through container options to ansible-runner.