### PR TITLE
[WIP]: Add venv tox entrypoint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,8 @@ allowlist_externals = ansible-playbook
 commands =
     mypy --txt-report ./{[base]mypy_tmp_dir} ./{[base]pkg_name} ./tests ./share
 
+[testenv:venv]
+commands = {posargs}
 
 [flake8]
 # E123, E125, E203 skipped as they are invalid PEP-8.


### PR DESCRIPTION
It is possible users want to have tox bootstrap a sandbox environment to
run ansible-navigator from. In this case, zuul so we can do better
integration testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>