### PR TITLE
[yaml] remove explicit sort_keys

### DIFF
--- a/ansible_navigator/yaml.py
+++ b/ansible_navigator/yaml.py
@@ -26,7 +26,6 @@ class YamlStyle(NamedTuple):
 
     default_flow_style: bool = False
     explicit_start: bool = True
-    sort_keys: bool = True
 
 
 def human_dump(obj: Any, filename: str = None, fmode: str = "w") -> Union[str, None]:


### PR DESCRIPTION
Change:
- Remove explicit sort_keys which got passed to yaml.dump(). Old PyYAML did
  not allow this kwarg. Old and new PyYAML both default to sorting keys, and
  we never override that, so just remove the line and let PyYAML do its thing.
  If we need to override it in the future, we can add a version check (though
  it gets annoying to handle version comparisons manually).

Test Plan:
- Tested locally on PyYAML 3 and PyYAML 5.4.

Tickets:
- Fixes #517
- Fixes #522
- Fixes #525

Signed-off-by: Rick Elrod <rick@elrod.me>