### PR TITLE
Revert "Drop `{tty}` and `{temp_dir}` substitutions"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ mypy_tmp_dir = mypy_tmp_dir
 
 [tox]
 envlist = linters, type, py38, report, clean
-minversion = 1.4.2
+minversion = 3.16.1
 skipsdist = True
 skip_missing_interpreters = true
 
@@ -91,11 +91,11 @@ commands =
   {envpython} -m sphinx \
     -j auto \
     -b html \
-    --color \
+    {tty:--color} \
     -a \
     -n \
     -W --keep-going \
-    -d "{toxinidir}/.tmp/.doctrees" \
+    -d "{temp_dir}/.doctrees" \
     . \
     "{envdir}/docs_out"
 


### PR DESCRIPTION
This reverts commit 48601e8df49c5240aad5ee96cf9b9bce7e8a50cb.

Depends-On: https://github.com/ansible/ansible-navigator/pull/571