### PR TITLE
Set use_develop in tox.ini

### DIFF
--- a/tests/smoketests/run.yml
+++ b/tests/smoketests/run.yml
@@ -1,11 +1,6 @@
 ---
 - hosts: localhost
   tasks:
-    - name: Install ansible-navigator
-      pip:
-        chdir: "{{ playbook_dir }}/../../"
-        name: .
-
     - name: Run `ansible-navigator --help`
       command: ansible-navigator --help
       register: anh

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ minversion = 1.4.2
 skipsdist = True
 skip_missing_interpreters = true
 
-
 [testenv]
 description = Run pytest under {basepython} ({envpython})
 # the pytest command line is not in the project.toml because of issues 
@@ -34,11 +33,11 @@ setenv =
 passenv = HOME
           USER
           XDIST_CPU
+usedevelop = True
 
 [testenv:clean]
 description = Erase coverage data
 deps = coverage
-skip_install = true
 commands = coverage erase
            rm -rf ./{[base]mypy_tmp_dir}
 
@@ -54,7 +53,6 @@ commands =
 [testenv:report]
 description = Produce coverage report
 deps = coverage
-skip_install = true
 commands =
     coverage report
     cat ./{[base]mypy_tmp_dir}/index.txt
@@ -64,7 +62,6 @@ commands =
 [testenv:smoke]
 description = Run smoke tests under {basepython} ({envpython})
 commands = ansible-playbook tests/smoketests/run.yml
-allowlist_externals = ansible-playbook
 
 [testenv:type]
 description = Verify static typing with MyPy under {basepython} ({envpython})
@@ -113,7 +110,6 @@ commands =
 isolated_build = true
 passenv =
   SSH_AUTH_SOCK
-skip_install = false
 usedevelop = true
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ description = Erase coverage data
 deps = coverage
 commands = coverage erase
            rm -rf ./{[base]mypy_tmp_dir}
+skip_install = true
 
 [testenv:linters]
 description = Enforce quality standards under {basepython} ({envpython})

--- a/tox.ini
+++ b/tox.ini
@@ -55,18 +55,21 @@ commands =
 [testenv:report]
 description = Produce coverage report
 deps = coverage
+skip_install = true
 commands =
     coverage report
     cat ./{[base]mypy_tmp_dir}/index.txt
 
 # Note included in the default envlist above since it's destructive
 # (requires tmux, git, runs a bunch of commands, etc.)
+
 [testenv:smoke]
 description = Run smoke tests under {basepython} ({envpython})
 commands = ansible-playbook tests/smoketests/run.yml
 
 [testenv:type]
 description = Verify static typing with MyPy under {basepython} ({envpython})
+skip_install = false
 commands =
     mypy --txt-report ./{[base]mypy_tmp_dir} ./{[base]pkg_name} ./tests ./share
 
@@ -113,7 +116,6 @@ isolated_build = true
 passenv =
   SSH_AUTH_SOCK
 usedevelop = true
-
 
 [flake8]
 # E203 skipped because it annoys black.

--- a/tox.ini
+++ b/tox.ini
@@ -38,9 +38,10 @@ usedevelop = True
 [testenv:clean]
 description = Erase coverage data
 deps = coverage
-commands = coverage erase
-           rm -rf ./{[base]mypy_tmp_dir}
 skip_install = true
+commands =
+  coverage erase
+  rm -rf ./{[base]mypy_tmp_dir}
 
 [testenv:linters]
 description = Enforce quality standards under {basepython} ({envpython})

--- a/tox.ini
+++ b/tox.ini
@@ -118,6 +118,7 @@ passenv =
   SSH_AUTH_SOCK
 usedevelop = true
 
+
 [flake8]
 # E203 skipped because it annoys black.
 # no pyproject.toml support https://gitlab.com/pycqa/flake8/-/issues/428

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ minversion = 1.4.2
 skipsdist = True
 skip_missing_interpreters = true
 
+
 [testenv]
 description = Run pytest under {basepython} ({envpython})
 # the pytest command line is not in the project.toml because of issues 


### PR DESCRIPTION
We are using ansible to install navigator into tox, we do not need to do
this. Lets set use_develop and have tox to it for free.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>