### PR TITLE
Enable use of release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,51 @@
+# Format and labels used aim to match those used by Ansible project
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: 'Major Changes'
+    labels:
+      - 'major'  # c6476b
+  - title: 'Minor Changes'
+    labels:
+      - 'feature'  # 006b75
+      - 'enhancement'  # ededed
+      - 'refactoring'
+  - title: 'Bugfixes'
+    labels:
+      - 'bug'  # fbca04
+  - title: 'Deprecations'
+    labels:
+      - 'deprecated'  # fef2c0
+exclude-labels:
+  - 'skip-changelog'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'feature'
+      - 'enhancement'
+      - 'refactoring'
+  patch:
+    labels:
+      - 'patch'
+      - 'bug'
+      - 'deprecated'
+  default: patch
+autolabeler:
+  - label: 'skip-changelog'
+    title: '/chore/i'
+  - label: 'bug'
+    title: '/fix/i'
+  - label: 'enhancement'
+    title: '/(enhance|improve)/i'
+  - label: 'feature'
+    title: '/feature/i'
+  - label: 'dreprecated'
+    title: '/deprecat/i'
+template: |
+  $CHANGES
+
+  Kudos goes to: $CONTRIBUTORS

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,21 @@
+# See https://github.com/jesusvasquez333/verify-pr-label-action
+name: labels
+on:
+  pull_request_target:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  check_pr_labels:
+    runs-on: ubuntu-latest
+    name: verify
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Verify PR label action
+        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          valid-labels: 'bug, enhancement, feature, refactoring, major, deprecated, skip-changelog'
+          invalid-labels: 'help wanted, invalid, feedback-needed, incomplete'
+          pull-request-number: '${{ github.event.pull_request.number }}'
+          disable-reviews: true

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: release-drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+      - 'releases/**'
+      - 'stable/**'
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-20.04
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Make use of release-drafter for building release notes and computing
the next version using semver meaning of merged PRs.

This config is based on the one already used by molecule and
ansible-lint. Results can be seen at https://github.com/ansible-community/molecule/releases

The release manager still has the freedom to change the release
notes manually.

Fixes: #558