### PR TITLE
Fix tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,15 +5,16 @@ small_test_ee = quay.io/ansible/python-base
 mypy_tmp_dir = mypy_tmp_dir
 
 [tox]
-envlist = linters, type, py38, report, clean
-minversion = 3.16.1
+envlist = linters, type, py{36,37,38,39,310}, report, clean
+# we do not want debug old bugs
+minversion = 3.24.3
 skipsdist = True
 skip_missing_interpreters = true
 
 
 [testenv]
 description = Run pytest under {basepython} ({envpython})
-# the pytest command line is not in the project.toml because of issues 
+# the pytest command line is not in the project.toml because of issues
 # with catching breakpoints while debugging unit tests
 # the number of CPUs is set to 50% b/c CI timeout failures were more likely
 # the small test image is used an alternative to the default, but should be it


### PR DESCRIPTION
- include all supported python versions in default invocation of tox (when is called without any arguments)
- remove leading space at end of line
- add a `minversion` pointing to current newest release of tox in order to ensure we do not accidentally run with old versions that may be affected by bugs that can affect the final outcome.