### PR TITLE
[utils] Fix share dir when running from repo clone

### DIFF
--- a/src/ansible_navigator/utils.py
+++ b/src/ansible_navigator/utils.py
@@ -282,7 +282,7 @@ def get_share_directory(app_name) -> Tuple[List[LogMessage], List[ExitMessage], 
     # We want the share directory to resolve adjacent to the directory the code lives in
     # as that's the layout in the source.
     share_directory = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "..", "share", app_name)
+        os.path.join(os.path.dirname(__file__), "..", "..", "share", app_name)
     )
     description = "development path"
     if os.path.exists(share_directory):


### PR DESCRIPTION
Change:
- #562 broke people who run navigator from a clone of the repository
  without installing it somewhere. The search path for the share
  directory starts with looking for it relative to utils.py for exactly
  this scenario. However when the ansible_navigator directory got moved
  a level deeper, this path wasn't updated.

Test Plan:
- Ran ansible-navigator from git clone after pip uninstalling it.

Signed-off-by: Rick Elrod <rick@elrod.me>