### PR TITLE
[ui_framework] Several niceties in prep for lint

### DIFF
--- a/src/ansible_navigator/ui_framework/__init__.py
+++ b/src/ansible_navigator/ui_framework/__init__.py
@@ -8,6 +8,7 @@ from .curses_defs import CursesLines
 from .form import Form
 from .form_utils import dict_to_form
 from .form_utils import form_to_dict
+from .form_utils import error_notification
 from .form_utils import nonblocking_notification
 from .form_utils import warning_notification
 

--- a/src/ansible_navigator/ui_framework/form_utils.py
+++ b/src/ansible_navigator/ui_framework/form_utils.py
@@ -148,3 +148,15 @@ def warning_notification(messages: List[str]) -> Form:
         "type": "notification",
     }
     return dict_to_form(form)
+
+
+def error_notification(messages: List[str]) -> Form:
+    """generate a std error notification"""
+    messages = break_long_lines(messages)
+    form = {
+        "title": "ERROR",
+        "title_color": 1,
+        "fields": [{"name": "info", "information": messages, "type": "information"}],
+        "type": "notification",
+    }
+    return dict_to_form(form)

--- a/src/ansible_navigator/ui_framework/menu_builder.py
+++ b/src/ansible_navigator/ui_framework/menu_builder.py
@@ -1,6 +1,7 @@
 """ build a menu
 """
 import curses
+import enum
 import re
 
 from typing import Any
@@ -190,7 +191,9 @@ class MenuBuilder:
         color, decoration = self._color_menu_item(colno, cols[colno], dyct)
 
         text = str(coltext)[0 : adj_colws[colno]]
-        if isinstance(coltext, (int, bool, float)) or cols[colno].lower() == "__duration":
+        if (isinstance(coltext, (int, bool, float)) and not isinstance(coltext, enum.Enum)) or cols[
+            colno
+        ].lower() == "__duration":
             # right jusitfy on header if int, bool, float or "duration"
             print_at = col_starts[colno] + len(header[colno][1]) - len(text)
         elif cols[colno].lower() == "__progress":

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -129,7 +129,7 @@ class UserInterface(CursesWindow):
         self._default_colors = None
         self._default_pairs = None
         self._default_obj_serialization = "source.yaml"
-        self._filter_content_keys: Callable[[Dict[Any, Any]], Dict[Any, Any]]
+        self._filter_content_keys: Callable[[Any], Dict[Any, Any]]
         self._hide_keys = True
         self._kegexes = kegexes
         self._logger = logging.getLogger(__name__)
@@ -611,9 +611,7 @@ class UserInterface(CursesWindow):
         :rtype: CursesLines
         """
         heading = self._content_heading(obj, self._screen_w)
-        filtered_obj = (
-            self._filter_content_keys(obj) if self._hide_keys and isinstance(obj, dict) else obj
-        )
+        filtered_obj = self._filter_content_keys(obj) if self._hide_keys else obj
         lines = self._serialize_color(filtered_obj)
         return heading, lines
 
@@ -713,11 +711,7 @@ class UserInterface(CursesWindow):
                 if name == "refresh":
                     action = action._replace(value=index)
 
-                filtered = (
-                    self._filter_content_keys(current)
-                    if self._hide_keys and isinstance(current, dict)
-                    else current
-                )
+                filtered = self._filter_content_keys(current) if self._hide_keys else current
                 content = Content(showing=filtered)
                 return Interaction(name=name, action=action, content=content, ui=self._ui)
 


### PR DESCRIPTION
Change:
- Add error_notification (similar to warning_notification, but more red)

- In menu_builder, don't try to render IntEnums as ints (preferring to
  keep them left-aligned)

- Let filter_content_keys take any object, don't force it to be a
  Dict[Any, Any]. As long as it *returns* a dictionary, we can render it
  just fine. This lets actions use custom classes (such as dataclasses)
  to manipulate their internal data, without needing to do as many
  conversions to interact with the rest of the navigator UI system.

Test Plan:
- Most of this is being tested and used in the lint action I'm working
  on; there isn't code that makes use of these changes in the current
  codebase.

Signed-off-by: Rick Elrod <rick@elrod.me>