### PR TITLE
[POC] Redo #614 with rpm Python lib

### DIFF
--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -356,7 +356,7 @@ class Action(App):
         self._images.selected["__introspected"] = True
         share_directory = self._args.internals.share_directory
         container_volume_mounts = [f"{share_directory}/utils:{share_directory}/utils"]
-        python_exec_path = "python3"
+        python_exec_path = "/usr/libexec/platform-python"
 
         kwargs = {
             "cmdline": [f"{share_directory}/utils/image_introspect.py"],


### PR DESCRIPTION
Change:
- This is a proof of concept to rewrite the change in #614 but
  using the Python rpm binding instead. In addition to fixing various
  issues with parsing `rpm -qi` output, this also gives us access to
  more information to display.
- This only serves as a demo - there is some work to be done before
  this could actually replace 614. See TODOs in this patch.

Test Plan:
- Tested locally a bunch.

Signed-off-by: Rick Elrod <rick@elrod.me>