### PR TITLE
set task duration to zero if None (fixes #598)

### DIFF
--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -662,7 +662,13 @@ class Action(App):
                     task["__task"] = task["task"]
                     task["__result"] = result.upper()
                     task["__changed"] = task.get("res", {}).get("changed", False)
-                    task["__duration"] = human_time(seconds=round(task["duration"], 2))
+                    if isinstance(task["duration"], (int, float)):
+                        task["__duration"] = human_time(seconds=round(task["duration"], 2))
+                    else:
+                        msg = f"Task duration for \'{task['task']}\' was type {type(task['duration'])}, set to 0"
+                        self._logger.debug(msg)
+                        task["__duration"] = 0
+                                           
                     task_id = None
                     for idx, play_task in enumerate(self._plays.value[play_id]["tasks"]):
                         if task["task_uuid"] == play_task["task_uuid"]:


### PR DESCRIPTION
fixes #598 with @cidrblock 's recommendation 

Worked with @alisonlhart was able to reproduce the issue and tested with steps listed in the issue. 

before 
```
Traceback (most recent call last):
  File "/home/aubin/work/env/py38.0/bin/ansible-navigator", line 8, in <module>
    sys.exit(main())
  File "/home/aubin/work/env/py38.0/lib/python3.8/site-packages/ansible_navigator/cli.py", line 141, in main
    return_code = run(args)
  File "/home/aubin/work/env/py38.0/lib/python3.8/site-packages/ansible_navigator/cli.py", line 79, in run
    return_code = run_action_stdout(args.app.replace("-", "_"), args)
  File "/home/aubin/work/env/py38.0/lib/python3.8/site-packages/ansible_navigator/actions/_actions.py", line 109, in run_stdout
    return action_cls(args).run_stdout()
  File "/home/aubin/work/env/py38.0/lib/python3.8/site-packages/ansible_navigator/actions/run.py", line 249, in run_stdout
    self._dequeue()
  File "/home/aubin/work/env/py38.0/lib/python3.8/site-packages/ansible_navigator/actions/run.py", line 612, in _dequeue
    self._handle_message(message)
  File "/home/aubin/work/env/py38.0/lib/python3.8/site-packages/ansible_navigator/actions/run.py", line 664, in _handle_message
    task["__duration"] = human_time(seconds=round(task["duration"], 2))
TypeError: type NoneType doesn't define __round__ method
```

after
```
ansible-navigator run ./test_inventory.yml -m stdout  -v -i ./inventory.ini
No config file found; using defaults

PLAY [all] *********************************************************************

TASK [End play if remote host] *************************************************
skipping: [localhost] => {"msg": "end_host conditional evaluated to false, continuing execution for localhost", "skip_reason": "end_host conditional evaluated to False, continuing execution for localhost"}

PLAY RECAP *********************************************************************
```
ansible-navigator log entry
```
211123164144.219 DEBUG 'ansible_navigator.actions.run_playbook._handle_message' Task duration for 'End play if remote host' was type <class 'NoneType'>, set to 0
```

