### PR TITLE
[typing] Ensure `:run` passes rounded int to `utils.human_time`

### DIFF
--- a/docs/changelog-fragments.d/640.misc.md
+++ b/docs/changelog-fragments.d/640.misc.md
@@ -1,0 +1,2 @@
+Ensure durations in the TUI are rounding consistently (half-up).
+-- by {user}`cidrblock`

--- a/docs/changelog-fragments.d/640.misc.md
+++ b/docs/changelog-fragments.d/640.misc.md
@@ -1,2 +1,2 @@
-Ensure durations in the TUI are rounding consistently (half-up).
+Ensure durations in the TUI are rounded consistently (half-up).
 -- by {user}`cidrblock`

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -39,6 +39,7 @@ from ..ui_framework import warning_notification
 from ..utils import abs_user_path
 from ..utils import human_time
 from ..utils import remove_ansi
+from ..utils import round_half_up
 
 
 RESULT_TO_COLOR = [
@@ -663,7 +664,7 @@ class Action(App):
                     task["__result"] = result.upper()
                     task["__changed"] = task.get("res", {}).get("changed", False)
                     if isinstance(task["duration"], (int, float)):
-                        task["__duration"] = human_time(seconds=round(task["duration"], 2))
+                        task["__duration"] = human_time(seconds=round_half_up(task["duration"]))
                     else:
                         msg = (
                             f"Task duration for '{task['task']}' was type {type(task['duration'])},"

--- a/src/ansible_navigator/utils.py
+++ b/src/ansible_navigator/utils.py
@@ -1,7 +1,7 @@
 """ some utilities that are specific to ansible_navigator
 """
 import ast
-
+import decimal
 import logging
 import html
 import os
@@ -408,6 +408,12 @@ def remove_dbl_un(string):
     if string.startswith("__"):
         return string.replace("__", "", 1)
     return string
+
+
+def round_half_up(number: Union[float, int]) -> int:
+    """Round a number to the nearest integer with ties going away from zero."""
+    rounded = decimal.Decimal(number).quantize(decimal.Decimal("1"), rounding=decimal.ROUND_HALF_UP)
+    return int(rounded)
 
 
 def str2bool(value: Any) -> bool:

--- a/src/ansible_navigator/utils.py
+++ b/src/ansible_navigator/utils.py
@@ -411,7 +411,16 @@ def remove_dbl_un(string):
 
 
 def round_half_up(number: Union[float, int]) -> int:
-    """Round a number to the nearest integer with ties going away from zero."""
+    """Round a number to the nearest integer with ties going away from zero.
+
+    This is different the round() where exact halfway cases are rounded to the nearest
+    even result instead of away from zero. (e.g. round(2.5) = 2, round(3.5) = 4).
+
+    This will always round based on distance from zero. (e.g round(2.5) = 3, round(3.5) = 4).
+
+    :param number: The number to round
+    :return: The rounded number as an it
+    """
     rounded = decimal.Decimal(number).quantize(decimal.Decimal("1"), rounding=decimal.ROUND_HALF_UP)
     return int(rounded)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,6 +3,7 @@
 import os
 
 from typing import List
+from typing import NamedTuple
 from typing import Optional
 from typing import NamedTuple
 from typing import Union
@@ -157,3 +158,32 @@ def test_human_time_negative_float(data: HumanTimeTestData) -> None:
     """
     result = utils.human_time(-float(data.value))
     assert result == f"-{data.expected}"
+
+
+class RoundHalfUpTestData(NamedTuple):
+    """Data for round half up tests."""
+
+    id: str
+    value: Union[int, float]
+    expected: int
+
+
+round_half_up_test_data = [
+    RoundHalfUpTestData(id="integer", value=1, expected=1),
+    RoundHalfUpTestData(id="negative integer", value=-1, expected=-1),
+    RoundHalfUpTestData(id="down float", value=1.49999999, expected=1),
+    RoundHalfUpTestData(id="up float", value=1.50000001, expected=2),
+    RoundHalfUpTestData(id="negative down float", value=-1.49999999, expected=-1),
+    RoundHalfUpTestData(id="negative up float", value=-1.50000001, expected=-2),
+]
+
+
+@pytest.mark.parametrize("data", round_half_up_test_data, ids=lambda data: data.id)
+def test_round_half_up(data: RoundHalfUpTestData) -> None:
+    """Test for the utils.round_half_up function.
+
+    Ensure the number passed is consistently rounded to the nearset integer with ties going away from zero.
+    """
+    for _iteration in range(100):
+        result = utils.round_half_up(data.value)
+        assert result == data.expected

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -175,7 +175,7 @@ round_half_up_test_data = [
     RoundHalfUpTestData(id="negative down float", value=-1.49999999, expected=-1),
     RoundHalfUpTestData(id="negative up float", value=-1.50000001, expected=-2),
     RoundHalfUpTestData(id="half_even", value=2.5, expected=3),
-    RoundHalfUpTestData(id="half_even", value=3.5, expected=4)
+    RoundHalfUpTestData(id="half_even", value=3.5, expected=4),
 ]
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -5,7 +5,6 @@ import os
 from typing import List
 from typing import NamedTuple
 from typing import Optional
-from typing import NamedTuple
 from typing import Union
 
 import pytest
@@ -182,7 +181,8 @@ round_half_up_test_data = [
 def test_round_half_up(data: RoundHalfUpTestData) -> None:
     """Test for the utils.round_half_up function.
 
-    Ensure the number passed is consistently rounded to the nearset integer with ties going away from zero.
+    Ensure the number passed is consistently rounded to the nearset
+    integer with ties going away from zero.
     """
     for _iteration in range(100):
         result = utils.round_half_up(data.value)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -174,6 +174,8 @@ round_half_up_test_data = [
     RoundHalfUpTestData(id="up float", value=1.50000001, expected=2),
     RoundHalfUpTestData(id="negative down float", value=-1.49999999, expected=-1),
     RoundHalfUpTestData(id="negative up float", value=-1.50000001, expected=-2),
+    RoundHalfUpTestData(id="half_even", value=2.5, expected=3),
+    RoundHalfUpTestData(id="half_even", value=3.5, expected=4)
 ]
 
 
@@ -184,6 +186,5 @@ def test_round_half_up(data: RoundHalfUpTestData) -> None:
     Ensure the number passed is consistently rounded to the nearset
     integer with ties going away from zero.
     """
-    for _iteration in range(100):
-        result = utils.round_half_up(data.value)
-        assert result == data.expected
+    result = utils.round_half_up(data.value)
+    assert result == data.expected


### PR DESCRIPTION
depends-on: https://github.com/ansible/ansible-navigator/pull/671
Fixes #640 

- Without a guarantee of the runner duration value being an int, assume it can be either float or int, and round half up
- helper function added to utils
- unit test to help demonstrate the behavior of decimal