### PR TITLE
[tests] Fix pylint errors in `tests/interactive`

### DIFF
--- a/tests/integration/_action_run_test.py
+++ b/tests/integration/_action_run_test.py
@@ -22,7 +22,9 @@ from ansible_navigator.steps import Steps
 
 
 class ActionRunTest:
-    """directly run an action"""
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-arguments
+    """Directly run an action."""
 
     def __init__(
         self,
@@ -115,6 +117,7 @@ class ActionRunTest:
         return action
 
     def run_action_stdout(self, **kwargs) -> Tuple[int, str, str]:
+        # pylint: disable=too-many-locals
         """run the action"""
         self._app_args.update({"mode": "stdout"})
         self._app_args.update(kwargs)
@@ -137,23 +140,26 @@ class ActionRunTest:
         sys.stdin = stty  # type: ignore
 
         # set stderr and stdout to fds
-        sys.stdout = tempfile.TemporaryFile()  # type: ignore
-        sys.stderr = tempfile.TemporaryFile()  # type: ignore
+        with tempfile.TemporaryFile() as sys_stdout:
+            sys.stdout = sys_stdout  # type: ignore
 
-        # run the action
-        return_code = action.run_stdout()
+            with tempfile.TemporaryFile() as sys_stderr:
+                sys.stderr = sys_stderr  # type: ignore
 
-        # restore stdin
-        sys.stdin = __stdin__
+                # run the action
+                return_code = action.run_stdout()
 
-        # read and restore stdout
-        sys.stdout.seek(0)
-        stdout = sys.stdout.read().decode()  # type: ignore
-        sys.stdout = __stdout__
+                # restore stdin
+                sys.stdin = __stdin__
 
-        # read and restore stderr
-        sys.stderr.seek(0)
-        stderr = sys.stderr.read().decode()  # type: ignore
-        sys.stderr = __stderr__
+                # read and restore stdout
+                sys.stdout.seek(0)
+                stdout = sys.stdout.read().decode()  # type: ignore
+                sys.stdout = __stdout__
+
+                # read and restore stderr
+                sys.stderr.seek(0)
+                stderr = sys.stderr.read().decode()  # type: ignore
+                sys.stderr = __stderr__
 
         return return_code, stdout, stderr

--- a/tests/integration/_action_run_test.py
+++ b/tests/integration/_action_run_test.py
@@ -140,26 +140,24 @@ class ActionRunTest:
         sys.stdin = stty  # type: ignore
 
         # set stderr and stdout to fds
-        with tempfile.TemporaryFile() as sys_stdout:
+        with tempfile.TemporaryFile() as sys_stdout, tempfile.TemporaryFile() as sys_stderr:
             sys.stdout = sys_stdout  # type: ignore
+            sys.stderr = sys_stderr  # type: ignore
 
-            with tempfile.TemporaryFile() as sys_stderr:
-                sys.stderr = sys_stderr  # type: ignore
+            # run the action
+            return_code = action.run_stdout()
 
-                # run the action
-                return_code = action.run_stdout()
+            # restore stdin
+            sys.stdin = __stdin__
 
-                # restore stdin
-                sys.stdin = __stdin__
+            # read and restore stdout
+            sys.stdout.seek(0)
+            stdout = sys.stdout.read().decode()  # type: ignore
+            sys.stdout = __stdout__
 
-                # read and restore stdout
-                sys.stdout.seek(0)
-                stdout = sys.stdout.read().decode()  # type: ignore
-                sys.stdout = __stdout__
-
-                # read and restore stderr
-                sys.stderr.seek(0)
-                stderr = sys.stderr.read().decode()  # type: ignore
-                sys.stderr = __stderr__
+            # read and restore stderr
+            sys.stderr.seek(0)
+            stderr = sys.stderr.read().decode()  # type: ignore
+            sys.stderr = __stderr__
 
         return return_code, stdout, stderr

--- a/tests/integration/_common.py
+++ b/tests/integration/_common.py
@@ -24,6 +24,7 @@ def get_executable_path(name):
 def update_fixtures(
     request, index, received_output, comment, testname=None, additional_information=None
 ):
+    # pylint: disable=too-many-arguments
     """Used by action plugins to generate the fixtures"""
     dir_path, file_name = fixture_path_from_request(request, index, testname=testname)
     os.makedirs(dir_path, exist_ok=True)
@@ -73,6 +74,7 @@ class Error(EnvironmentError):
 
 
 def sanitize_output(output):
+    """Sanitize test output that may be env specific or unique per run."""
     re_uuid = re.compile(
         "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE
     )

--- a/tests/integration/_interactions.py
+++ b/tests/integration/_interactions.py
@@ -43,8 +43,7 @@ class Command(NamedTuple):
         cmd = " ".join(shlex.quote(str(arg)) for arg in args)
         if self.preclear:
             return "clear && " + cmd
-        else:
-            return cmd
+        return cmd
 
 
 class Step(NamedTuple):

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -14,6 +14,9 @@ from ._common import generate_test_log_dir
 
 
 class TmuxSession:
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-locals
     """tmux session"""
 
     def __init__(
@@ -161,10 +164,14 @@ class TmuxSession:
         ignore_within_response=None,
         timeout=300,
     ):
-        """interact with the tmux session
+        # pylint: disable=too-many-branches
+        # pylint: disable=too-many-statements
+        """Interact with the tmux session.
+
         :param value: send to screen
-        :param search_within_response: a list of strs or str to find
-        :param ignore_within_reponse: ignore screen if this there
+        :param search_within_response: a list of strings or string to find
+        :param ignore_within_response: ignore screen if this there
+        :param timeout: the amount of time is seconds to allow for completion
         """
         showing = None
         if self._fail_remaining:
@@ -261,7 +268,7 @@ class TmuxSession:
 
             elapsed = timer() - start_time
             if elapsed > timeout:
-                with open(setup_capture_path, "w") as filehandle:
+                with open(file=setup_capture_path, mode="w", encoding="utf-8") as filehandle:
                     filehandle.writelines("\n".join(self._setup_capture))
 
                 tstamp = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
@@ -271,7 +278,7 @@ class TmuxSession:
                 ]
                 alerts.append(f"******** Captured to: {timeout_capture_path}")
                 showing = alerts + showing
-                with open(timeout_capture_path, "w") as filehandle:
+                with open(file=timeout_capture_path, mode="w", encoding="utf-8") as filehandle:
                     filehandle.writelines("\n".join(showing))
                 self._fail_remaining = ["******** PREVIOUS TEST FAILURE ********"]
                 return showing

--- a/tests/integration/actions/collections/base.py
+++ b/tests/integration/actions/collections/base.py
@@ -1,4 +1,4 @@
-""" base class for config interactive tests
+"""Base class for collections interactive tests.
 """
 import difflib
 import json
@@ -17,8 +17,8 @@ from ....defaults import FIXTURES_COLLECTION_DIR
 
 
 class BaseClass:
-    # pylint: disable=attribute-defined-outside-init
-    """base class for interactive collections tests"""
+    # pylint: disable=too-few-public-methods
+    """Base class for interactive collections tests."""
 
     UPDATE_FIXTURES = False
     EXECUTION_ENVIRONMENT_TEST = False
@@ -27,7 +27,7 @@ class BaseClass:
     @staticmethod
     @pytest.fixture(scope="module", name="tmux_collections_session")
     def _fixture_tmux_config_session(request, os_indendent_tmp):
-        """tmux fixture for this module"""
+        """Tmux fixture for this module."""
 
         tmp_coll_dir = os.path.join(os_indendent_tmp, request.node.name, "")
         os.makedirs(tmp_coll_dir, exist_ok=True)
@@ -57,13 +57,12 @@ class BaseClass:
         user_input,
         comment,
     ):
-        # pylint:disable=unused-argument
-        # pylint: disable=too-few-public-methods
         # pylint: disable=too-many-arguments
-        """test interactive config"""
+        """Run the tests for collections, mode and ee set in child class.
 
-        # wait on help here to ensure we get the welcome screen and subsequent screens
-        # after entering a : command
+        wait on help here to ensure we get the welcome screen and subsequent screens
+        after entering a : command
+        """
 
         ignore_within_response = "Collecting collection content"
         if self.TEST_FOR_MODE == "interactive":
@@ -88,7 +87,7 @@ class BaseClass:
         ):
             update_fixtures(request, index, received_output, comment)
         dir_path, file_name = fixture_path_from_request(request, index)
-        with open(f"{dir_path}/{file_name}") as infile:
+        with open(file=f"{dir_path}/{file_name}", encoding="utf-8") as infile:
             expected_output = json.load(infile)["output"]
         assert expected_output == received_output, "\n" + "\n".join(
             difflib.unified_diff(expected_output, received_output, "expected", "received")

--- a/tests/integration/actions/collections/test_direct_interactive_ee.py
+++ b/tests/integration/actions/collections/test_direct_interactive_ee.py
@@ -1,9 +1,8 @@
-""" collections direct from cli interactive with ee
+"""Tests for collections from cli, interactive, with ee.
 """
 import pytest
 
 from .base import BaseClass
-
 
 CLI = "ansible-navigator collections --execution-environment true"
 
@@ -26,7 +25,8 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment", testdata)
 class Test(BaseClass):
-    """run the tests"""
+    # pylint: disable=too-few-public-methods
+    """Run the tests for collections from cli, interactive, with ee."""
 
     TEST_FOR_MODE = "interactive"
     EXECUTION_ENVIRONMENT_TEST = True

--- a/tests/integration/actions/collections/test_direct_interactive_noee.py
+++ b/tests/integration/actions/collections/test_direct_interactive_noee.py
@@ -1,4 +1,4 @@
-""" collections direct from cli interactive w/o ee
+"""Tests for collections from cli, interactive, without ee.
 """
 import pytest
 
@@ -25,7 +25,8 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment", testdata)
 class Test(BaseClass):
-    """run the tests"""
+    # pylint: disable=too-few-public-methods
+    """Run the tests for collections from cli, interactive, without ee."""
 
     TEST_FOR_MODE = "interactive"
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/collections/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/collections/test_welcome_interactive_ee.py
@@ -1,9 +1,8 @@
-""" collections from welcome interactive w/0 ee
+"""Tests for collections from welcome, interactive, with ee.
 """
 import pytest
 
 from .base import BaseClass
-
 
 CLI = "ansible-navigator --execution-environment true"
 
@@ -27,7 +26,8 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment", testdata)
 class Test(BaseClass):
-    """run the tests"""
+    # pylint: disable=too-few-public-methods
+    """Run the tests for collections from welcome, interactive, with ee."""
 
     TEST_FOR_MODE = "interactive"
     EXECUTION_ENVIRONMENT_TEST = True

--- a/tests/integration/actions/collections/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/collections/test_welcome_interactive_noee.py
@@ -1,4 +1,4 @@
-""" collections from welcome interactive w/0 ee
+"""Tests for collections from welcome, interactive, without ee.
 """
 import pytest
 
@@ -26,7 +26,8 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment", testdata)
 class Test(BaseClass):
-    """run the tests"""
+    # pylint: disable=too-few-public-methods
+    """Run the tests for collections from welcome, interactive, without ee."""
 
     TEST_FOR_MODE = "interactive"
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/config/base.py
+++ b/tests/integration/actions/config/base.py
@@ -1,4 +1,4 @@
-""" base class for config interactive tests
+"""Base class for config interactive/stdout tests.
 """
 import difflib
 import json
@@ -29,7 +29,7 @@ base_steps = (
 
 
 class BaseClass:
-    """base class for interactive/stdout config tests"""
+    """Base class for interactive/stdout config tests."""
 
     UPDATE_FIXTURES = False
     PANE_HEIGHT = 25
@@ -48,10 +48,7 @@ class BaseClass:
             yield tmux_session
 
     def test(self, request, tmux_session, step):
-        # pylint:disable=unused-argument
-        # pylint: disable=too-few-public-methods
-        # pylint: disable=too-many-arguments
-        """test interactive/stdout config"""
+        """Run the tests for config, mode and ee set in child class."""
 
         if step.search_within_response is SearchFor.HELP:
             search_within_response = ":help help"
@@ -99,7 +96,7 @@ class BaseClass:
 
         if not any((step.look_fors, step.look_nots)):
             dir_path, file_name = fixture_path_from_request(request, step.step_index)
-            with open(f"{dir_path}/{file_name}") as infile:
+            with open(file=f"{dir_path}/{file_name}", encoding="utf-8") as infile:
                 expected_output = json.load(infile)["output"]
 
             assert expected_output == received_output, "\n" + "\n".join(

--- a/tests/integration/actions/config/test_direct_interactive_ee.py
+++ b/tests/integration/actions/config/test_direct_interactive_ee.py
@@ -1,4 +1,4 @@
-""" config direct from cli interactive w/ ee
+"""Tests for config from cli, interactive, with ee.
 """
 import pytest
 
@@ -20,6 +20,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for config from cli, interactive, with ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/config/test_direct_interactive_noee.py
+++ b/tests/integration/actions/config/test_direct_interactive_noee.py
@@ -1,4 +1,4 @@
-""" config direct from cli interactive w/o ee
+"""Tests for config from cli, interactive, without ee.
 """
 import pytest
 
@@ -19,6 +19,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for config from cli, interactive, without ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/config/test_stdout_tmux.py
+++ b/tests/integration/actions/config/test_stdout_tmux.py
@@ -1,5 +1,4 @@
-"""Tests for config from cli, stdout
-"""
+"""Tests for config from cli, stdout."""
 import pytest
 
 

--- a/tests/integration/actions/config/test_stdout_tmux.py
+++ b/tests/integration/actions/config/test_stdout_tmux.py
@@ -1,4 +1,5 @@
-""" config stdout tests using tmux """
+"""Tests for config from cli, stdout
+"""
 import pytest
 
 
@@ -129,6 +130,6 @@ def step_id(value):
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for config from cli, mode stdout."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/config/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/config/test_welcome_interactive_ee.py
@@ -1,4 +1,4 @@
-""" config from welcome interactive w ee
+""" Tests for config from welcome, interactive, with ee.
 """
 import pytest
 
@@ -22,6 +22,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for config from welcome, interactive, with ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/config/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/config/test_welcome_interactive_noee.py
@@ -1,4 +1,4 @@
-""" config from welcome interactive w ee
+"""Tests for config from cli, interactive, without ee.
 """
 import pytest
 
@@ -22,6 +22,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for config from cli, interactive, without ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/config/test_welcome_interactive_param_use.py
+++ b/tests/integration/actions/config/test_welcome_interactive_param_use.py
@@ -1,4 +1,4 @@
-""" config from welcome interactive w ee
+"""Tests for config from welcome, interactive, with parameters.
 """
 import pytest
 
@@ -34,6 +34,6 @@ steps = add_indicies(steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for config from welcome, interactive, with parameters."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/config/test_welcome_interactive_specified_config.py
+++ b/tests/integration/actions/config/test_welcome_interactive_specified_config.py
@@ -1,4 +1,4 @@
-""" config from welcome interactive w ee and specified config
+"""Tests for config from welcome, interactive, specify config.
 """
 import pytest
 
@@ -36,7 +36,7 @@ steps = add_indicies(steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for config from welcome, interactive, specify config."""
 
     PANE_HEIGHT = 300
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/doc/base.py
+++ b/tests/integration/actions/doc/base.py
@@ -46,7 +46,6 @@ class BaseClass:
         # pylint: disable=too-many-locals
         # pylint: disable=too-many-branches
         """Run the tests for collections, mode and ee set in child class."""
-
         if self.TEST_FOR_MODE == "interactive":
             search_within_response = ":help help"
         elif self.TEST_FOR_MODE == "stdout":

--- a/tests/integration/actions/doc/base.py
+++ b/tests/integration/actions/doc/base.py
@@ -1,12 +1,12 @@
-""" base class for doc tests
+"""Base class for doc interactive/stdout tests.
 """
 import difflib
 import json
 import os
 
-import pytest
-
 from typing import Optional
+
+import pytest
 
 from ..._common import fixture_path_from_request
 from ..._common import update_fixtures
@@ -16,7 +16,7 @@ from ....defaults import FIXTURES_COLLECTION_DIR
 
 
 class BaseClass:
-    """base class for interactive doc tests"""
+    """Base class for interactive/stdout doc tests."""
 
     UPDATE_FIXTURES = False
     TEST_FOR_MODE: Optional[str] = None
@@ -24,7 +24,8 @@ class BaseClass:
     @staticmethod
     @pytest.fixture(scope="module", name="tmux_doc_session")
     def fixture_tmux_doc_session(request):
-        """tmux fixture for this module"""
+        # pylint: disable=too-many-locals
+        """Tmux fixture for this module."""
         params = {
             "pane_height": "2000",
             "pane_width": "200",
@@ -41,10 +42,11 @@ class BaseClass:
     def test(
         self, request, tmux_doc_session, index, user_input, comment, testname, expected_in_output
     ):
-        # pylint:disable=unused-argument
-        # pylint: disable=too-few-public-methods
         # pylint: disable=too-many-arguments
-        """test interactive/stdout config"""
+        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-branches
+        """Run the tests for collections, mode and ee set in child class."""
+
         if self.TEST_FOR_MODE == "interactive":
             search_within_response = ":help help"
         elif self.TEST_FOR_MODE == "stdout":

--- a/tests/integration/actions/doc/test_direct_interactive_ee.py
+++ b/tests/integration/actions/doc/test_direct_interactive_ee.py
@@ -1,4 +1,4 @@
-""" doc direct from cli interactive w/ ee
+"""Tests for doc from cli, interactive, with ee.
 """
 from typing import List
 
@@ -8,7 +8,7 @@ from .base import BaseClass
 
 
 # module doc
-CLI_MODULE_DOC = "ansible-navigator doc testorg.coll_1.mod_1" " --execution-environment true"
+CLI_MODULE_DOC = "ansible-navigator doc testorg.coll_1.mod_1 --execution-environment true"
 
 testdata_module_doc: List = [
     (0, CLI_MODULE_DOC, "ansible-navigator doc module plugin display", "module_doc_pass", []),
@@ -17,7 +17,7 @@ testdata_module_doc: List = [
 
 # lookup plugin doc
 CLI_LOOKUP_DOC = (
-    "ansible-navigator doc testorg.coll_1.lookup_1 -t lookup" " --execution-environment true"
+    "ansible-navigator doc testorg.coll_1.lookup_1 -t lookup --execution-environment true"
 )
 
 testdata_lookup_doc: List = [
@@ -26,7 +26,7 @@ testdata_lookup_doc: List = [
 
 # plugin does not exist
 CLI_WRONG_MODULE_NOT_EXIST = (
-    "ansible-navigator doc testorg.coll_1.doesnotexist" " --execution-environment true"
+    "ansible-navigator doc testorg.coll_1.doesnotexist --execution-environment true"
 )
 
 testdata_module_doc_not_exist = [
@@ -44,7 +44,7 @@ testdata_module_doc_not_exist = [
     "index, user_input, comment, testname, expected_in_output", testdata_module_doc
 )
 class TestModuleDoc(BaseClass):
-    """run the tests"""
+    """Run the tests for doc from cli, interactive, with ee."""
 
     TEST_FOR_MODE = "interactive"
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/doc/test_direct_interactive_noee.py
+++ b/tests/integration/actions/doc/test_direct_interactive_noee.py
@@ -1,8 +1,10 @@
-""" doc direct from cli interactive w/o ee
+"""Tests for doc from cli, interactive, without ee.
 """
-import pytest
 
 from typing import List
+
+import pytest
+
 from .base import BaseClass
 
 # module doc
@@ -39,7 +41,7 @@ testdata_module_doc_not_exist = [
     "index, user_input, comment, testname, expected_in_output", testdata_module_doc
 )
 class TestModuleDoc(BaseClass):
-    """run the tests"""
+    """Run the tests for doc from cli, interactive, without ee."""
 
     TEST_FOR_MODE = "interactive"
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/doc/test_stdout.py
+++ b/tests/integration/actions/doc/test_stdout.py
@@ -1,4 +1,4 @@
-""" doc direct from cli stdout tests
+"""Tests for doc from cli, stdout.
 """
 from typing import List
 
@@ -26,20 +26,20 @@ testdata_1: List = [
 
 @pytest.mark.parametrize("index, user_input, comment, testname, expected_in_output", testdata_1)
 class TestDocHelpWithEE(BaseClass):
-    """run the tests"""
+    """Run the tests for doc help from cli, stdout, with ee."""
 
     TEST_FOR_MODE = "stdout"
 
 
 # ansible-doc help without EE
-CLI_DOC_HELP_WITH_EE = (
+CLI_DOC_HELP_WITHOUT_EE = (
     "ansible-navigator doc testorg.coll_1.mod_1 --help-doc -m stdout --execution-environment false"
 )
 
 testdata_2: List = [
     (
         0,
-        CLI_DOC_HELP_WITH_EE,
+        CLI_DOC_HELP_WITHOUT_EE,
         "ansible-navigator doc help without ee",
         "doc_help_without_ee",
         ["usage: ansible-doc [-h]"],
@@ -49,7 +49,7 @@ testdata_2: List = [
 
 @pytest.mark.parametrize("index, user_input, comment, testname, expected_in_output", testdata_2)
 class TestDocHelpWithoutEE(BaseClass):
-    """run the tests"""
+    """Run the tests for doc help from cli, stdout, without ee."""
 
     TEST_FOR_MODE = "stdout"
 
@@ -73,7 +73,7 @@ testdata_3: List = [
 
 @pytest.mark.parametrize("index, user_input, comment, testname, expected_in_output", testdata_3)
 class TestDocHelpWithEEWrongMode(BaseClass):
-    """run the tests"""
+    """Run the tests for doc help from cli, stdout, with ee, wrong mode."""
 
     TEST_FOR_MODE = "stdout"
 
@@ -97,14 +97,14 @@ testdata_4: List = [
 
 @pytest.mark.parametrize("index, user_input, comment, testname, expected_in_output", testdata_4)
 class TestDocHelpWithoutEEWrongMode(BaseClass):
-    """run the tests"""
+    """Run the tests for doc help from cli, stdout, without ee, wrong mode."""
 
     TEST_FOR_MODE = "stdout"
 
 
 # doc command run in stdout mode without EE
 CLI_MODULE_DOC_WITHOUT_EE = (
-    "ansible-navigator doc testorg.coll_1.mod_1 -m stdout -j" " --execution-environment false"
+    "ansible-navigator doc testorg.coll_1.mod_1 -m stdout -j --execution-environment false"
 )
 
 testdata_5: List = [
@@ -120,7 +120,7 @@ testdata_5: List = [
 
 @pytest.mark.parametrize("index, user_input, comment, testname, expected_in_output", testdata_5)
 class TestModuleDocWithoutEE(BaseClass):
-    """run the tests"""
+    """Run the tests for doc from cli, stdout, without ee, module doc."""
 
     TEST_FOR_MODE = "stdout"
     UPDATE_FIXTURES = False
@@ -128,7 +128,7 @@ class TestModuleDocWithoutEE(BaseClass):
 
 # doc command run in stdout mode with EE
 CLI_MODULE_DOC_WITH_EE = (
-    "ansible-navigator doc testorg.coll_1.mod_1 -m stdout -j" " --execution-environment true"
+    "ansible-navigator doc testorg.coll_1.mod_1 -m stdout -j --execution-environment true"
 )
 
 testdata_6: List = [
@@ -144,7 +144,7 @@ testdata_6: List = [
 
 @pytest.mark.parametrize("index, user_input, comment, testname, expected_in_output", testdata_6)
 class TestModuleDocWithEE(BaseClass):
-    """run the tests"""
+    """Run the tests for doc from cli, stdout, with ee, module doc."""
 
     TEST_FOR_MODE = "stdout"
     UPDATE_FIXTURES = False
@@ -169,7 +169,7 @@ testdata_7: List = [
 
 @pytest.mark.parametrize("index, user_input, comment, testname, expected_in_output", testdata_7)
 class TestLookUpDocWithoutEE(BaseClass):
-    """run the tests"""
+    """Run the tests for doc from cli, stdout, without ee, lookup doc."""
 
     TEST_FOR_MODE = "stdout"
     UPDATE_FIXTURES = False
@@ -194,7 +194,7 @@ testdata_8: List = [
 
 @pytest.mark.parametrize("index, user_input, comment, testname, expected_in_output", testdata_8)
 class TestLookUpDocWithEE(BaseClass):
-    """run the tests"""
+    """Run the tests for doc from cli, stdout, with ee, lookup doc."""
 
     TEST_FOR_MODE = "stdout"
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/doc/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/doc/test_welcome_interactive_ee.py
@@ -1,4 +1,4 @@
-""" from welcome interactive w/ ee
+"""Tests for doc from welcome, interactive, with ee.
 """
 from typing import List
 
@@ -17,7 +17,7 @@ testdata_module_doc: List = [
 ]
 
 # lookup plugin doc
-CLI_LOOKUP_DOC = "ansible-navigator" " --execution-environment true"
+CLI_LOOKUP_DOC = "ansible-navigator --execution-environment true"
 
 testdata_lookup_doc: List = [
     (0, CLI_LOOKUP_DOC, "welcome", "lookup_doc_pass", []),
@@ -25,7 +25,7 @@ testdata_lookup_doc: List = [
 ]
 
 # plugin does not exist
-CLI_WRONG_MODULE_NOT_EXIST = "ansible-navigator" " --execution-environment true"
+CLI_WRONG_MODULE_NOT_EXIST = "ansible-navigator --execution-environment true"
 
 testdata_module_doc_not_exist = [
     (0, CLI_WRONG_MODULE_NOT_EXIST, "welcome", "module_doc_fail", []),
@@ -43,7 +43,7 @@ testdata_module_doc_not_exist = [
     "index, user_input, comment, testname, expected_in_output", testdata_module_doc
 )
 class TestModuleDoc(BaseClass):
-    """run the tests"""
+    """Run the tests for doc from welcome, interactive, with ee, module doc."""
 
     TEST_FOR_MODE = "interactive"
     UPDATE_FIXTURES = False
@@ -53,7 +53,7 @@ class TestModuleDoc(BaseClass):
     "index, user_input, comment, testname, expected_in_output", testdata_lookup_doc
 )
 class TestLookUpDoc(BaseClass):
-    """run the tests"""
+    """Run the tests for doc from welcome, interactive, with ee, lookup doc."""
 
     TEST_FOR_MODE = "interactive"
     UPDATE_FIXTURES = False
@@ -63,7 +63,7 @@ class TestLookUpDoc(BaseClass):
     "index, user_input, comment, testname, expected_in_output", testdata_module_doc_not_exist
 )
 class TestModuleDocNotExist(BaseClass):
-    """run the tests"""
+    """Run the tests for doc from welcome, interactive, with ee, doc not found."""
 
     TEST_FOR_MODE = "interactive"
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/doc/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/doc/test_welcome_interactive_noee.py
@@ -1,6 +1,6 @@
-""" from welcome interactive w/o ee
+"""Tests for doc from welcome, interactive, without ee.
 """
-from typing import List, Optional
+from typing import List
 
 import pytest
 
@@ -43,7 +43,7 @@ testdata_module_doc_not_exist = [
     "index, user_input, comment, testname, expected_in_output", testdata_module_doc
 )
 class TestModuleDoc(BaseClass):
-    """run the tests"""
+    """Run the tests for doc from welcome, interactive, without ee, module doc."""
 
     TEST_FOR_MODE = "interactive"
     UPDATE_FIXTURES = False
@@ -53,7 +53,7 @@ class TestModuleDoc(BaseClass):
     "index, user_input, comment, testname, expected_in_output", testdata_lookup_doc
 )
 class TestLookUpDoc(BaseClass):
-    """run the tests"""
+    """Run the tests for doc from welcome, interactive, without ee, lookup doc."""
 
     TEST_FOR_MODE = "interactive"
     UPDATE_FIXTURES = False
@@ -63,7 +63,7 @@ class TestLookUpDoc(BaseClass):
     "index, user_input, comment, testname, expected_in_output", testdata_module_doc_not_exist
 )
 class TestModuleDocNotExist(BaseClass):
-    """run the tests"""
+    """Run the tests for doc from welcome, interactive, without ee, doc not found."""
 
     TEST_FOR_MODE = "interactive"
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/images/base.py
+++ b/tests/integration/actions/images/base.py
@@ -1,4 +1,4 @@
-""" base class for imagesß interactive tests
+"""Base class for images interactive tests.
 """
 import difflib
 import json
@@ -11,10 +11,9 @@ from ..._common import update_fixtures
 from ..._tmux_session import TmuxSession
 from ..._interactions import SearchFor
 from ..._interactions import Step
-from ....defaults import FIXTURES_DIR
 from ....defaults import DEFAULT_CONTAINER_IMAGE
 
-IMAGE_SHORT = DEFAULT_CONTAINER_IMAGE.split("/")[-1].split(":")[0]
+IMAGE_SHORT = DEFAULT_CONTAINER_IMAGE.rsplit("/", maxsplit=1)[-1].split(":")[0]
 
 
 step_back = Step(user_input=":back", comment="goto info menu", look_fors=["Everything"])
@@ -39,12 +38,13 @@ base_steps = (
 
 
 class BaseClass:
-    """base class for interactive/stdout config tests"""
+    """Base class for interactive images tests."""
 
     UPDATE_FIXTURES = False
 
+    @staticmethod
     @pytest.fixture(scope="module", name="tmux_session")
-    def fixture_tmux_session(self, request):
+    def fixture_tmux_session(request):
         """tmux fixture for this module"""
         params = {
             "unique_test_id": request.node.nodeid,
@@ -53,10 +53,7 @@ class BaseClass:
             yield tmux_session
 
     def test(self, request, tmux_session, step):
-        # pylint:disable=unused-argument
-        # pylint: disable=too-few-public-methods
-        # pylint: disable=too-many-arguments
-        """test interactive/stdout config"""
+        """Run the tests for images, mode and ee set in child class."""
 
         if step.search_within_response is SearchFor.HELP:
             search_within_response = ":help help"
@@ -96,7 +93,7 @@ class BaseClass:
 
         if not any((step.look_fors, step.look_nots)):
             dir_path, file_name = fixture_path_from_request(request, step.step_index)
-            with open(f"{dir_path}/{file_name}") as infile:
+            with open(file=f"{dir_path}/{file_name}", encoding="utf-8") as infile:
                 expected_output = json.load(infile)["output"]
 
             assert expected_output == received_output, "\n" + "\n".join(

--- a/tests/integration/actions/images/test_direct_interactive_ee.py
+++ b/tests/integration/actions/images/test_direct_interactive_ee.py
@@ -1,4 +1,4 @@
-""" direct from cli interactive w/ ee
+"""Tests for images from cli, interactive, with ee.
 """
 import pytest
 
@@ -23,6 +23,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for images from cli, interactive, with ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/images/test_direct_interactive_noee.py
+++ b/tests/integration/actions/images/test_direct_interactive_noee.py
@@ -1,4 +1,4 @@
-""" direct from cli interactive w/o ee
+"""Tests for images from cli, interactive, without ee.
 """
 import pytest
 
@@ -24,6 +24,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for images from cli, interactive, without ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/images/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/images/test_welcome_interactive_ee.py
@@ -1,4 +1,4 @@
-""" welcome interactive w/ ee
+"""Tests for images from welcome, interactive, with ee.
 """
 import pytest
 
@@ -26,6 +26,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for images from welcome, interactive, with ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/images/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/images/test_welcome_interactive_noee.py
@@ -1,4 +1,4 @@
-""" welcome interactive w/o ee
+"""Tests for images from cli, interactive, without ee.
 """
 import pytest
 
@@ -11,7 +11,7 @@ from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import step_id
 
-# this is misleadeing b/c images will use an ee, but not for automation
+# this is misleading b/c images will use an ee, but not for automation
 CLI = Command(execution_environment=False).join()
 
 initial_steps = (
@@ -26,6 +26,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for images from welcome, interactive, without ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/inventory/base.py
+++ b/tests/integration/actions/inventory/base.py
@@ -1,4 +1,4 @@
-""" base class for inventory interactive tests
+"""Base class for inventory interactive/stdout tests.
 """
 import difflib
 import json
@@ -45,7 +45,7 @@ base_steps = (
 
 
 class BaseClass:
-    """base class for interactive inventory tests"""
+    """base class for inventory interactive/stdout tests"""
 
     UPDATE_FIXTURES = False
 
@@ -68,11 +68,7 @@ class BaseClass:
             yield tmux_session
 
     def test(self, request, tmux_session, step):
-        # pylint:disable=unused-argument
-        # pylint: disable=too-few-public-methods
-        # pylint: disable=too-many-arguments
-
-        """test interactive/stdout inventory"""
+        """Run the tests for inventory, mode and ee set in child class."""
         assert os.path.exists(ANSIBLE_INVENTORY_FIXTURE_DIR)
         assert os.path.exists(TEST_CONFIG_FILE)
 
@@ -120,7 +116,7 @@ class BaseClass:
 
         if not any((step.look_fors, step.look_nots)):
             dir_path, file_name = fixture_path_from_request(request, step.step_index)
-            with open(os.path.join(dir_path, file_name)) as infile:
+            with open(file=os.path.join(dir_path, file_name), encoding="utf-8") as infile:
                 expected_output = json.load(infile)["output"]
 
             assert expected_output == received_output, "\n" + "\n".join(

--- a/tests/integration/actions/inventory/test_direct_interactive_ee.py
+++ b/tests/integration/actions/inventory/test_direct_interactive_ee.py
@@ -1,4 +1,4 @@
-""" inventory direct from cli interactive w/ ee
+"""Tests for inventory from cli, interactive, with ee.
 """
 import pytest
 
@@ -23,6 +23,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for inventory from cli, interactive, with ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/inventory/test_direct_interactive_noee.py
+++ b/tests/integration/actions/inventory/test_direct_interactive_noee.py
@@ -1,4 +1,4 @@
-""" inventory direct from cli interactive without ee
+"""Tests for inventory from cli, interactive, without ee.
 """
 import pytest
 
@@ -23,6 +23,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for inventory from cli, interactive, without ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/inventory/test_stdout_tmux.py
+++ b/tests/integration/actions/inventory/test_stdout_tmux.py
@@ -1,4 +1,5 @@
-""" inventory stdout tests using tmux """
+"""Tests for inventory from cli, stdout.
+"""
 import pytest
 
 from .base import BaseClass
@@ -93,6 +94,6 @@ def step_id(value):
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for inventory from cli, stdout."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/inventory/test_stdout_tmux.py
+++ b/tests/integration/actions/inventory/test_stdout_tmux.py
@@ -1,5 +1,4 @@
-"""Tests for inventory from cli, stdout.
-"""
+"""Tests for inventory from cli, stdout."""
 import pytest
 
 from .base import BaseClass

--- a/tests/integration/actions/inventory/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/inventory/test_welcome_interactive_ee.py
@@ -1,4 +1,4 @@
-""" inventory from welcome interactive w/ ee
+"""Tests for inventory from welcome, interactive, with ee.
 """
 import pytest
 
@@ -26,6 +26,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for inventory from cli, interactive, with ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/inventory/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/inventory/test_welcome_interactive_noee.py
@@ -1,4 +1,4 @@
-""" inventory from welcome interactive w/ ee
+"""Tests for inventory from welcome, interactive, without ee.
 """
 import pytest
 
@@ -26,6 +26,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for inventory from cli, interactive, without ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/replay/base.py
+++ b/tests/integration/actions/replay/base.py
@@ -40,7 +40,6 @@ class BaseClass:
     def test(self, request, tmux_session, index, user_input, comment, search_within_response):
         # pylint: disable=too-many-arguments
         """Run the tests for replay, mode and ee set in child class."""
-
         assert os.path.exists(PLAYBOOK_ARTIFACT)
         assert os.path.exists(TEST_CONFIG_FILE)
 

--- a/tests/integration/actions/replay/base.py
+++ b/tests/integration/actions/replay/base.py
@@ -1,4 +1,4 @@
-""" base class for replay interactive tests
+"""Base class for replay interactive tests.
 """
 import difflib
 import json
@@ -17,7 +17,7 @@ TEST_CONFIG_FILE = os.path.join(TEST_FIXTURE_DIR, "ansible-navigator.yml")
 
 
 class BaseClass:
-    """base class for interactive stdout tests"""
+    """Base class for replay interactive tests."""
 
     UPDATE_FIXTURES = False
 
@@ -38,11 +38,9 @@ class BaseClass:
             yield tmux_session
 
     def test(self, request, tmux_session, index, user_input, comment, search_within_response):
-        # pylint:disable=unused-argument
-        # pylint: disable=too-few-public-methods
         # pylint: disable=too-many-arguments
+        """Run the tests for replay, mode and ee set in child class."""
 
-        """test"""
         assert os.path.exists(PLAYBOOK_ARTIFACT)
         assert os.path.exists(TEST_CONFIG_FILE)
 
@@ -53,7 +51,7 @@ class BaseClass:
         ):
             update_fixtures(request, index, received_output, comment)
         dir_path, file_name = fixture_path_from_request(request, index)
-        with open(f"{dir_path}/{file_name}") as infile:
+        with open(file=f"{dir_path}/{file_name}", encoding="utf-8") as infile:
             expected_output = json.load(infile)["output"]
         assert expected_output == received_output, "\n" + "\n".join(
             difflib.unified_diff(expected_output, received_output, "expected", "received")

--- a/tests/integration/actions/replay/test_direct_interactive_ee.py
+++ b/tests/integration/actions/replay/test_direct_interactive_ee.py
@@ -1,4 +1,4 @@
-"""direct from cli interactive w/ ee
+"""Tests for replay from cli, interactive, with ee.
 """
 import pytest
 
@@ -21,6 +21,6 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment, search_within_response", testdata)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for replay from cli, interactive, with ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/replay/test_direct_interactive_noee.py
+++ b/tests/integration/actions/replay/test_direct_interactive_noee.py
@@ -1,4 +1,4 @@
-""" direct from cli interactive w/o ee
+"""Tests for replay from cli, interactive, without ee.
 """
 import pytest
 
@@ -20,6 +20,6 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment, search_within_response", testdata)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for images from cli, interactive, without ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/replay/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/replay/test_welcome_interactive_ee.py
@@ -1,4 +1,4 @@
-""" from welcome interactive w/ ee
+"""Tests for replay from welcome, interactive, with ee.
 """
 import pytest
 
@@ -23,6 +23,6 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment, search_within_response", testdata)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for images from welcome, interactive, with ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/replay/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/replay/test_welcome_interactive_noee.py
@@ -1,4 +1,4 @@
-""" from welcome interactive w/o ee
+"""Tests for replay from welcome, interactive, without ee.
 """
 import pytest
 
@@ -21,6 +21,6 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment, search_within_response", testdata)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for images from welcome, interactive, without ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/run/base.py
+++ b/tests/integration/actions/run/base.py
@@ -1,11 +1,13 @@
-""" base class for run interactive tests
+"""Base class for run interactive/stdout tests.
 """
 import difflib
 import json
 import os
-import pytest
 
 from typing import Optional
+
+import pytest
+
 from ..._interactions import SearchFor
 from ..._interactions import Step
 from ....defaults import FIXTURES_DIR
@@ -37,7 +39,7 @@ base_steps = (
 
 
 class BaseClass:
-    """base class for interactive/stdout run tests"""
+    """Base class for run interactive/stdout tests."""
 
     UPDATE_FIXTURES = False
     TEST_FOR_MODE: Optional[str] = None
@@ -59,10 +61,8 @@ class BaseClass:
             yield tmux_session
 
     def test(self, request, tmux_session, step):
-        # pylint:disable=unused-argument
-        # pylint: disable=too-few-public-methods
-        # pylint: disable=too-many-arguments
-        """test interactive/stdout config"""
+        # pylint: disable=too-many-branches
+        """Run the tests for run, mode and ee set in child class."""
 
         if step.search_within_response is SearchFor.HELP:
             search_within_response = ":help help"
@@ -113,7 +113,7 @@ class BaseClass:
 
         if not any((step.look_fors, step.look_nots)):
             dir_path, file_name = fixture_path_from_request(request, step.step_index)
-            with open(os.path.join(dir_path, file_name)) as infile:
+            with open(file=os.path.join(dir_path, file_name), encoding="utf-8") as infile:
                 expected_output = json.load(infile)["output"]
 
             assert expected_output == received_output, "\n" + "\n".join(

--- a/tests/integration/actions/run/test_direct_interactive_ee.py
+++ b/tests/integration/actions/run/test_direct_interactive_ee.py
@@ -1,4 +1,4 @@
-""" run direct from cli interactive with ee
+"""Tests for run from cli, interactive, with ee.
 """
 import pytest
 
@@ -30,6 +30,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for run from cli, interactive, with ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/run/test_direct_interactive_noee.py
+++ b/tests/integration/actions/run/test_direct_interactive_noee.py
@@ -1,4 +1,4 @@
-""" run direct from cli interactive w/o ee
+"""Tests for run from cli, interactive, without ee.
 """
 import pytest
 
@@ -30,6 +30,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for run from cli, interactive, without ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/run/test_stdout_tmux.py
+++ b/tests/integration/actions/run/test_stdout_tmux.py
@@ -1,4 +1,5 @@
-""" run stdout tests using tmux """
+"""Tests for run from cli, stdout.
+"""
 import pytest
 
 from .base import BaseClass
@@ -90,6 +91,6 @@ def step_id(value):
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for run from cli, stdout."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/run/test_stdout_tmux.py
+++ b/tests/integration/actions/run/test_stdout_tmux.py
@@ -1,5 +1,4 @@
-"""Tests for run from cli, stdout.
-"""
+"""Tests for run from cli, stdout."""
 import pytest
 
 from .base import BaseClass

--- a/tests/integration/actions/run/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/run/test_welcome_interactive_ee.py
@@ -1,4 +1,4 @@
-""" from welcome interactive with ee
+"""Tests for run from welcome, interactive, with ee.
 """
 import pytest
 
@@ -31,6 +31,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for run from welcome, interactive, with ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/run/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/run/test_welcome_interactive_noee.py
@@ -1,4 +1,4 @@
-""" from welcome interactive without ee
+"""Tests for run from welcome, interactive, without ee.
 """
 import pytest
 
@@ -31,6 +31,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for run from welcome, interactive, without ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/stdout/base.py
+++ b/tests/integration/actions/stdout/base.py
@@ -40,7 +40,6 @@ class BaseClass:
     def test(self, request, tmux_session, index, user_input, comment, search_within_response):
         # pylint:disable=too-many-arguments
         """Run the tests for stdout, mode and ee set in child class."""
-
         assert os.path.exists(ANSIBLE_PLAYBOOK)
         assert os.path.exists(TEST_CONFIG_FILE)
 

--- a/tests/integration/actions/stdout/base.py
+++ b/tests/integration/actions/stdout/base.py
@@ -1,4 +1,4 @@
-""" base class for stdout interactive tests
+"""Base class for stdout interactive tests.
 """
 import difflib
 import json
@@ -17,7 +17,7 @@ TEST_CONFIG_FILE = os.path.join(TEST_FIXTURE_DIR, "ansible-navigator.yml")
 
 
 class BaseClass:
-    """base class for interactive stdout tests"""
+    """Base class for stdout interactive stdout."""
 
     UPDATE_FIXTURES = False
 
@@ -38,11 +38,9 @@ class BaseClass:
             yield tmux_session
 
     def test(self, request, tmux_session, index, user_input, comment, search_within_response):
-        # pylint:disable=unused-argument
-        # pylint: disable=too-few-public-methods
-        # pylint: disable=too-many-arguments
+        # pylint:disable=too-many-arguments
+        """Run the tests for stdout, mode and ee set in child class."""
 
-        """test"""
         assert os.path.exists(ANSIBLE_PLAYBOOK)
         assert os.path.exists(TEST_CONFIG_FILE)
 
@@ -54,7 +52,7 @@ class BaseClass:
         ):
             update_fixtures(request, index, received_output, comment)
         dir_path, file_name = fixture_path_from_request(request, index)
-        with open(f"{dir_path}/{file_name}") as infile:
+        with open(file=f"{dir_path}/{file_name}", encoding="utf-8") as infile:
             expected_output = json.load(infile)["output"]
         assert expected_output == received_output, "\n" + "\n".join(
             difflib.unified_diff(expected_output, received_output, "expected", "received")

--- a/tests/integration/actions/stdout/test_direct_interactive_ee.py
+++ b/tests/integration/actions/stdout/test_direct_interactive_ee.py
@@ -1,4 +1,4 @@
-"""direct from cli interactive w/ ee
+"""Tests for stdout from cli, interactive, with ee.
 """
 import pytest
 
@@ -19,6 +19,6 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment, search_within_response", testdata)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for stdout from cli, interactive, with ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/stdout/test_direct_interactive_noee.py
+++ b/tests/integration/actions/stdout/test_direct_interactive_noee.py
@@ -1,4 +1,4 @@
-""" direct from cli interactive w/o ee
+"""Tests for stdout from cli, interactive, without ee.
 """
 import pytest
 
@@ -18,6 +18,6 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment, search_within_response", testdata)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for stdout from cli, interactive, without ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/stdout/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/stdout/test_welcome_interactive_ee.py
@@ -1,4 +1,4 @@
-""" from welcome interactive w/ ee
+"""Tests for stdout from welcome, interactive, with ee.
 """
 import pytest
 
@@ -6,7 +6,7 @@ from .base import BaseClass
 from .base import ANSIBLE_PLAYBOOK
 
 
-CLI = "ansible-navigator" " --execution-environment true"
+CLI = "ansible-navigator --execution-environment true"
 
 testdata = [
     (0, CLI, "welcome", ":help help"),
@@ -20,6 +20,6 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment, search_within_response", testdata)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for stdout from welcome, interactive, with ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/stdout/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/stdout/test_welcome_interactive_noee.py
@@ -1,4 +1,4 @@
-""" from welcome interactive w/o ee
+"""Tests for stdout from welcome, interactive, without ee.
 """
 import pytest
 
@@ -20,6 +20,6 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment, search_within_response", testdata)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for stdout from welcome, interactive, without ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -122,7 +122,7 @@ class BaseClass:
 
         if not any((step.look_fors, step.look_nots)):
             dir_path, file_name = fixture_path_from_request(request, step.step_index)
-            with open(os.path.join(dir_path, file_name)) as infile:
+            with open(file=os.path.join(dir_path, file_name), encoding="utf-8") as infile:
                 expected_output = json.load(infile)["output"]
 
             assert expected_output == received_output, "\n" + "\n".join(

--- a/tests/integration/actions/templar/test_direct_interactive_ee.py
+++ b/tests/integration/actions/templar/test_direct_interactive_ee.py
@@ -1,4 +1,4 @@
-""" run direct from cli interactive with ee
+"""Tests for templar from cli, interactive, with ee.
 """
 import pytest
 
@@ -30,6 +30,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for templar from cli, interactive, with ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/templar/test_direct_interactive_noee.py
+++ b/tests/integration/actions/templar/test_direct_interactive_noee.py
@@ -1,4 +1,4 @@
-""" run direct from cli interactive w/o ee
+"""Tests for templar from cli, interactive, without ee.
 """
 import pytest
 
@@ -30,6 +30,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for templar from cli, interactive, without ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/templar/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/templar/test_welcome_interactive_ee.py
@@ -1,4 +1,4 @@
-""" from welcome interactive with ee
+"""Tests for templar from welcome, interactive, with ee.
 """
 import pytest
 
@@ -31,6 +31,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for templar from welcome, interactive, with ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/templar/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/templar/test_welcome_interactive_noee.py
@@ -1,4 +1,4 @@
-""" from welcome interactive without ee
+"""Tests for templar from welcome, interactive, without ee.
 """
 import pytest
 
@@ -31,6 +31,6 @@ steps = add_indicies(initial_steps + base_steps)
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """run the tests"""
+    """Run the tests for templar from welcome, interactive, without ee."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/test_execution_environment.py
+++ b/tests/integration/test_execution_environment.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-import ansible_navigator.cli as cli
+from ansible_navigator import cli
 
 from ._cli2runner import Cli2Runner
 from ..defaults import FIXTURES_DIR

--- a/tests/integration/test_execution_environment_image.py
+++ b/tests/integration/test_execution_environment_image.py
@@ -1,4 +1,4 @@
-""" test the use of execution-environment-image throguh to runner
+"""Test the use of execution-environment-image through to runner.
 """
 import os
 import shlex
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-import ansible_navigator.cli as cli
+from ansible_navigator import cli
 
 from ._cli2runner import Cli2Runner
 from ..defaults import DEFAULT_CONTAINER_IMAGE

--- a/tests/integration/test_pass_environment_variable.py
+++ b/tests/integration/test_pass_environment_variable.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-import ansible_navigator.cli as cli
+from ansible_navigator import cli
 
 from ._cli2runner import Cli2Runner
 from ..defaults import FIXTURES_DIR
@@ -65,6 +65,7 @@ class Test(Cli2Runner):
     }
 
     def run_test(self, mocked_runner, tmpdir, cli_entry, config_fixture, expected):
+        # pylint: disable=too-many-arguments
         """mock the runner call so it raises an exception
         mock the command line with sys.argv
         set the ANSIBLE_NAVIGATOR_CONFIG envvar

--- a/tests/integration/test_set_environment_variable.py
+++ b/tests/integration/test_set_environment_variable.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-import ansible_navigator.cli as cli
+from ansible_navigator import cli
 
 from ._cli2runner import Cli2Runner
 from ..defaults import FIXTURES_DIR
@@ -65,7 +65,9 @@ class Test(Cli2Runner):
     }
 
     def run_test(self, mocked_runner, tmpdir, cli_entry, config_fixture, expected):
-        """mock the runner call so it raises an exception
+        # pylint: disable=too-many-arguments
+        """Mock the runner call so it raises an exception.
+
         mock the command line with sys.argv
         set the ANSIBLE_NAVIGATOR_CONFIG envvar
         call cli.main(), check the kwarg envvars passed to the runner func


### PR DESCRIPTION
Related #643 

- does what it says
- formatted/added specifics to doc strings as encountered
- remove unneeded pylint disables as encountered
- one constant name correction made when seen