### PR TITLE
Add MVP GHA workflows

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,78 @@
+name: tox
+
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
+on:
+  create:  # is used for publishing to PyPI and TestPyPI
+    tags:  # any tag regardless of its name, no branches
+      - "**"
+  push:  # only publishes pushes to the main branch to TestPyPI
+    branches:  # any integration branch but not tag
+      - "main"
+  pull_request:
+
+jobs:
+  tox:
+    name: ${{ matrix.tox_env }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        tox_env:
+          - lint
+          - build-docs
+        python-version:
+          - 3.8
+        include:
+          - tox_env: lint-vetting
+            devel: true
+          - tox_env: py36
+            python-version: 3.6
+          - tox_env: py37
+            python-version: 3.7
+          - tox_env: py38
+            python-version: 3.8
+          - tox_env: py39
+            python-version: 3.9
+          - tox_env: py310
+            python-version: "3.10"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # needed by setuptools-scm
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: >-
+          Log the currently selected Python
+          version info (${{ matrix.python-version }})
+        run: |
+          python --version --version
+          which python
+      - name: Install tox
+        run: |
+          python3 -m pip install --upgrade tox
+      - name: Log installed dists
+        run: >-
+          python3 -m pip freeze --all
+      - name: "tox -e ${{ matrix.tox_env }}"
+        continue-on-error: ${{ matrix.devel || false }}
+        run: |
+          python3 -m tox
+        env:
+          TOXENV: ${{ matrix.tox_env }}
+
+  check:
+    if: always()
+
+    needs:
+      - tox
+    runs-on: ubuntu-latest
+    steps:
+      - name: Done!
+        run: echo "Done!"

--- a/tests/integration/actions/config/test_welcome_interactive_param_use.py
+++ b/tests/integration/actions/config/test_welcome_interactive_param_use.py
@@ -17,7 +17,6 @@ steps = (
         user_input=":config",
         comment="enter config from welcome screen",
         mask=False,
-        look_nots=["/home/runner"],
         look_fors=["ANSIBLE_CACHE_PLUGIN_TIMEOUT", "42"],
     ),
     Step(user_input=":back", comment="return to welcome screen"),

--- a/tests/integration/actions/config/test_welcome_interactive_specified_config.py
+++ b/tests/integration/actions/config/test_welcome_interactive_specified_config.py
@@ -18,7 +18,6 @@ steps = (
         user_input=":config",
         comment="enter config from welcome screen (no ee)",
         mask=False,
-        look_nots=["/home/runner"],
         look_fors=["YAML_FILENAME_EXTENSIONS", "['.yml', '.yaml', '.json']"],
     ),
     Step(user_input=":back", comment="return to welcome screen"),
@@ -26,7 +25,6 @@ steps = (
         user_input=":config -c " + CONFIG_FIXTURE,
         comment="enter config from welcome screen, custom config, (no ee)",
         mask=False,
-        look_nots=["/home/runner"],
         look_fors=["YAML_FILENAME_EXTENSIONS", "['.yahmool']"],
     ),
 )


### PR DESCRIPTION
This change aims to add a MVP implementation of GHA that replicates current zuul config.

Deliberately it does not include features that are not already covered by zuul jobs, and it also does not include a release pipeline.


The `look_nots` are being removed because `/home/runner` was used as a check in those tests to confirm that the test was not running in an EE.   Because GHA uses `runner` as the default user in it's images, we cannot use this test in the future.  