### PR TITLE
Reinstate linters zuul job

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -27,3 +27,12 @@
     vars:
       tox_envlist: smoke
       tox_extra_args: -vv --skip-missing-interpreters false
+
+- job:
+    name: ansible-navigator-tox-lint
+    parent: ansible-tox-py38
+    vars:
+      tox_envlist: linters,type
+      tox_extra_args: -vv --skip-missing-interpreters false
+    # TODO: remove once we fix linters
+    voting: false

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -3,6 +3,7 @@
     check:
       jobs: &id001
         - ansible-buildset-registry
+        - ansible-navigator-tox-lint
         - ansible-navigator-tox-py38
         - ansible-navigator-tox-smoke
     gate:


### PR DESCRIPTION
Adds back lint zuul job as non-voting until we can fix all linting errors.

Related: https://github.com/ansible/ansible-navigator/pull/665