### PR TITLE
Only run flake8 on manual invocations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,9 @@
 ---
 
+ci:
+  skip:
+  - flake8
+
 repos:
 - repo: https://github.com/asottile/add-trailing-comma.git
   rev: v2.0.1


### PR DESCRIPTION
This cannot run in `pre-commit.ci` because it's too heavy.