### PR TITLE
Add a config for darglint

### DIFF
--- a/.darglint
+++ b/.darglint
@@ -1,0 +1,8 @@
+[darglint]
+# NOTE: All `darglint` styles except for `sphinx` hit ridiculously low
+# NOTE: performance on some of the in-project Python modules.
+# Refs:
+# * https://github.com/terrencepreilly/darglint/issues/186
+# * https://github.com/wemake-services/wemake-python-styleguide/issues/2287
+docstring_style = sphinx
+strictness = full


### PR DESCRIPTION
This config explicitly specifies what is expected from the already
integrated linter plugin.