### PR TITLE
[tests] Update 2 periodically failing tests

### DIFF
--- a/tests/fixtures/integration/actions/inventory/test_stdout_tmux.py/test/0.json
+++ b/tests/fixtures/integration/actions/inventory/test_stdout_tmux.py/test/0.json
@@ -3,9 +3,12 @@
     "index": 0,
     "comment": "inventory list with ee",
     "additional_information": {
-        "look_fors": [],
+        "look_fors": [
+            "_meta",
+            "group03"
+        ],
         "look_nots": [],
-        "compared_fixture": true
+        "compared_fixture": false
     },
     "output": [
         "{",

--- a/tests/fixtures/integration/actions/inventory/test_stdout_tmux.py/test/1.json
+++ b/tests/fixtures/integration/actions/inventory/test_stdout_tmux.py/test/1.json
@@ -3,9 +3,12 @@
     "index": 1,
     "comment": "inventory list without ee",
     "additional_information": {
-        "look_fors": [],
+        "look_fors": [
+            "_meta",
+            "group03"
+        ],
         "look_nots": [],
-        "compared_fixture": true
+        "compared_fixture": false
     },
     "output": [
         "{",

--- a/tests/fixtures/integration/actions/inventory/test_stdout_tmux.py/test/2.json
+++ b/tests/fixtures/integration/actions/inventory/test_stdout_tmux.py/test/2.json
@@ -1,0 +1,44 @@
+{
+    "name": "test[inventory help with ee  clear && ansible-navigator inventory --help-inventory --ee True --ll debug --mode stdout]",
+    "index": 2,
+    "comment": "inventory help with ee",
+    "additional_information": {
+        "look_fors": [
+            "usage: ansible-inventory [-h]"
+        ],
+        "look_nots": [],
+        "compared_fixture": false
+    },
+    "output": [
+        "usage: ansible-inventory [-h] [--version] [-v] [-i INVENTORY] [--vault-id VAULT_IDS] [--ask-vault-password | --vault-password-file VAULT_PASSWORD_FILES] [--playbook-dir BASEDIR] [-e EXTRA_VARS] [--list] [--host HOST] [--graph] [-y] [--toml] [--vars] [--export] [--output OUTPUT_FILE] [host|group]",
+        "positional arguments:",
+        "  host|group",
+        "optional arguments:",
+        "  --ask-vault-password, --ask-vault-pass",
+        "                        ask for vault password",
+        "  --export              When doing an --list, represent in a way that is optimized for export,not as an accurate representation of how Ansible has processed it",
+        "  --output OUTPUT_FILE  When doing --list, send the inventory to a file instead of to the screen",
+        "  --playbook-dir BASEDIR",
+        "                        Since this tool does not use playbooks, use this as a substitute playbook directory.This sets the relative path for many features including roles/ group_vars/ etc.",
+        "  --toml                Use TOML format instead of default JSON, ignored for --graph",
+        "  --vars                Add vars to graph display, ignored unless used with --graph",
+        "  --vault-id VAULT_IDS  the vault identity to use",
+        "  --vault-password-file VAULT_PASSWORD_FILES, --vault-pass-file VAULT_PASSWORD_FILES",
+        "                        vault password file",
+        "  --version             show program's version number, config file location, configured module search path, module location, executable location and exit",
+        "  -e EXTRA_VARS, --extra-vars EXTRA_VARS",
+        "                        set additional variables as key=value or YAML/JSON, if filename prepend with @",
+        "  -h, --help            show this help message and exit",
+        "  -i INVENTORY, --inventory INVENTORY, --inventory-file INVENTORY",
+        "                        specify inventory host path or comma separated host list. --inventory-file is deprecated",
+        "  -v, --verbose         verbose mode (-vvv for more, -vvvv to enable connection debugging)",
+        "  -y, --yaml            Use YAML format instead of default JSON, ignored for --graph",
+        "Actions:",
+        "  One of following must be used on invocation, ONLY ONE!",
+        "  --graph               create inventory graph, if supplying pattern it must be a valid group name",
+        "  --host HOST           Output specific host info, works as inventory script",
+        "  --list                Output all hosts info, works as inventory script",
+        "Show Ansible inventory information, by default it uses the inventory script JSON format",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    ]
+}

--- a/tests/fixtures/integration/actions/inventory/test_stdout_tmux.py/test/3.json
+++ b/tests/fixtures/integration/actions/inventory/test_stdout_tmux.py/test/3.json
@@ -1,0 +1,44 @@
+{
+    "name": "test[inventory help without ee  clear && ansible-navigator inventory --help-inventory --ee False --ll debug --mode stdout]",
+    "index": 3,
+    "comment": "inventory help without ee",
+    "additional_information": {
+        "look_fors": [
+            "usage: ansible-inventory [-h]"
+        ],
+        "look_nots": [],
+        "compared_fixture": false
+    },
+    "output": [
+        "usage: ansible-inventory [-h] [--version] [-v] [-i INVENTORY] [--vault-id VAULT_IDS] [--ask-vault-password | --vault-password-file VAULT_PASSWORD_FILES] [--playbook-dir BASEDIR] [-e EXTRA_VARS] [--list] [--host HOST] [--graph] [-y] [--toml] [--vars] [--export] [--output OUTPUT_FILE] [host|group]",
+        "positional arguments:",
+        "  host|group",
+        "options:",
+        "  --ask-vault-password, --ask-vault-pass",
+        "                        ask for vault password",
+        "  --export              When doing an --list, represent in a way that is optimized for export,not as an accurate representation of how Ansible has processed it",
+        "  --output OUTPUT_FILE  When doing --list, send the inventory to a file instead of to the screen",
+        "  --playbook-dir BASEDIR",
+        "                        Since this tool does not use playbooks, use this as a substitute playbook directory.This sets the relative path for many features including roles/ group_vars/ etc.",
+        "  --toml                Use TOML format instead of default JSON, ignored for --graph",
+        "  --vars                Add vars to graph display, ignored unless used with --graph",
+        "  --vault-id VAULT_IDS  the vault identity to use",
+        "  --vault-password-file VAULT_PASSWORD_FILES, --vault-pass-file VAULT_PASSWORD_FILES",
+        "                        vault password file",
+        "  --version             show program's version number, config file location, configured module search path, module location, executable location and exit",
+        "  -e EXTRA_VARS, --extra-vars EXTRA_VARS",
+        "                        set additional variables as key=value or YAML/JSON, if filename prepend with @",
+        "  -h, --help            show this help message and exit",
+        "  -i INVENTORY, --inventory INVENTORY, --inventory-file INVENTORY",
+        "                        specify inventory host path or comma separated host list. --inventory-file is deprecated",
+        "  -v, --verbose         verbose mode (-vvv for more, -vvvv to enable connection debugging)",
+        "  -y, --yaml            Use YAML format instead of default JSON, ignored for --graph",
+        "Actions:",
+        "  One of following must be used on invocation, ONLY ONE!",
+        "  --graph               create inventory graph, if supplying pattern it must be a valid group name",
+        "  --host HOST           Output specific host info, works as inventory script",
+        "  --list                Output all hosts info, works as inventory script",
+        "Show Ansible inventory information, by default it uses the inventory script JSON format",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    ]
+}

--- a/tests/fixtures/integration/actions/inventory/test_stdout_tmux.py/test/4.json
+++ b/tests/fixtures/integration/actions/inventory/test_stdout_tmux.py/test/4.json
@@ -1,0 +1,22 @@
+{
+    "name": "test[inventory help-inventory fail with interactive with ee  clear && ansible-navigator inventory --help-inventory --ee True --ll debug --mode interactive]",
+    "index": 4,
+    "comment": "inventory help-inventory fail with interactive with ee",
+    "additional_information": {
+        "look_fors": [
+            "--hi or --help-inventory is valid only when 'mode' argument is set to 'stdout'"
+        ],
+        "look_nots": [],
+        "compared_fixture": false
+    },
+    "output": [
+        "[ERROR]: Command provided: 'inventory --help-inventory --ee True --ll debug --mode interactive'",
+        "[ERROR]: --hi or --help-inventory is valid only when 'mode' argument is set to 'stdout'",
+        " [HINT]: Try again with '-m stdout'",
+        "[ERROR]: An inventory is required when using the inventory subcommand",
+        " [HINT]: Try again with '-i <path to inventory>'",
+        "[ERROR]: Configuration failed, using default log file location: /home/user/github/ansible-navigator/ansible-navigator.log. Log level set to debug",
+        " [HINT]: Review the hints and log file to see what went wrong: /home/user/github/ansible-navigator/ansible-navigator.log",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    ]
+}

--- a/tests/fixtures/integration/actions/inventory/test_stdout_tmux.py/test/5.json
+++ b/tests/fixtures/integration/actions/inventory/test_stdout_tmux.py/test/5.json
@@ -1,0 +1,22 @@
+{
+    "name": "test[inventory help-inventory fail with interactive without ee  clear && ansible-navigator inventory --help-inventory --ee False --ll debug --mode interactive]",
+    "index": 5,
+    "comment": "inventory help-inventory fail with interactive without ee",
+    "additional_information": {
+        "look_fors": [
+            "--hi or --help-inventory is valid only when 'mode' argument is set to 'stdout'"
+        ],
+        "look_nots": [],
+        "compared_fixture": false
+    },
+    "output": [
+        "[ERROR]: Command provided: 'inventory --help-inventory --ee False --ll debug --mode interactive'",
+        "[ERROR]: --hi or --help-inventory is valid only when 'mode' argument is set to 'stdout'",
+        " [HINT]: Try again with '-m stdout'",
+        "[ERROR]: An inventory is required when using the inventory subcommand",
+        " [HINT]: Try again with '-i <path to inventory>'",
+        "[ERROR]: Configuration failed, using default log file location: /home/user/github/ansible-navigator/ansible-navigator.log. Log level set to debug",
+        " [HINT]: Review the hints and log file to see what went wrong: /home/user/github/ansible-navigator/ansible-navigator.log",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    ]
+}

--- a/tests/integration/actions/inventory/test_stdout_tmux.py
+++ b/tests/integration/actions/inventory/test_stdout_tmux.py
@@ -30,6 +30,7 @@ stdout_tests = (
             mode="stdout",
             execution_environment=True,
         ).join(),
+        look_fors=["_meta", "group03"],
     ),
     ShellCommand(
         comment="inventory list without ee",
@@ -38,6 +39,7 @@ stdout_tests = (
             mode="stdout",
             execution_environment=False,
         ).join(),
+        look_fors=["_meta", "group03"],
     ),
     ShellCommand(
         comment="inventory help with ee",

--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -50,13 +50,17 @@ class BaseClass:
     @staticmethod
     @pytest.fixture(scope="module", name="tmux_session")
     def fixture_tmux_session(request):
-        """tmux fixture for this module"""
+        """tmux fixture for this module
+
+        The EDITOR is set here such that vim will not create swap files
+        """
         params = {
             "pane_height": "1000",
             "pane_width": "500",
             "setup_commands": [
                 "export ANSIBLE_DEVEL_WARNING=False",
                 "export ANSIBLE_DEPRECATION_WARNINGS=False",
+                "export EDITOR='vim -n'"
             ],
             "unique_test_id": request.node.nodeid,
         }

--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -50,9 +50,9 @@ class BaseClass:
     @staticmethod
     @pytest.fixture(scope="module", name="tmux_session")
     def fixture_tmux_session(request):
-        """tmux fixture for this module
+        """Return a new tmux session.
 
-        The EDITOR is set here such that vim will not create swap files
+        The EDITOR is set here such that vim will not create swap files.
         """
         params = {
             "pane_height": "1000",


### PR DESCRIPTION
The templar integration tests fail periodically, this _should_ fix that.

Since the file is `:opened` vim might be leaving a swap file:

```
'Found a swap file by the name '
 '"~/src/github.com/ansible/ansible-navigator/tests/fixtures/integration/actions/run/.site.yaml.swp"',
 '          owned by: zuul   dated: Tue Dec  7 18:52:13 2021',
 '         file name: '
 '~zuul/src/github.com/ansible/ansible-navigator/tests/fixtures/integration/actions/run/site.yaml',
 '          modified: no',
 '         user name: zuul   host name: '
 'centos-8-stream-vexxhost-sjc1-000204357',
 '        process ID: 76326 (still running)',
 'While opening file '
```

The inventory integration tests fail periodically, this _may_ fix that.

- additionally add some look_fors to failing inventory test (as a test)