### PR TITLE
Fix linting regressions

### DIFF
--- a/docs/_ext/spelling_stub_ext.py
+++ b/docs/_ext/spelling_stub_ext.py
@@ -19,9 +19,9 @@ class SpellingNoOpDirective(SphinxDirective):
 
 def setup(app: Sphinx) -> None:
     """Initialize the extension."""
-    app.add_directive('spelling', SpellingNoOpDirective)
+    app.add_directive("spelling", SpellingNoOpDirective)
 
     return {
-        'parallel_read_safe': True,
-        'version': 'builtin',
+        "parallel_read_safe": True,
+        "version": "builtin",
     }

--- a/src/ansible_navigator/utils.py
+++ b/src/ansible_navigator/utils.py
@@ -342,12 +342,14 @@ def get_share_directory(app_name) -> Tuple[List[LogMessage], List[ExitMessage], 
     exit_messages.append(ExitMessage(message=exit_msg))
     return messages, exit_messages, None
 
+
 def divmod_int(numerator: Union[int, float], denominator: Union[int, float]) -> Tuple[int, int]:
     """Return the result of divmod, as a tuple of integers."""
     quotient, remainder = divmod(numerator, denominator)
     return int(quotient), int(remainder)
 
-def human_time(seconds: int) -> str:
+
+def human_time(seconds: Union[int, float]) -> str:
     """Convert seconds into human readable 00d00h00m00s format."""
     sign_string = "-" if seconds < 0 else ""
     seconds = abs(int(seconds))


### PR DESCRIPTION
Fixes problems causing flake8, black and mypy to fail.

This is making `tox -e linters,type` pass, both of them were failing before this change as we had multiple pull-requests merged without running any linting in CI.

These fixes were originally included into https://github.com/ansible/ansible-navigator/pull/653 but I was asked to make them separately, even if it that would not allow proper testing on CI.