### PR TITLE
Fix the externally managed file by partialy reverting invalid "Fix linting regressions (#665)"

### DIFF
--- a/docs/_ext/spelling_stub_ext.py
+++ b/docs/_ext/spelling_stub_ext.py
@@ -19,9 +19,9 @@ class SpellingNoOpDirective(SphinxDirective):
 
 def setup(app: Sphinx) -> Dict[str, Union[bool, str]]:
     """Initialize the extension."""
-    app.add_directive("spelling", SpellingNoOpDirective)
+    app.add_directive('spelling', SpellingNoOpDirective)
 
     return {
-        "parallel_read_safe": True,
-        "version": "builtin",
+        'parallel_read_safe': True,
+        'version': 'builtin',
     }

--- a/docs/_ext/spelling_stub_ext.py
+++ b/docs/_ext/spelling_stub_ext.py
@@ -1,3 +1,4 @@
+# fmt: off
 """Sphinx extension for making the spelling directive noop."""
 
 from typing import Dict, List, Union


### PR DESCRIPTION
This fixes an invalid formatting change introduced by #665.