### PR TITLE
Move slow flake8 plugins to run manually

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 ---
+
 repos:
 - repo: https://github.com/asottile/add-trailing-comma.git
   rev: v2.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -227,6 +227,7 @@ repos:
     language_version: python3
     additional_dependencies:
     - flake8-2020 >= 1.6.0
+    - flake8-docstrings >= 1.5.0
     - flake8-pytest-style >= 1.2.2
 
 - repo: https://github.com/PyCQA/flake8.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -236,12 +236,13 @@ repos:
   hooks:
   - id: flake8
     language_version: python3
-    stages: ["manual"]
     additional_dependencies:
     - flake8-2020 >= 1.6.0
     - flake8-docstrings >= 1.5.0
     - flake8-pytest-style >= 1.2.2
     - wemake-python-styleguide ~= 0.15.0
+    stages:
+    - manual
 
 - repo: https://github.com/pre-commit/mirrors-mypy.git
   rev: v0.910

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,4 @@
 ---
-
-ci:
-  skip:
-  - flake8
-
 repos:
 - repo: https://github.com/asottile/add-trailing-comma.git
   rev: v2.0.1
@@ -230,6 +225,16 @@ repos:
   hooks:
   - id: flake8
     language_version: python3
+    additional_dependencies:
+    - flake8-2020 >= 1.6.0
+    - flake8-pytest-style >= 1.2.2
+
+- repo: https://github.com/PyCQA/flake8.git
+  rev: 3.9.2
+  hooks:
+  - id: flake8
+    language_version: python3
+    stages: ["manual"]
     additional_dependencies:
     - flake8-2020 >= 1.6.0
     - flake8-docstrings >= 1.5.0

--- a/docs/changelog-fragments.d/668.internal.md
+++ b/docs/changelog-fragments.d/668.internal.md
@@ -1,0 +1,4 @@
+Added an additional manually triggered slow flake8 check
+to [pre-commit] -- by {user}`ssbarnea` and {user}`webknjaz`
+
+[pre-commit]: https://pre-commit.com

--- a/docs/changelog-fragments.d/668.internal.md
+++ b/docs/changelog-fragments.d/668.internal.md
@@ -1,4 +1,2 @@
 Added an additional manually triggered slow flake8 check
 to [pre-commit] -- by {user}`ssbarnea` and {user}`webknjaz`
-
-[pre-commit]: https://pre-commit.com


### PR DESCRIPTION
This is fixing pre-commit.ci by avoiding two plugins which we did not
fully evaluate, one of them causing huge performance problems that
prevented use of pre-commit.ci and made local execution not practical.

We keep two other plugins as we already used them in order places and
they do not report problems.
