### PR TITLE
[lint] Add tests directory to pylint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ commands = coverage erase
 description = Enforce quality standards under {basepython} ({envpython})
 install_command = pip install {opts} {packages}
 commands =
-  pylint {[base]pkg_name} --ignore=tm_tokenize
+  pylint {[base]pkg_name} tests --ignore=tm_tokenize
   black -v --diff --check {toxinidir}
   flake8 {posargs}
   yamllint -s .


### PR DESCRIPTION
- This would enable pylint to run on the tests directory
- A number of other PRs have merged which cleaned up the test directory enough such that this should now be ok