### PR TITLE
zuul: remove dependency on ansible-runner

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -1,24 +1,11 @@
 ---
 - job:
     name: ansible-navigator-tox-py38
-    parent: ansible-buildset-registry-consumer
-    dependencies:
-      - ansible-buildset-registry
-    timeout: 5400
-    vars:
-      container_command: podman
-      tox_extra_args: -vv --skip-missing-interpreters false
-
-- job:
-    name: ansible-navigator-tox-py38
     parent: ansible-tox-py38
-    requires:
-      - python-base-container-image
-    required-projects:
-      - github.com/ansible/ansible-runner
     nodeset: centos-8-stream
+    pre-run: playbooks/pre-run.yaml
     vars:
-      tox_package_name: "{{ zuul.project.short_name }}"
+      tox_envlist: py38
       tox_extra_args: -vv --skip-missing-interpreters false
 
 - job:

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -2,7 +2,6 @@
 - project:
     check:
       jobs: &id001
-        - ansible-buildset-registry
         - ansible-navigator-tox-lint
         - ansible-navigator-tox-py38
         - ansible-navigator-tox-smoke

--- a/playbooks/pre-run.yaml
+++ b/playbooks/pre-run.yaml
@@ -1,0 +1,6 @@
+---
+- hosts: all:!appliance
+  tasks:
+    - name: Install podman
+      include_role:
+        name: ensure-podman


### PR DESCRIPTION
As we no longer need to perform cross testing of
changes between ansible-runner and ansible-navigator
we remove that dependency.

This greatly improves the performance of zuul testing
and lower the resources usage as we no longer need
to wait for the container to be built.
