### PR TITLE
Add tox-ini-fmt pre-commit hook (wip)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
 ---
 
 repos:
+- repo: https://github.com/tox-dev/tox-ini-fmt
+  rev: "0.5.1"
+  hooks:
+    - id: tox-ini-fmt
+      args: ["-p", "linters,type"]
 - repo: https://github.com/asottile/add-trailing-comma.git
   rev: v2.0.1
   hooks:

--- a/tox.ini
+++ b/tox.ini
@@ -1,190 +1,175 @@
-[base]
-pkg_name = ansible_navigator
-default_ee = quay.io/ansible/creator-ee:v0.2.0
-small_test_ee = quay.io/ansible/python-base
-mypy_tmp_dir = mypy_tmp_dir
-
 [tox]
-envlist = linters, type, py38, report, clean
-minversion = 3.16.1
-skipsdist = True
+envlist =
+    linters
+    type
+    py38
+    report
+    clean
+skipsdist = true
 skip_missing_interpreters = true
-
+minversion = 3.16.1
 
 [testenv]
 description = Run pytest under {basepython} ({envpython})
-# the pytest command line is not in the project.toml because of issues 
-# with catching breakpoints while debugging unit tests
-# the number of CPUs is set to 50% b/c CI timeout failures were more likely
-# the small test image is used an alternative to the default, but should be it
-# one of it's layer
-allowlist_externals = cat
-                      rm
-                      grep
-deps = -r{toxinidir}/requirements.txt
-       -r{toxinidir}/test-requirements.txt
+passenv =
+    HOME
+    USER
+    XDIST_CPU
+setenv =
+    TERM = xterm-256color
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
 commands =
     /bin/bash -c 'grep -FInrq "UPDATE_FIXTURES = True" ./tests && exit 1 || exit 0'
     /bin/bash -c 'podman pull {[base]default_ee} || docker pull {[base]default_ee}'
     /bin/bash -c 'podman pull {[base]small_test_ee} || docker pull {[base]small_test_ee}'
     /bin/bash -c 'py.test -vvvv -n `python -c "import multiprocessing; import os; print(int(os.environ.get(\"XDIST_CPU\") or multiprocessing.cpu_count()))"` --dist=loadfile --maxfail=15 --durations=100 --cov ansible_navigator --cov share --cov-report term-missing --cov-branch --showlocals'
-setenv =
-    TERM = xterm-256color
-passenv = HOME
-          USER
-          XDIST_CPU
-
-[testenv:clean]
-description = Erase coverage data
-deps = coverage
-skip_install = true
-commands = coverage erase
-           rm -rf ./{[base]mypy_tmp_dir}
+allowlist_externals =
+    cat
+    grep
+    rm
 
 [testenv:linters]
 description = Enforce quality standards under {basepython} ({envpython})
+commands =
+    pylint {[base]pkg_name} tests --ignore=tm_tokenize
+    black -v --diff --check {toxinidir}
+    flake8 {posargs}
+    yamllint -s .
 install_command = pip install {opts} {packages}
-commands =
-  pylint {[base]pkg_name} tests --ignore=tm_tokenize
-  black -v --diff --check {toxinidir}
-  flake8 {posargs}
-  yamllint -s .
-
-[testenv:report]
-description = Produce coverage report
-deps = coverage
-skip_install = true
-commands =
-    coverage report
-    cat ./{[base]mypy_tmp_dir}/index.txt
-
-# Note included in the default envlist above since it's destructive
-# (requires tmux, git, runs a bunch of commands, etc.)
-[testenv:smoke]
-description = Run smoke tests under {basepython} ({envpython})
-commands = ansible-playbook tests/smoketests/run.yml
-allowlist_externals = ansible-playbook
 
 [testenv:type]
 description = Verify static typing with MyPy under {basepython} ({envpython})
 commands =
     mypy --txt-report ./{[base]mypy_tmp_dir} ./src/{[base]pkg_name} ./tests ./share
 
+[testenv:report]
+description = Produce coverage report
+skip_install = true
+deps =
+    coverage
+commands =
+    coverage report
+    cat ./{[base]mypy_tmp_dir}/index.txt
+
+[testenv:clean]
+description = Erase coverage data
+skip_install = true
+deps =
+    coverage
+commands =
+    coverage erase
+    rm -rf ./{[base]mypy_tmp_dir}
+
+[testenv:smoke]
+description = Run smoke tests under {basepython} ({envpython})
+commands =
+    ansible-playbook tests/smoketests/run.yml
+allowlist_externals = ansible-playbook
 
 [testenv:lint]
 description =
-  Enforce quality standards under `{basepython}` ({envpython})
-commands =
-  {envpython} -m \
-    pre_commit run \
-    --show-diff-on-failure \
-    --hook-stage manual \
-    {posargs:--all-files -v}
-
-  # Print out the advice on how to install pre-commit from this env into Git:
-  -{envpython} -c \
-  'cmd = "{envpython} -m pre_commit install"; \
-    scr_width = len(cmd) + 10; \
-    sep = "=" * scr_width; \
-    cmd_str = "    $ \{cmd\}";' \
-    'print(f"\n\{sep\}\nTo install pre-commit hooks into the Git repo, run:\n\n\{cmd_str\}\n\n\{sep\}\n")'
-deps =
-  pre-commit
-  pylint ~= 2.8.0
-  pylint-pytest < 1.1.0
-isolated_build = true
+    Enforce quality standards under `{basepython}` ({envpython})
 skip_install = true
-
+deps =
+    pre-commit
+    pylint~=2.8.0
+    pylint-pytest<1.1.0
+commands =
+    {envpython} -m \
+      pre_commit run \
+      --show-diff-on-failure \
+      --hook-stage manual \
+      {posargs:--all-files -v}
+    -{envpython} -c \
+      'cmd = "{envpython} -m pre_commit install"; \
+      scr_width = len(cmd) + 10; \
+      sep = "=" * scr_width; \
+      cmd_str = "    $ \{cmd\}";' \
+      'print(f"\n\{sep\}\nTo install pre-commit hooks into the Git repo, run:\n\n\{cmd_str\}\n\n\{sep\}\n")'
+isolated_build = true
 
 [testenv:build-docs]
-allowlist_externals =
-  git
-deps =
-  -r{toxinidir}/docs/requirements.in
-  # FIXME: re-enable the "-r" + "-c" paradigm once the pip bug is fixed.
-  # Ref: https://github.com/pypa/pip/issues/9243
-  # -r{toxinidir}/docs/requirements.in
-  # -c{toxinidir}/docs/requirements.txt
 description = Build The Docs
-changedir = {toxinidir}/docs
-commands =
-  # Retrieve possibly missing commits:
-  -git fetch --unshallow
-  -git fetch --tags
-
-  # Build the html docs with Sphinx:
-  {envpython} -m sphinx \
-    -j auto \
-    -b html \
-    {tty:--color} \
-    -a \
-    -n \
-    -W --keep-going \
-    -d "{temp_dir}/.doctrees" \
-    . \
-    "{envdir}/docs_out"
-
-  # Print out the output docs dir and a way to serve html:
-  -{envpython} -c\
-  'import pathlib;\
-  docs_dir = pathlib.Path(r"{envdir}") / "docs_out";\
-  index_file = docs_dir / "index.html";\
-  print("\n" + "=" * 120 +\
-  f"\n\nDocumentation available under:\n\n\
-  \tfile://\{index_file\}\n\nTo serve docs, use\n\n\
-  \t$ python3 -m http.server --directory \
-  \N\{QUOTATION MARK\}\{docs_dir\}\N\{QUOTATION MARK\} 0\n\n" +\
-  "=" * 120)'
-isolated_build = true
 passenv =
-  SSH_AUTH_SOCK
+    SSH_AUTH_SOCK
 skip_install = false
 usedevelop = true
-
+deps =
+    -r{toxinidir}/docs/requirements.in
+changedir = {toxinidir}/docs
+commands =
+    -git fetch --unshallow
+    -git fetch --tags
+    {envpython} -m sphinx \
+      -j auto \
+      -b html \
+      {tty:--color} \
+      -a \
+      -n \
+      -W --keep-going \
+      -d "{temp_dir}/.doctrees" \
+      . \
+      "{envdir}/docs_out"
+    -{envpython} -c \
+      'import pathlib; \
+      docs_dir = pathlib.Path(r"{envdir}") / "docs_out"; \
+      index_file = docs_dir / "index.html"; \
+      print("\n" + "=" * 120 + \
+      f"\n\nDocumentation available under:\n\n \
+      \tfile://\{index_file\}\n\nTo serve docs, use\n\n \
+      \t$ python3 -m http.server --directory \
+      \N\{QUOTATION MARK\}\{docs_dir\}\N\{QUOTATION MARK\} 0\n\n" + \
+      "=" * 120)'
+allowlist_externals =
+    git
+isolated_build = true
 
 [testenv:make-changelog]
-basepython = python3
-depends =
-  check-changelog
 description =
-  Generate a changelog from fragments using Towncrier. Getting an
-  unreleased changelog preview does not require extra arguments.
-  When invoking to update the changelog, pass the desired version as an
-  argument after `--`. For example, `tox -e {envname} -- 1.3.2`.
-commands =
-  {envpython} -m \
-    towncrier.build \
-    --version \
-    {posargs:'[UNRELEASED DRAFT]' --draft}
-deps =
-  towncrier == 21.3.0
-isolated_build = true
+    Generate a changelog from fragments using Towncrier. Getting an
+    unreleased changelog preview does not require extra arguments.
+    When invoking to update the changelog, pass the desired version as an
+    argument after `--`. For example, `tox -e {envname} -- 1.3.2`.
+basepython = python3
 skip_install = true
-
+deps =
+    towncrier==21.3
+commands =
+    {envpython} -m \
+      towncrier.build \
+      --version \
+      {posargs:'[UNRELEASED DRAFT]' --draft}
+depends =
+    check-changelog
+isolated_build = true
 
 [testenv:check-changelog]
-basepython = {[testenv:make-changelog]basepython}
 description =
-  Check Towncrier change notes
-commands =
-  {envpython} -m \
-    towncrier.check \
-    --compare-with origin/main \
-    {posargs:}
+    Check Towncrier change notes
+basepython = {[testenv:make-changelog]basepython}
+skip_install = false
 deps =
-  {[testenv:make-changelog]deps}
+    {[testenv:make-changelog]deps}
+commands =
+    {envpython} -m \
+      towncrier.check \
+      --compare-with origin/main \
+      {posargs:}
 isolated_build = {[testenv:make-changelog]isolated_build}
-skip_install = {[testenv:make-changelog]skip_install}
 
+[base]
+pkg_name = ansible_navigator
+default_ee = quay.io/ansible/creator-ee:v0.2.0
+small_test_ee = quay.io/ansible/python-base
+mypy_tmp_dir = mypy_tmp_dir
 
 [flake8]
-# E203 skipped because it annoys black.
-# no pyproject.toml support https://gitlab.com/pycqa/flake8/-/issues/428
 show-source = true
 extend-ignore =
     E203,
     F401,
-    # FIXME:
     C409,
     C414,
     Q000,
@@ -286,11 +271,8 @@ extend-ignore =
 max-line-length = 100
 builtins = _
 extend-exclude =
-    # skip tool cache dirs
     *_cache
-    # skip project env vars
     .env,
-    # skip adjacent venv
     venv
 per-file-ignores =
     src/ansible_navigator/actions/sample_working.py: D107, D200, D210, D400, DAR101, I001, I003, I005


### PR DESCRIPTION
In order to avoid random indentation and ordering of tox.ini options, we now use tox-ini-fmt to ensure a consistent content.

[tox-ini-fmt](https://github.com/tox-dev/tox-ini-fmt) was created by the current maintainer of tox so you cannot get more official than that. The main benefit is that we no longer need to manually correct human indentation mistakes, it will fix them for us.

As clearly documented, non tox sections are not touched, only moved to the end of file. In fact use of non tox sections inside tox.ini file is discouraged and something we should look into sort in a follow-up.

Note that the content of that `tox.ini` was the result of running the hook, I did not make any other manual change to it. Still, I find the outcome a net improvement over the old one.