### PR TITLE
Ensure flake8 and yamllint run from pre-commit

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,4 +1,6 @@
-# Needed for Zuul (CI) to run smoke tests
+# Needed for Zuul (CI) to run smoke and lint
+gcc [test]
 git [test]
+python3-devel [test]
 tmux [test]
 vim [test]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,12 +1,11 @@
 ansible-core
 black
-flake8
 libtmux
 lxml
 mypy
+pre-commit
 pylint < 2.9  # v2.9.0 introduced a check for `with` which is not yet fixed
 pytest-cov
 pytest-xdist
 types-dataclasses
 types-PyYAML
-yamllint

--- a/tox.ini
+++ b/tox.ini
@@ -49,10 +49,9 @@ commands =
 description = Enforce quality standards under {basepython} ({envpython})
 install_command = pip install {opts} {packages}
 commands =
+  pre-commit run -a {posargs}
   pylint {[base]pkg_name} tests --ignore=tm_tokenize
   black -v --diff --check {toxinidir}
-  flake8 {posargs}
-  yamllint -s .
 
 [testenv:report]
 description = Produce coverage report


### PR DESCRIPTION
Instead of running flake8 and yamllint in two different ways, we run pre-commit from tox -e linters. This allows
us avoid surprises cause by different tool versions.

The plan is to do the same for the other linters in follow-up.
