### PR TITLE
Add initial CoC/contributing/security docs infrastructure

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+# Community Code of Conduct
+
+Please see the official [Ansible Community Code of Conduct][CoC].
+
+[CoC]:
+https://docs.ansible.com/ansible/latest/community/code_of_conduct.html

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to Ansible Navigator
+
+In order to contribute, you'll need to:
+
+1. Fork the repository.
+
+2. Create a branch, push your changes there. Don't forget to
+   {ref}`include news files for the changelog <_ansible_navigator_adding_changelog_fragments>`.
+
+3. Send it to us as a PR.
+
+4. Iterate on your PR, incorporating the requested improvements
+   and participating in the discussions.
+
+Prerequisites:
+
+1. Have {doc}`tox <tox:index>`.
+
+2. Use {doc}`tox <tox:index>` to run the tests.
+
+3. Before sending a PR, make sure that the linters pass:
+
+   ```shell-session
+   $ tox -e linters
+   linters create: .tox/linters
+   linters installdeps: -rrequirements.txt, -rtest-requirements.txt
+   linters installed: ...
+   linters run-test-pre: PYTHONHASHSEED='4242713142'
+   linters run-test: commands[0] | pylint ansible_navigator tests ...
+   ...
+   ```
+
+4. We also suggest you to _optionally_ run the following check that is
+   not yet enforced (meaning you can skip it, especially since it's
+   annoyingly slow):
+
+   ```shell-session
+   $ tox -e lint
+   lint create: .tox/lint
+   lint installdeps: pre-commit, pylint ~= 2.8.0, pylint-pytest < 1.1.0
+   lint installed: ...
+   lint run-test-pre: PYTHONHASHSEED='2351399476'
+   lint run-test: commands[0] | python -m pre_commit run ... --all-files -v
+   ...
+   [INFO] Initializing environment for https://github.com/asottile/add-trailing-comma.git.
+   ...
+   [INFO] Installing environment for https://github.com/asottile/add-trailing-comma.git.
+   [INFO] Once installed this environment will be reused.
+   [INFO] This may take a few minutes...
+   ...
+   Add trailing commas..................................(no files to check)Skipped
+   - hook id: add-trailing-comma
+   ...
+   ```

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+Ansible Navigator does not backport security fixes only applying
+them to the main branch and making the next patch release in the stream.
+
+## Reporting a Vulnerability
+
+We encourage responsible disclosure practices for security
+vulnerabilities. Please read our [policies for reporting bugs][bug
+reports policy] if you want to report a security issue that might affect
+Ansible.
+
+[bug reports policy]:
+https://docs.ansible.com/ansible/devel/community/reporting_bugs_and_features.html#reporting-a-bug

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,7 +105,7 @@ repos:
         (
           \.github/ISSUE_TEMPLATE/\w+|
           docs/(
-            changelog-fragments\.d/\d+\.\w+|
+            changelog-fragments\.d/\d+\.\w+(\.\d+)?|
             faq|
             index|
             installation

--- a/docs/changelog-fragments.d/680.internal.1.md
+++ b/docs/changelog-fragments.d/680.internal.1.md
@@ -1,0 +1,2 @@
+Added an initial contributing guidelines infrastructure
+to the documentation -- by {user}`webknjaz`

--- a/docs/changelog-fragments.d/680.internal.2.md
+++ b/docs/changelog-fragments.d/680.internal.2.md
@@ -1,0 +1,1 @@
+Added an security guideline to the repository -- by {user}`webknjaz`

--- a/docs/changelog-fragments.d/680.internal.3.md
+++ b/docs/changelog-fragments.d/680.internal.3.md
@@ -1,0 +1,1 @@
+Added Code Of Conduct pointers to the repository -- by {user}`webknjaz`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -234,8 +234,10 @@ extlinks = {
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "ansible-runner": ("https://ansible-runner.rtfd.io/en/latest", None),
+    'myst': ('https://myst-parser.rtfd.io/en/latest', None),
     "python": ("https://docs.python.org/3", None),
     "python2": ("https://docs.python.org/2", None),
+    'tox': ('https://tox.wiki/en/latest', None),
 }
 
 # -- Options for sphinxcontrib.apidoc extension ------------------------------

--- a/docs/contributing/code_of_conduct.md
+++ b/docs/contributing/code_of_conduct.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable first-line-heading -->
+```{include} ../../.github/CODE_OF_CONDUCT.md
+```

--- a/docs/contributing/guidelines.md
+++ b/docs/contributing/guidelines.md
@@ -1,0 +1,58 @@
+<!-- markdownlint-disable first-line-heading -->
+```{spelling}
+de
+facto
+linters
+Pre
+reStructuredText
+Towncrier
+```
+
+```{include} ../../.github/CONTRIBUTING.md
+```
+
+# Contributing docs
+
+We use [Sphinx] to generate our docs website. You can trigger
+the process locally by executing:
+
+```shell-session
+$ tox -e build-docs
+build-docs create: .tox/build-docs
+build-docs installdeps: -rdocs/requirements.txt
+...
+
+========================================================================================================================
+
+Documentation available under:
+
+    file://.tox/build-docs/docs_out/index.html
+
+To serve docs, use
+
+    $ python3 -m http.server --directory  ".tox/build-docs/docs_out" 0
+
+========================================================================================================================
+_______________________________________________________ summary ________________________________________________________
+  build-docs: commands succeeded
+  congratulations :)
+```
+
+It is also integrated with [Read The Docs] that builds and
+publishes each commit to the main branch and generates live
+docs previews for each pull request.
+
+The sources of the [Sphinx] documents use reStructuredText as a
+de-facto standard. But in order to make contributing docs more
+beginner-friendly, we have integrated [MyST parser] allowing us
+to also accept new documents written in an extended version of
+Markdown that supports using Sphinx directives and roles.
+{ref}`Read the docs <myst:intro/writing>` to learn more on how
+to use it.
+
+[MyST parser]: https://pypi.org/project/myst-parser/
+[Read The Docs]: https://readthedocs.org
+[Sphinx]: https://www.sphinx-doc.org
+
+```{include} ../changelog-fragments.d/README.md
+```

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -1,0 +1,7 @@
+<!-- markdownlint-disable first-line-heading -->
+```{spelling}
+backport
+```
+
+```{include} ../../.github/SECURITY.md
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ changelog
 :caption: Contributions
 :hidden:
 
+contributing/security
 contributing/guidelines
 Private unsupported (dev) API autodoc <pkg/modules>
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ changelog
 :caption: Contributions
 :hidden:
 
+Code Of Conduct <contributing/code_of_conduct>
 contributing/security
 contributing/guidelines
 Private unsupported (dev) API autodoc <pkg/modules>

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,5 +39,6 @@ changelog
 :caption: Contributions
 :hidden:
 
+contributing/guidelines
 Private unsupported (dev) API autodoc <pkg/modules>
 ```


### PR DESCRIPTION
This is mostly copy-paste and it intentionally skips polishing or debating on the standards. It is supposed to be a base that would be improved/reworded/refactored post-merge.

Preview: https://ansible-navigator--680.org.readthedocs.build/en/680/contributing/guidelines/