### PR TITLE
Use a 2-line base indentation style @ tox sections

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,32 +14,36 @@ skip_missing_interpreters = true
 [testenv]
 description = Run pytest under {basepython} ({envpython})
 # the pytest command line is not in the project.toml because of issues 
-# with catching breakpoints while debugging unit tests
-# the number of CPUs is set to 50% b/c CI timeout failures were more likely
-# the small test image is used an alternative to the default, but should be it
+# with catching breakpoints while debugging unit tests the number of
+# CPUs is set to 50% b/c CI timeout failures were more likely the small
+# test image is used an alternative to the default, but should be it
 # one of it's layer
-allowlist_externals = cat
-                      rm
-                      grep
-deps = -r{toxinidir}/requirements.txt
-       -r{toxinidir}/test-requirements.txt
+allowlist_externals =
+  cat
+  rm
+  grep
+deps =
+  -r{toxinidir}/requirements.txt
+  -r{toxinidir}/test-requirements.txt
 commands =
-    /bin/bash -c 'grep -FInrq "UPDATE_FIXTURES = True" ./tests && exit 1 || exit 0'
-    /bin/bash -c 'podman pull {[base]default_ee} || docker pull {[base]default_ee}'
-    /bin/bash -c 'podman pull {[base]small_test_ee} || docker pull {[base]small_test_ee}'
-    /bin/bash -c 'py.test -vvvv -n `python -c "import multiprocessing; import os; print(int(os.environ.get(\"XDIST_CPU\") or multiprocessing.cpu_count()))"` --dist=loadfile --maxfail=15 --durations=100 --cov ansible_navigator --cov share --cov-report term-missing --cov-branch --showlocals'
+  /bin/bash -c 'grep -FInrq "UPDATE_FIXTURES = True" ./tests && exit 1 || exit 0'
+  /bin/bash -c 'podman pull {[base]default_ee} || docker pull {[base]default_ee}'
+  /bin/bash -c 'podman pull {[base]small_test_ee} || docker pull {[base]small_test_ee}'
+  /bin/bash -c 'py.test -vvvv -n `python -c "import multiprocessing; import os; print(int(os.environ.get(\"XDIST_CPU\") or multiprocessing.cpu_count()))"` --dist=loadfile --maxfail=15 --durations=100 --cov ansible_navigator --cov share --cov-report term-missing --cov-branch --showlocals'
 setenv =
-    TERM = xterm-256color
-passenv = HOME
-          USER
-          XDIST_CPU
+  TERM = xterm-256color
+passenv =
+  HOME
+  USER
+  XDIST_CPU
 
 [testenv:clean]
 description = Erase coverage data
 deps = coverage
 skip_install = true
-commands = coverage erase
-           rm -rf ./{[base]mypy_tmp_dir}
+commands =
+  coverage erase
+  rm -rf ./{[base]mypy_tmp_dir}
 
 [testenv:linters]
 description = Enforce quality standards under {basepython} ({envpython})
@@ -66,9 +70,12 @@ commands = ansible-playbook tests/smoketests/run.yml
 allowlist_externals = ansible-playbook
 
 [testenv:type]
-description = Verify static typing with MyPy under {basepython} ({envpython})
+description =
+  Verify static typing with MyPy under {basepython} ({envpython})
 commands =
-    mypy --txt-report ./{[base]mypy_tmp_dir} ./src/{[base]pkg_name} ./tests ./share
+  mypy \
+    --txt-report ./{[base]mypy_tmp_dir} \
+    ./src/{[base]pkg_name} ./tests ./share
 
 
 [testenv:lint]


### PR DESCRIPTION
This is a less intrusive version of #677 that implements the same goals. I've skipped touching the non-tox section `[flake8]` because about to be moved out in a parallel effort. The comment reflow matches most of the other ones but changing long bash commands has also been skipped because editing them is scary (tox tends to break these if they are split incorrectly).