### PR TITLE
Ensure mypy runs via pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,7 +131,6 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
-mypy_tmp_dir/
 
 # Pyre type checker
 .pyre/

--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -19,7 +19,7 @@
     name: ansible-navigator-tox-lint
     parent: ansible-tox-py38
     vars:
-      tox_envlist: linters,type
+      tox_envlist: linters
       tox_extra_args: -vv --skip-missing-interpreters false
 
 - job:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,10 +2,7 @@ ansible-core
 black
 libtmux
 lxml
-mypy
 pre-commit
 pylint < 2.9  # v2.9.0 introduced a check for `with` which is not yet fixed
 pytest-cov
 pytest-xdist
-types-dataclasses
-types-PyYAML

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 pkg_name = ansible_navigator
 default_ee = quay.io/ansible/creator-ee:v0.2.0
 small_test_ee = quay.io/ansible/python-base
-mypy_tmp_dir = mypy_tmp_dir
 
 [tox]
 envlist = linters, type, py38, report, clean
@@ -43,13 +42,11 @@ deps = coverage
 skip_install = true
 commands =
   coverage erase
-  rm -rf ./{[base]mypy_tmp_dir}
 
 [testenv:linters]
 description = Enforce quality standards under {basepython} ({envpython})
 install_command = pip install {opts} {packages}
 commands =
-  pre-commit run -a {posargs}
   pylint {[base]pkg_name} tests --ignore=tm_tokenize
   black -v --diff --check {toxinidir}
 
@@ -59,7 +56,7 @@ deps = coverage
 skip_install = true
 commands =
     coverage report
-    cat ./{[base]mypy_tmp_dir}/index.txt
+    cat .tox/.tmp/.mypy/index.txt
 
 # Note included in the default envlist above since it's destructive
 # (requires tmux, git, runs a bunch of commands, etc.)
@@ -67,15 +64,6 @@ commands =
 description = Run smoke tests under {basepython} ({envpython})
 commands = ansible-playbook tests/smoketests/run.yml
 allowlist_externals = ansible-playbook
-
-[testenv:type]
-description =
-  Verify static typing with MyPy under {basepython} ({envpython})
-commands =
-  mypy \
-    --txt-report ./{[base]mypy_tmp_dir} \
-    ./src/{[base]pkg_name} ./tests ./share
-
 
 [testenv:lint-vetting]
 description =


### PR DESCRIPTION
Removes old tox -e type and relies on pre-commit. We still have
the report generated and available to tox -e report.
