### PR TITLE
Add lint-vetting job for all optional linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
       ^
         .*
       $
+    stages: ["manual"]
 
 - repo: https://github.com/timothycrosley/isort.git
   rev: 5.10.1
@@ -24,6 +25,7 @@ repos:
       ^
         .*
       $
+    stages: ["manual"]
 
 - repo: https://github.com/Lucas-C/pre-commit-hooks.git
   rev: v1.1.10
@@ -47,12 +49,14 @@ repos:
       ^
         .*
       $
+    stages: ["manual"]
   - id: end-of-file-fixer
     exclude: |
       (?x)
       ^
         .*
       $
+    stages: ["manual"]
   - id: requirements-txt-fixer
     exclude: >-
       ^requirements\.txt$
@@ -67,6 +71,7 @@ repos:
       $
     files: >-
       ^tests/[^_].*\.py$
+    stages: ["manual"]
   - id: check-added-large-files
   - id: check-byte-order-marker
   - id: check-case-conflict
@@ -146,6 +151,7 @@ repos:
       D412,
       D413,
       D415,
+    stages: ["manual"]
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.1.0
@@ -203,6 +209,7 @@ repos:
           tox\.ini
         )
       $
+    stages: ["manual"]
 
 - repo: https://github.com/adrienverge/yamllint.git
   rev: v1.26.3
@@ -219,8 +226,6 @@ repos:
     language_version: python3
     additional_dependencies:
     - flake8-2020 >= 1.6.0
-    - flake8-docstrings >= 1.5.0
-    - flake8-pytest-style >= 1.2.2
 
 - repo: https://github.com/PyCQA/flake8.git
   rev: 3.9.2

--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -21,3 +21,11 @@
     vars:
       tox_envlist: linters,type
       tox_extra_args: -vv --skip-missing-interpreters false
+
+- job:
+    name: ansible-navigator-tox-lint-vetting
+    parent: ansible-tox-py38
+    vars:
+      tox_envlist: lint-vetting
+      tox_extra_args: -vv --skip-missing-interpreters false
+    voting: false

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -1,9 +1,13 @@
 ---
 - project:
     check:
-      jobs: &id001
+      jobs:
         - ansible-navigator-tox-lint
+        - ansible-navigator-tox-lint-vetting
         - ansible-navigator-tox-py38
         - ansible-navigator-tox-smoke
     gate:
-      jobs: *id001
+      jobs:
+        - ansible-navigator-tox-lint
+        - ansible-navigator-tox-py38
+        - ansible-navigator-tox-smoke

--- a/tox.ini
+++ b/tox.ini
@@ -78,9 +78,9 @@ commands =
     ./src/{[base]pkg_name} ./tests ./share
 
 
-[testenv:lint]
+[testenv:lint-vetting]
 description =
-  Enforce quality standards under `{basepython}` ({envpython})
+  Vetting newer quality standards under `{basepython}` ({envpython})
 commands =
   {envpython} -m \
     pre_commit run \


### PR DESCRIPTION
- ensure that all optional pre-commit hooks are run with `manual`
- use `lint-vetting` as tox env name and job name for the run  linting with all optional hooks
- add non-voting zuul job named `lint-veting`
- normal run of `pre-commit.ci` will run only required/approved hooks, making its result relevant for the review process
