### PR TITLE
[tests] Preset condition var

### DIFF
--- a/tests/integration/actions/collections/base.py
+++ b/tests/integration/actions/collections/base.py
@@ -81,11 +81,13 @@ class BaseClass:
             line.replace(os_indendent_tmp, "FIXTURES_COLLECTION_DIR") for line in received_output
         ]
 
-        if (
+        fixtures_update_requested = (
             self.UPDATE_FIXTURES
             or os.environ.get("ANSIBLE_NAVIGATOR_UPDATE_TEST_FIXTURES") == "true"
-        ):
+        )
+        if fixtures_update_requested:
             update_fixtures(request, index, received_output, comment)
+
         dir_path, file_name = fixture_path_from_request(request, index)
         with open(file=f"{dir_path}/{file_name}", encoding="utf-8") as infile:
             expected_output = json.load(infile)["output"]

--- a/tests/integration/actions/collections/base.py
+++ b/tests/integration/actions/collections/base.py
@@ -59,7 +59,6 @@ class BaseClass:
     ):
         # pylint: disable=too-many-arguments
         # pylint: disable=too-many-locals
-
         """Run the tests for collections, mode and ee set in child class.
 
         wait on help here to ensure we get the welcome screen and subsequent screens

--- a/tests/integration/actions/collections/base.py
+++ b/tests/integration/actions/collections/base.py
@@ -58,6 +58,8 @@ class BaseClass:
         comment,
     ):
         # pylint: disable=too-many-arguments
+        # pylint: disable=too-many-locals
+
         """Run the tests for collections, mode and ee set in child class.
 
         wait on help here to ensure we get the welcome screen and subsequent screens

--- a/tests/integration/actions/config/base.py
+++ b/tests/integration/actions/config/base.py
@@ -70,10 +70,11 @@ class BaseClass:
                 if any(m in line for m in maskables):
                     received_output[idx] = mask
 
-        if (
+        fixtures_update_requested = (
             self.UPDATE_FIXTURES
             or os.environ.get("ANSIBLE_NAVIGATOR_UPDATE_TEST_FIXTURES") == "true"
-        ):
+        )
+        if fixtures_update_requested:
             update_fixtures(
                 request,
                 step.step_index,

--- a/tests/integration/actions/config/base.py
+++ b/tests/integration/actions/config/base.py
@@ -48,6 +48,7 @@ class BaseClass:
             yield tmux_session
 
     def test(self, request, tmux_session, step):
+        # pylint: disable=too-many-locals
         """Run the tests for config, mode and ee set in child class."""
 
         if step.search_within_response is SearchFor.HELP:

--- a/tests/integration/actions/doc/base.py
+++ b/tests/integration/actions/doc/base.py
@@ -77,10 +77,11 @@ class BaseClass:
             for out in expected_in_output:
                 assert any(out in line for line in received_output), (out, received_output)
         else:
-            if (
-                self.UPDATE_FIXTURES
+            fixtures_update_requested = (
+               self.UPDATE_FIXTURES
                 or os.environ.get("ANSIBLE_NAVIGATOR_UPDATE_TEST_FIXTURES") == "true"
-            ):
+            )
+            if fixtures_update_requested:
                 update_fixtures(request, index, updated_received_output, comment, testname=testname)
 
             dir_path, file_name = fixture_path_from_request(request, index, testname=testname)

--- a/tests/integration/actions/doc/base.py
+++ b/tests/integration/actions/doc/base.py
@@ -78,7 +78,7 @@ class BaseClass:
                 assert any(out in line for line in received_output), (out, received_output)
         else:
             fixtures_update_requested = (
-               self.UPDATE_FIXTURES
+                self.UPDATE_FIXTURES
                 or os.environ.get("ANSIBLE_NAVIGATOR_UPDATE_TEST_FIXTURES") == "true"
             )
             if fixtures_update_requested:

--- a/tests/integration/actions/images/base.py
+++ b/tests/integration/actions/images/base.py
@@ -53,6 +53,7 @@ class BaseClass:
             yield tmux_session
 
     def test(self, request, tmux_session, step):
+        # pylint: disable=too-many-locals
         """Run the tests for images, mode and ee set in child class."""
 
         if step.search_within_response is SearchFor.HELP:

--- a/tests/integration/actions/images/base.py
+++ b/tests/integration/actions/images/base.py
@@ -67,10 +67,11 @@ class BaseClass:
             search_within_response=search_within_response,
         )
 
-        if (
+        fixtures_update_requested = (
             self.UPDATE_FIXTURES
             or os.environ.get("ANSIBLE_NAVIGATOR_UPDATE_TEST_FIXTURES") == "true"
-        ):
+        )
+        if fixtures_update_requested:
             update_fixtures(
                 request,
                 step.step_index,

--- a/tests/integration/actions/inventory/base.py
+++ b/tests/integration/actions/inventory/base.py
@@ -90,11 +90,12 @@ class BaseClass:
                 if tmux_session.cli_prompt in line:
                     received_output[idx] = mask
 
-        if (
+        fixtures_update_requested = (
             self.UPDATE_FIXTURES
             or os.environ.get("ANSIBLE_NAVIGATOR_UPDATE_TEST_FIXTURES") == "true"
             and not any((step.look_fors, step.look_nots))
-        ):
+        )
+        if fixtures_update_requested:
             update_fixtures(
                 request,
                 step.step_index,

--- a/tests/integration/actions/replay/base.py
+++ b/tests/integration/actions/replay/base.py
@@ -39,6 +39,7 @@ class BaseClass:
 
     def test(self, request, tmux_session, index, user_input, comment, search_within_response):
         # pylint: disable=too-many-arguments
+        # pylint: disable=too-many-locals
         """Run the tests for replay, mode and ee set in child class."""
         assert os.path.exists(PLAYBOOK_ARTIFACT)
         assert os.path.exists(TEST_CONFIG_FILE)

--- a/tests/integration/actions/replay/base.py
+++ b/tests/integration/actions/replay/base.py
@@ -44,11 +44,14 @@ class BaseClass:
         assert os.path.exists(TEST_CONFIG_FILE)
 
         received_output = tmux_session.interaction(user_input, search_within_response)
-        if (
+
+        fixtures_update_requested = (
             self.UPDATE_FIXTURES
             or os.environ.get("ANSIBLE_NAVIGATOR_UPDATE_TEST_FIXTURES") == "true"
-        ):
+        )
+        if fixtures_update_requested:
             update_fixtures(request, index, received_output, comment)
+
         dir_path, file_name = fixture_path_from_request(request, index)
         with open(file=f"{dir_path}/{file_name}", encoding="utf-8") as infile:
             expected_output = json.load(infile)["output"]

--- a/tests/integration/actions/run/base.py
+++ b/tests/integration/actions/run/base.py
@@ -62,6 +62,7 @@ class BaseClass:
 
     def test(self, request, tmux_session, step):
         # pylint: disable=too-many-branches
+        # pylint: disable=too-many-locals
         """Run the tests for run, mode and ee set in child class."""
 
         if step.search_within_response is SearchFor.HELP:

--- a/tests/integration/actions/run/base.py
+++ b/tests/integration/actions/run/base.py
@@ -87,11 +87,12 @@ class BaseClass:
                         if out in line:
                             received_output[idx] = mask
 
-        if (
+        fixtures_update_requested = (
             self.UPDATE_FIXTURES
             or os.environ.get("ANSIBLE_NAVIGATOR_UPDATE_TEST_FIXTURES") == "true"
             and not any((step.look_fors, step.look_nots))
-        ):
+        )
+        if fixtures_update_requested:
             update_fixtures(
                 request,
                 step.step_index,

--- a/tests/integration/actions/stdout/base.py
+++ b/tests/integration/actions/stdout/base.py
@@ -45,11 +45,13 @@ class BaseClass:
 
         received_output = tmux_session.interaction(user_input, search_within_response)
 
-        if (
+        fixtures_update_requested = (
             self.UPDATE_FIXTURES
             or os.environ.get("ANSIBLE_NAVIGATOR_UPDATE_TEST_FIXTURES") == "true"
-        ):
+        )
+        if fixtures_update_requested:
             update_fixtures(request, index, received_output, comment)
+
         dir_path, file_name = fixture_path_from_request(request, index)
         with open(file=f"{dir_path}/{file_name}", encoding="utf-8") as infile:
             expected_output = json.load(infile)["output"]

--- a/tests/integration/actions/stdout/base.py
+++ b/tests/integration/actions/stdout/base.py
@@ -39,6 +39,7 @@ class BaseClass:
 
     def test(self, request, tmux_session, index, user_input, comment, search_within_response):
         # pylint:disable=too-many-arguments
+        # pylint: disable=too-many-locals
         """Run the tests for stdout, mode and ee set in child class."""
         assert os.path.exists(ANSIBLE_PLAYBOOK)
         assert os.path.exists(TEST_CONFIG_FILE)

--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -68,10 +68,8 @@ class BaseClass:
             yield tmux_session
 
     def test(self, request, tmux_session, step):
-        # pylint:disable=unused-argument
-        # pylint: disable=too-few-public-methods
-        # pylint: disable=too-many-arguments
         # pylint: disable=too-many-branches
+        # pylint: disable=too-many-locals
         """test interactive/stdout config"""
 
         if step.search_within_response is SearchFor.HELP:

--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -97,10 +97,11 @@ class BaseClass:
                         if out in line:
                             received_output[idx] = mask
 
-        if (
+        fixtures_update_requested = (
             self.UPDATE_FIXTURES
             or os.environ.get("ANSIBLE_NAVIGATOR_UPDATE_TEST_FIXTURES") == "true"
-        ):
+        )
+        if fixtures_update_requested:
             update_fixtures(
                 request,
                 step.step_index,


### PR DESCRIPTION
as suggested in #624 reduce complexity by presetting the var used in the condition.

Additionally, correctly set the pylint: disable statements for this function across tests, removing unneeded and adding new.

(this can be cleaned up more, #693 might be a good place to do that)

