### PR TITLE
[tests] grep case insensitive UPDATE_FIXTURES

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt
 commands =
-  /bin/bash -c 'grep -FInrq "UPDATE_FIXTURES = True" ./tests && exit 1 || exit 0'
+  /bin/bash -c 'grep -iFInrq "UPDATE_FIXTURES = True" ./tests && exit 1 || exit 0'
   /bin/bash -c 'podman pull {[base]default_ee} || docker pull {[base]default_ee}'
   /bin/bash -c 'podman pull {[base]small_test_ee} || docker pull {[base]small_test_ee}'
   /bin/bash -c 'py.test -vvvv -n `python -c "import multiprocessing; import os; print(int(os.environ.get(\"XDIST_CPU\") or multiprocessing.cpu_count()))"` --dist=loadfile --maxfail=15 --durations=100 --cov ansible_navigator --cov share --cov-report term-missing --cov-branch --showlocals'


### PR DESCRIPTION
The current pattern in the tests is

```

class BaseClass:
    # pylint: disable=too-few-public-methods
    """Base class for interactive collections tests."""

    UPDATE_FIXTURES = False
```

which uses a capital constant

In case future developers decide to adhere to this:

https://wemake-python-stylegui.de/en/latest/pages/usage/violations/naming.html#wemake_python_styleguide.violations.naming.UpperCaseAttributeViolation

The grep was changed to case insensitive