### PR TITLE
Use tox lint job and document it

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,15 +39,15 @@ Prerequisites:
 
 2. Use {doc}`tox <tox:index>` to run the tests.
 
-3. Before sending a PR, make sure that the linters pass:
+3. Before sending a PR, make sure that `lint` passes:
 
    ```shell-session
-   $ tox -e linters
-   linters create: .tox/linters
-   linters installdeps: -rrequirements.txt, -rtest-requirements.txt
-   linters installed: ...
-   linters run-test-pre: PYTHONHASHSEED='4242713142'
-   linters run-test: commands[0] | pylint ansible_navigator tests ...
+   $ tox -e lint
+   lint create: .tox/linters
+   lint installdeps: -rrequirements.txt, -rtest-requirements.txt
+   lint installed: ...
+   lint run-test-pre: PYTHONHASHSEED='4242713142'
+   lint run-test: commands[0] | pylint ansible_navigator tests ...
    ...
    ```
 
@@ -56,12 +56,12 @@ Prerequisites:
    annoyingly slow):
 
    ```shell-session
-   $ tox -e lint
-   lint create: .tox/lint
-   lint installdeps: pre-commit, pylint ~= 2.8.0, pylint-pytest < 1.1.0
-   lint installed: ...
-   lint run-test-pre: PYTHONHASHSEED='2351399476'
-   lint run-test: commands[0] | python -m pre_commit run ... --all-files -v
+   $ tox -e lint-vetting
+   lint-vetting create: .tox/lint-vetting
+   lint-vetting installdeps: pre-commit, pylint ~= 2.8.0, pylint-pytest < 1.1.0
+   lint-vetting installed: ...
+   lint-vetting run-test-pre: PYTHONHASHSEED='2351399476'
+   lint-vetting run-test: commands[0] | python -m pre_commit run ... --all-files -v
    ...
    [INFO] Initializing environment for https://github.com/asottile/add-trailing-comma.git.
    ...

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,2 @@
+MD013:
+  code_blocks: false

--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -53,7 +53,7 @@
     name: ansible-navigator-tox-lint
     parent: ansible-tox-py38
     vars:
-      tox_envlist: linters
+      tox_envlist: lint
       tox_extra_args: -vv --skip-missing-interpreters false
 
 - job:

--- a/docs/changelog-fragments.d/708.internal.md
+++ b/docs/changelog-fragments.d/708.internal.md
@@ -1,0 +1,3 @@
+Updated the linting tox environment names in the contributing document to
+match the configuration changes in the repository. It now mentions separate
+commands for `lint` and `lint-vetting` suites -- by {user}`ssbarnea`

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ default_ee = quay.io/ansible/creator-ee:v0.2.0
 small_test_ee = quay.io/ansible/python-base
 
 [tox]
-envlist = linters, type, py38, report, clean
+envlist = lint, py38, report, clean
 minversion = 3.16.1
 skipsdist = True
 skip_missing_interpreters = true
@@ -43,7 +43,7 @@ skip_install = true
 commands =
   coverage erase
 
-[testenv:linters]
+[testenv:lint]
 description = Enforce quality standards under {basepython} ({envpython})
 install_command = pip install {opts} {packages}
 commands =


### PR DESCRIPTION
- use 'lint' instead of 'linters' for both tox and zuul jobs, so
  they are consistent across all our projects. zuul job name is
  already named `ansible-navigator-tox-lint` so it does not need change.
- remove leftover type from envlist in tox as it was removed, as is
  part of lint.
- remove output lines from lint command that are not only outdated
  but also irrelevant for docs inclusion.
