### PR TITLE
Make codespell an official linter

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,6 +10,8 @@ maintain it and you contribute.
 
 2. pylint (lints all the things)
 
+3. code-spell (prevents typos in code)
+
 ```{note}
 In early development cycles, a decision was made to use black as a formatter
 which is why current pull-requests are required to pass a

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -162,7 +162,6 @@ repos:
           share/ansible_navigator/grammar/.*\.json
         )
       $
-    stages: ["manual"]
 
 - repo: https://github.com/adrienverge/yamllint.git
   rev: v1.26.3

--- a/docs/changelog-fragments.d/727.internal.md
+++ b/docs/changelog-fragments.d/727.internal.md
@@ -1,0 +1,1 @@
+Made code-spell tool part of accepted project linters. -- by {user}`ssbarnea`


### PR DESCRIPTION
Make codespell implicit (required) in order to pass reviews.  

Errors found by codespell will need to be fixed for PRs to be merged if this is agreed to.

About [codespell](https://github.com/codespell-project/codespell):

Fix common misspellings in text files. It's designed primarily for checking misspelled words in source code, but it can be used with other files as well. It does not check for word membership in a complete dictionary, but instead looks for a set of common misspellings. Therefore it should catch errors like "adn", but it will not catch "adnasdfasdf". This also means it shouldn't generate false-positives when you use a niche term it doesn't know about.

Our configuration for it is here, it will be run by the precommit hook:

https://github.com/ansible/ansible-navigator/blob/main/.pre-commit-config.yaml#L150

This change is does close a **range of preparatory changes** that repaired problems identified by code-spell:
* #728
* #718
* #710
* #707
* #690

Please do not gate this change until the entire team approves it.