### PR TITLE
Fix and enable tests with py36 and py37

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -3,7 +3,6 @@
     name: ansible-navigator-tox-py36
     parent: ansible-tox-py36
     pre-run: playbooks/pre-run.yaml
-    voting: false
     vars:
       tox_envlist: py36
       tox_extra_args: -vv --skip-missing-interpreters false
@@ -12,7 +11,6 @@
     name: ansible-navigator-tox-py37
     parent: ansible-tox-py37
     pre-run: playbooks/pre-run.yaml
-    voting: false
     vars:
       tox_envlist: py37
       tox_extra_args: -vv --skip-missing-interpreters false

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/0.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/0.json
@@ -3,9 +3,12 @@
     "index": 0,
     "comment": "ansible-navigator config command top window",
     "additional_information": {
-        "look_fors": [],
+        "look_fors": [
+            "ACTION_WARNINGS",
+            "CALLBACKS_ENABLED"
+        ],
         "look_nots": [],
-        "compared_fixture": true
+        "compared_fixture": false
     },
     "output": [
         "    OPTION                                  DEFAULT SOURCE  VIA                             CURRENT VALUE",

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/4.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/4.json
@@ -3,9 +3,12 @@
     "index": 4,
     "comment": "clear filter, full list",
     "additional_information": {
-        "look_fors": [],
+        "look_fors": [
+            "ACTION_WARNINGS",
+            "CALLBACKS_ENABLED"
+        ],
         "look_nots": [],
-        "compared_fixture": true
+        "compared_fixture": false
     },
     "output": [
         "    OPTION                                  DEFAULT SOURCE  VIA                             CURRENT VALUE",

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/8.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/8.json
@@ -3,9 +3,12 @@
     "index": 8,
     "comment": "clear filter, full list",
     "additional_information": {
-        "look_fors": [],
+        "look_fors": [
+            "ACTION_WARNINGS",
+            "CALLBACKS_ENABLED"
+        ],
         "look_nots": [],
-        "compared_fixture": true
+        "compared_fixture": false
     },
     "output": [
         "    OPTION                                  DEFAULT SOURCE  VIA                             CURRENT VALUE",

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/1.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/1.json
@@ -3,9 +3,12 @@
     "index": 1,
     "comment": "enter config from welcome screen",
     "additional_information": {
-        "look_fors": [],
+        "look_fors": [
+            "ACTION_WARNINGS",
+            "CALLBACKS_ENABLED"
+        ],
         "look_nots": [],
-        "compared_fixture": true
+        "compared_fixture": false
     },
     "output": [
         "    OPTION                                  DEFAULT SOURCE  VIA                             CURRENT VALUE",

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/5.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/5.json
@@ -3,9 +3,12 @@
     "index": 5,
     "comment": "clear filter, full list",
     "additional_information": {
-        "look_fors": [],
+        "look_fors": [
+            "ACTION_WARNINGS",
+            "CALLBACKS_ENABLED"
+        ],
         "look_nots": [],
-        "compared_fixture": true
+        "compared_fixture": false
     },
     "output": [
         "    OPTION                                  DEFAULT SOURCE  VIA                             CURRENT VALUE",

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/9.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/9.json
@@ -3,9 +3,12 @@
     "index": 9,
     "comment": "clear filter, full list",
     "additional_information": {
-        "look_fors": [],
+        "look_fors": [
+            "ACTION_WARNINGS",
+            "CALLBACKS_ENABLED"
+        ],
         "look_nots": [],
-        "compared_fixture": true
+        "compared_fixture": false
     },
     "output": [
         "    OPTION                                  DEFAULT SOURCE  VIA                             CURRENT VALUE",

--- a/tests/integration/actions/config/base.py
+++ b/tests/integration/actions/config/base.py
@@ -20,11 +20,19 @@ base_steps = (
     Step(user_input=":f CACHE_PLUGIN_TIMEOUT", comment="filter for cache plugin timeout"),
     Step(user_input=":0", comment="cache plugin details"),
     Step(user_input=":back", comment="return to filtered list"),
-    Step(user_input=":f", comment="clear filter, full list"),
+    Step(
+        user_input=":f",
+        comment="clear filter, full list",
+        look_fors=["ACTION_WARNINGS", "CALLBACKS_ENABLED"],
+    ),
     Step(user_input=":f yaml", comment="filter off screen value"),
     Step(user_input=":3", comment="YAML_FILENAME_EXTENSIONS details"),
     Step(user_input=":back", comment="return to filtered list"),
-    Step(user_input=":f", comment="clear filter, full list"),
+    Step(
+        user_input=":f",
+        comment="clear filter, full list",
+        look_fors=["ACTION_WARNINGS", "CALLBACKS_ENABLED"],
+    ),
 )
 
 

--- a/tests/integration/actions/config/test_direct_interactive_noee.py
+++ b/tests/integration/actions/config/test_direct_interactive_noee.py
@@ -12,7 +12,13 @@ from ..._interactions import step_id
 
 CLI = Command(subcommand="config", execution_environment=False).join()
 
-initial_steps = (Step(user_input=CLI, comment="ansible-navigator config command top window"),)
+initial_steps = (
+    Step(
+        user_input=CLI,
+        comment="ansible-navigator config command top window",
+        look_fors=["ACTION_WARNINGS", "CALLBACKS_ENABLED"],
+    ),
+)
 
 steps = add_indicies(initial_steps + base_steps)
 

--- a/tests/integration/actions/config/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/config/test_welcome_interactive_noee.py
@@ -14,7 +14,11 @@ CLI = Command(execution_environment=False).join()
 
 initial_steps = (
     Step(user_input=CLI, comment="welcome screen"),
-    Step(user_input=":config", comment="enter config from welcome screen"),
+    Step(
+        user_input=":config",
+        comment="enter config from welcome screen",
+        look_fors=["ACTION_WARNINGS", "CALLBACKS_ENABLED"],
+    ),
 )
 
 steps = add_indicies(initial_steps + base_steps)


### PR DESCRIPTION
This changes the fialing tests such that they pass on both py36 and py37.

Because an older version of python may pull in an older version of ansible, we cannot directly compare the scrren contents for `:config` since the config options for different version of ansible may differ.

Only the `no ee` tests were failing because ansible was running outside the EE. Inside the EE the python version doesn't vary based on the version of python being tested... 

This adds "look_fors" for these tests (one near the top and one near the bottom of the output).

Also- renable the py36 and py37 tests so they are voting, and update fixtures to reflect the change from `compare_fixture` to simply looking for some strings on the screen. 

Related: https://github.com/ansible/ansible-navigator/pull/612