### PR TITLE
Bump flake8 WPS plugin to v0.16.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -179,17 +179,15 @@ repos:
     language_version: python3
     additional_dependencies:
     - flake8-2020 >= 1.6.0
-
-- repo: https://github.com/PyCQA/flake8.git
-  rev: 3.9.2
-  hooks:
   - id: flake8
+    name: >-
+      An unenforced set of strict flake8 plugins,
+      including WPS and pytest-style
     language_version: python3
     additional_dependencies:
-    - flake8-2020 >= 1.6.0
     - flake8-docstrings >= 1.5.0
     - flake8-pytest-style >= 1.2.2
-    - wemake-python-styleguide ~= 0.15.0
+    - wemake-python-styleguide ~= 0.16.0
     stages:
     - manual
 

--- a/docs/changelog-fragments.d/736.internal.md
+++ b/docs/changelog-fragments.d/736.internal.md
@@ -1,0 +1,5 @@
+Bumped the [wemake-python-styleguide] linter suite to v0.16.0 that comes
+with the support for flake8 v4 -- by {user}`webknjaz`
+
+[wemake-python-styleguide]:
+https://wemake-python-stylegui.de/en/latest/pages/usage/violations/


### PR DESCRIPTION
The 0.16.x stream is the first one compatible with flake8 v4.