### PR TITLE
[configuration] delayed postprocs, extra volmounts

### DIFF
--- a/src/ansible_navigator/configuration_subsystem/configurator.py
+++ b/src/ansible_navigator/configuration_subsystem/configurator.py
@@ -234,7 +234,17 @@ class Configurator:
                 self._messages.append(LogMessage(level=logging.INFO, message=message))
 
     def _post_process(self) -> None:
+        delayed = []
+        normal = []
+
+        # Separate normal and delayed entries so they can be processed in that order.
         for entry in self._config.entries:
+            if entry.delay_post_process:
+                delayed.append(entry)
+            else:
+                normal.append(entry)
+
+        for entry in normal + delayed:
             if self._initial or entry.change_after_initial:
                 processor = getattr(self._config.post_processor, entry.name, None)
                 if callable(processor):

--- a/src/ansible_navigator/configuration_subsystem/definitions.py
+++ b/src/ansible_navigator/configuration_subsystem/definitions.py
@@ -60,6 +60,7 @@ class Entry(SimpleNamespace):
     apply_to_subsequent_cli: Should this be applied to future CLIs parsed
     choice: valid choices for this entry
     cli_parameters: argparse specific params
+    delay_post_process: Post process in normal (alphabetical) order or wait until after first pass?
     environment_variable_override: override the default environment variable
     name: the reference name for the entry
     settings_file_path_override: over the default settings file path
@@ -76,6 +77,7 @@ class Entry(SimpleNamespace):
     change_after_initial: bool = True
     choices: List = []
     cli_parameters: Union[None, CliParameters] = None
+    delay_post_process: bool = False
     environment_variable_override: Union[None, str] = None
     settings_file_path_override: Union[None, str] = None
     subcommands: Union[List[str], Constants] = Constants.ALL

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -291,6 +291,7 @@ NavigatorConfiguration = ApplicationConfiguration(
         Entry(
             name="execution_environment_volume_mounts",
             cli_parameters=CliParameters(action="append", nargs="+", short="--eev"),
+            delay_post_process=True,
             settings_file_path_override="execution-environment.volume-mounts",
             short_description=(
                 "Specify volume to be bind mounted within an execution environment"

--- a/tests/unit/configuration_subsystem/test_navigator_post_processor.py
+++ b/tests/unit/configuration_subsystem/test_navigator_post_processor.py
@@ -1,0 +1,31 @@
+"""Tests for the navigator config post-processor."""
+
+import pytest
+
+from ansible_navigator.configuration_subsystem.navigator_post_processor import (
+    VolumeMount,
+    VolumeMountOption,
+)
+
+
+@pytest.mark.parametrize(
+    ("volmount", "expected"),
+    (
+        (VolumeMount("test_option", "/foo", "/bar"), "/foo:/bar"),
+        (VolumeMount("test_option", "/foo", "/bar", [VolumeMountOption.z]), "/foo:/bar:z"),
+        (
+            VolumeMount("test_option", "/foo", "/bar", [VolumeMountOption.z, VolumeMountOption.Z]),
+            "/foo:/bar:z,Z",
+        ),
+        (VolumeMount("test_option", "/foo", "/bar", []), "/foo:/bar"),
+    ),
+    ids=(
+        "normal mount",
+        "mount with relabel option",
+        "mount with a list of options",
+        "mount with empty list of options",
+    ),
+)
+def test_navigator_volume_mount_to_string(volmount, expected):
+    """Make sure volume mount ``to_string`` is sane."""
+    assert volmount.to_string() == expected


### PR DESCRIPTION
I've pulled this out from my lint work, where it was needed, because it feels like it should be a separate change because we probably want it regardless.

This allows post processors to be delayed until after the first pass of post processors has been completed.
At that point, it will run the delayed ones. There is only one "level" of delay (so delayed post processors can't wait for a third pass). This is intentional, to keep things simple, otherwise we'd have a whole tree of post processors and it gets complex quickly.

Doing it this way just provides a simple way to say "this post processor depends on some other things that happen in the first pass, let's wait for this before we actually run it."

```
Change:

- Allow post-processors to be delayed until after the first
  (alphabetical) pass. In the delayed pass, delayed post-processors
  are again executed alphabetically.

- In the interest of keeping configuration simple, we don't allow for
  multiple "levels" of delay. A post-processor is either run during the
  first pass, or delayed until after the first/normal pass.

- This also adds an "extra volmounts" variable to the navigator
  post-processor class, which can be used by other post-processors to
  signify that they want a volume to be mounted. The volume-mount post
  processor is now delayed to accommodate.

Test Plan:

- Using this in lint/navigator work, no new tests yet because there is
  no other post processor currently which adds an extra volume mount.

Signed-off-by: Rick Elrod <rick@elrod.me>
```