### PR TITLE
Restore execution of pre-commit from inside tox -e lint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ commands =
 description = Enforce quality standards under {basepython} ({envpython})
 install_command = pip install {opts} {packages}
 commands =
+  pre-commit run -a {posargs}
   pylint {[base]pkg_name} tests --ignore=tm_tokenize
   black -v --diff --check {toxinidir}
 


### PR DESCRIPTION
This correct unintended bug introduced at https://github.com/ansible/ansible-navigator/pull/686/files#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L52

Our intention was not to stop running the pre-commit hooks under
zuul. This brings the behavior in sync with our expectation and
documentation.
