### PR TITLE
Consolidate pylint configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -218,39 +218,24 @@ repos:
     - tests/
     pass_filenames: false
 
-- repo: local
+- repo: https://github.com/PyCQA/pylint
+  rev: v2.12.2
   hooks:
-  - id: pylint
-    language: system
-    name: PyLint
-    files: \.py$
-    entry: python -m pylint
-    args:
-    - --ignore=tm_tokenize
-    - |-
-      --disable=
-      consider-using-with,
-      implicit-str-concat,
-      import-error,
-      invalid-name,
-      missing-class-docstring,
-      missing-function-docstring,
-      missing-module-docstring,
-      no-else-return,
-      no-member,
-      no-self-use,
-      protected-access,
-      redefined-builtin,
-      too-few-public-methods,
-      too-many-arguments,
-      too-many-branches,
-      too-many-instance-attributes,
-      too-many-locals,
-      too-many-statements,
-      unused-import,
-      useless-else-on-loop,
-      wrong-import-order,
-    stages:
-    - manual
-
+    - id: pylint
+      additional_dependencies:
+        - ansible-runner
+        - libtmux
+        - onigurumacffi
+        - pytest
+        - pyyaml
+        - sphinx
+        - setuptools-scm
+      entry: pylint --rcfile=.pylintrc
+      exclude: >
+        (?x)^
+          (
+            share/ansible_navigator/utils/catalog_collections\.py|
+            src/ansible_navigator/tm_tokenize/.*
+          )
+        $
 ...

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,30 @@
 [MESSAGES CONTROL]
 
-disable=duplicate-code,unsubscriptable-object,fixme
+disable=
+    duplicate-code,
+    unsubscriptable-object,
+    fixme,
+    # FIXME: remove exclusions added during initial tool adoption
+    consider-using-with,
+    implicit-str-concat,
+    invalid-name,
+    missing-class-docstring,
+    missing-function-docstring,
+    missing-module-docstring,
+    no-else-return,
+    no-member,
+    no-self-use,
+    protected-access,
+    redefined-builtin,
+    too-few-public-methods,
+    too-many-arguments,
+    too-many-branches,
+    too-many-instance-attributes,
+    too-many-locals,
+    too-many-statements,
+    unspecified-encoding,
+    unused-import,
+    unused-variable,
+    use-list-literal,
+    useless-else-on-loop,
+    wrong-import-order,

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,6 @@ description = Enforce quality standards under {basepython} ({envpython})
 install_command = pip install {opts} {packages}
 commands =
   pre-commit run -a {posargs}
-  pylint {[base]pkg_name} tests --ignore=tm_tokenize
   black -v --diff --check {toxinidir}
 
 [testenv:report]


### PR DESCRIPTION
- ensure pylint is run by pre-commit hook instead of having two different ways of running it (from inside tox and as a pre-commit manual hook)
- avoid having two different pylint configs
- mark all excluded rules as temporary as we want to address them
  one by one once we fix them in current code
- keep the two file-path exclusions
