### PR TITLE
pylint: address unspecified-encoding rule

### DIFF
--- a/docs/_ext/single_sourced_data.py
+++ b/docs/_ext/single_sourced_data.py
@@ -158,7 +158,7 @@ def _params_get_param_file_entry(
 
 def _params_retrieve_details(filename: str) -> Dict:
     """load the param details file"""
-    with open(filename) as fhand:
+    with open(filename, encoding="utf-8") as fhand:
         return yaml.load(fhand, Loader=yaml.SafeLoader)
 
 

--- a/src/ansible_navigator/_yaml.py
+++ b/src/ansible_navigator/_yaml.py
@@ -40,7 +40,7 @@ def human_dump(obj: Any, filename: str = None, fmode: str = "w") -> Union[str, N
     """
     dumper = HumanDumper
     if filename is not None:
-        with open(filename, fmode) as outfile:
+        with open(filename, fmode, encoding="utf-8") as outfile:
             yaml.dump(
                 obj,
                 outfile,

--- a/src/ansible_navigator/actions/help_doc.py
+++ b/src/ansible_navigator/actions/help_doc.py
@@ -30,7 +30,8 @@ class Action(App):
         self._prepare_to_run(app, interaction)
 
         with open(
-            os.path.join(self._args.internals.share_directory, "markdown", "help.md")
+            os.path.join(self._args.internals.share_directory, "markdown", "help.md"),
+            encoding="utf-8",
         ) as fhand:
             help_md = fhand.read()
 

--- a/src/ansible_navigator/actions/log.py
+++ b/src/ansible_navigator/actions/log.py
@@ -31,7 +31,7 @@ class Action(App):
         auto_scroll = True
         while True:
             self._calling_app.update()
-            with open(self._args.log_file) as fhand:
+            with open(self._args.log_file, encoding="utf-8") as fhand:
                 dalog = fhand.read()
 
             new_scroll = len(dalog.splitlines())

--- a/src/ansible_navigator/actions/open_file.py
+++ b/src/ansible_navigator/actions/open_file.py
@@ -87,18 +87,18 @@ class Action:
         if not filename:
             if interaction.ui.xform() == "text.html.markdown":
                 filename = tempfile.NamedTemporaryFile(suffix=".md").name
-                with open(filename, "w") as outfile:
+                with open(filename, "w", encoding="utf-8") as outfile:
                     outfile.write(obj)
             elif interaction.ui.xform() == "source.yaml":
                 filename = tempfile.NamedTemporaryFile(suffix=".yaml").name
                 human_dump(obj=obj, filename=filename)
             elif interaction.ui.xform() == "source.json":
                 filename = tempfile.NamedTemporaryFile(suffix=".json").name
-                with open(filename, "w") as outfile:
+                with open(filename, "w", encoding="utf-8") as outfile:
                     json.dump(obj, outfile, indent=4, sort_keys=True)
             else:
                 filename = tempfile.NamedTemporaryFile(suffix=".txt").name
-                with open(filename, "w") as outfile:
+                with open(filename, "w", encoding="utf-8") as outfile:
                     outfile.write(obj)
 
         command = self._args.editor_command.format(filename=filename, line_number=line_number)

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -385,7 +385,7 @@ class Action(App):
             artifact_file = populated_form["fields"]["artifact_file"]["value"]
 
         try:
-            with open(artifact_file) as json_file:
+            with open(artifact_file, encoding="utf-8") as json_file:
                 data = json.load(json_file)
         except json.JSONDecodeError as exc:
             self._logger.debug("json decode error: %s", str(exc))
@@ -836,7 +836,7 @@ class Action(App):
 
             try:
                 os.makedirs(os.path.dirname(filename), exist_ok=True)
-                with open(filename, "w") as outfile:
+                with open(filename, "w", encoding="utf-8") as outfile:
                     artifact = {
                         "version": "1.0.0",
                         "plays": self._plays.value,

--- a/src/ansible_navigator/actions/welcome.py
+++ b/src/ansible_navigator/actions/welcome.py
@@ -35,7 +35,8 @@ class Action(App):
         self._prepare_to_run(app, interaction)
 
         with open(
-            os.path.join(self._args.internals.share_directory, "markdown", "welcome.md")
+            os.path.join(self._args.internals.share_directory, "markdown", "welcome.md"),
+            encoding="utf-8",
         ) as fhand:
             welcome_md = fhand.read()
 

--- a/src/ansible_navigator/actions/write_file.py
+++ b/src/ansible_navigator/actions/write_file.py
@@ -77,12 +77,12 @@ class Action:
                 write_as = interaction.ui.xform()
 
         if write_as == "text":
-            with open(os.path.abspath(filename), fmode) as outfile:
+            with open(os.path.abspath(filename), fmode, encoding="utf-8") as outfile:
                 outfile.write(obj)
         elif write_as == "yaml":
             human_dump(obj=obj, filename=filename, fmode=fmode)
         elif write_as == "json":
-            with open(os.path.abspath(filename), fmode) as outfile:
+            with open(os.path.abspath(filename), fmode, encoding="utf-8") as outfile:
                 json.dump(obj, outfile, indent=4, sort_keys=True)
                 outfile.write("\n")
 

--- a/src/ansible_navigator/configuration_subsystem/configurator.py
+++ b/src/ansible_navigator/configuration_subsystem/configurator.py
@@ -147,7 +147,7 @@ class Configurator:
 
     def _apply_settings_file(self) -> None:
         if self._settings_file_path:
-            with open(self._settings_file_path, "r") as config_fh:
+            with open(self._settings_file_path, "r", encoding="utf-8") as config_fh:
                 try:
                     config = yaml.load(config_fh, Loader=SafeLoader)
                 except (yaml.scanner.ScannerError, yaml.parser.ParserError) as exc:

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -78,7 +78,7 @@ class Colorize:
         self._load()
 
     def _load(self):
-        with open(os.path.join(self._theme_path)) as data_file:
+        with open(os.path.join(self._theme_path), encoding="utf-8") as data_file:
             self._schema = ColorSchema(json.load(data_file))
 
     @functools.lru_cache(maxsize=100)

--- a/src/ansible_navigator/ui_framework/curses_window.py
+++ b/src/ansible_navigator/ui_framework/curses_window.py
@@ -186,7 +186,7 @@ class CursesWindow:
         self._logger.debug("term_osc4_supprt: %s", self._term_osc4_supprt)
 
         if self._term_osc4_supprt:
-            with open(self._ui_config.terminal_colors_path) as data_file:
+            with open(self._ui_config.terminal_colors_path, encoding="utf-8") as data_file:
                 colors = json.load(data_file)
 
             for color_name, color_hex in colors.items():

--- a/tests/integration/actions/exec/base.py
+++ b/tests/integration/actions/exec/base.py
@@ -96,7 +96,7 @@ class BaseClass:
 
         if not any((step.look_fors, step.look_nots)):
             dir_path, file_name = fixture_path_from_request(request, step.step_index)
-            with open(f"{dir_path}/{file_name}") as infile:
+            with open(f"{dir_path}/{file_name}", encoding="utf-8") as infile:
                 expected_output = json.load(infile)["output"]
 
             diff = "\n".join(


### PR DESCRIPTION
Add explicit encoding to file operations. We already had this in several places but not on all.

Related: #742
