### PR TITLE
[lint] Disable pylint via tox, enable pylint via precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -241,7 +241,6 @@ repos:
     # docs:
     - sphinx
     - setuptools-scm
-    entry: pylint --rcfile=.pylintrc
     exclude: >
       (?x)^
         (

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -223,15 +223,24 @@ repos:
   hooks:
   - id: pylint
     additional_dependencies:
-      - ansible-core
-      - ansible-runner
-      - dataclasses; python_version<"3.7"
-      - libtmux
-      - onigurumacffi
-      - pytest
-      - pyyaml
-      - sphinx
-      - setuptools-scm
+    # NOTE: The entries below must be kept in sync with the contents of `setup.cfg` at all times,
+    # NOTE: including `install_requires` and any extras that may be imported in runtime to accommodate
+    # NOTE: for `pylint`'s ability to import the modules being checked. They must also include any of the
+    # NOTE: test and platform-dependent requirements that may be imported under different circumstances.
+    - ansible-core  # dependency imported in utils/catalog_collections.py
+    # setup.cfg:
+    - ansible-runner ~= 2.0
+    - dataclasses; python_version < "3.7"
+    - importlib-resources; python_version < "3.9.0"
+    - jinja2
+    - onigurumacffi
+    - pyyaml
+    # tests:
+    - libtmux
+    - pytest
+    # docs:
+    - sphinx
+    - setuptools-scm
     entry: pylint --rcfile=.pylintrc
     exclude: >
       (?x)^

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -218,7 +218,7 @@ repos:
     - tests/
     pass_filenames: false
 
-- repo: https://github.com/PyCQA/pylint
+- repo: https://github.com/PyCQA/pylint.git
   rev: v2.12.2
   hooks:
   - id: pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -225,6 +225,7 @@ repos:
     additional_dependencies:
       - ansible-core
       - ansible-runner
+      - dataclasses; python_version<"3.7"
       - libtmux
       - onigurumacffi
       - pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -218,39 +218,24 @@ repos:
     - tests/
     pass_filenames: false
 
-- repo: local
+- repo: https://github.com/PyCQA/pylint
+  rev: v2.12.2
   hooks:
   - id: pylint
-    language: system
-    name: PyLint
-    files: \.py$
-    entry: python -m pylint
-    args:
-    - --ignore=tm_tokenize
-    - |-
-      --disable=
-      consider-using-with,
-      implicit-str-concat,
-      import-error,
-      invalid-name,
-      missing-class-docstring,
-      missing-function-docstring,
-      missing-module-docstring,
-      no-else-return,
-      no-member,
-      no-self-use,
-      protected-access,
-      redefined-builtin,
-      too-few-public-methods,
-      too-many-arguments,
-      too-many-branches,
-      too-many-instance-attributes,
-      too-many-locals,
-      too-many-statements,
-      unused-import,
-      useless-else-on-loop,
-      wrong-import-order,
-    stages:
-    - manual
+    additional_dependencies:
+      - ansible-runner
+      - libtmux
+      - onigurumacffi
+      - pytest
+      - pyyaml
+      - sphinx
+      - setuptools-scm
+    entry: pylint --rcfile=.pylintrc
+    exclude: >
+      (?x)^
+        (
+          src/ansible_navigator/tm_tokenize/.*
+        )
+      $
 
 ...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -223,6 +223,7 @@ repos:
   hooks:
   - id: pylint
     additional_dependencies:
+      - ansible-core
       - ansible-runner
       - libtmux
       - onigurumacffi

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,6 @@ description = Enforce quality standards under {basepython} ({envpython})
 install_command = pip install {opts} {packages}
 commands =
   pre-commit run -a {posargs}
-  pylint {[base]pkg_name} tests --ignore=tm_tokenize
   black -v --diff --check {toxinidir}
 
 [testenv:report]


### PR DESCRIPTION
Depends on #745 #746 #748 #749 and maybe another one if I missed something

No pylint config changes here, although this depends on a little cleanup due to the later version.

Adds `ansible-core` as a dependency so the import statements in `utils/catalog_collections.py` can be resolved

Now also depends on #751 

and #754 