### PR TITLE
[lint] Unused var and import error

### DIFF
--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -29,10 +29,8 @@ try:
 except ImportError:
     from yaml import SafeLoader  # type: ignore
 
-# pylint: disable=import-error
-from key_value_store import KeyValueStore  # type: ignore
+from key_value_store import KeyValueStore  # type: ignore  # pylint: disable=import-error
 
-# pylint: enable=import-error
 
 PROCESSES = (multiprocessing.cpu_count() - 1) or 1
 

--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -31,6 +31,7 @@ except ImportError:
 
 # pylint: disable=import-error
 from key_value_store import KeyValueStore  # type: ignore
+
 # pylint: enable=import-error
 
 PROCESSES = (multiprocessing.cpu_count() - 1) or 1

--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -29,8 +29,9 @@ try:
 except ImportError:
     from yaml import SafeLoader  # type: ignore
 
+# pylint: disable=import-error
 from key_value_store import KeyValueStore  # type: ignore
-
+# pylint: enable=import-error
 
 PROCESSES = (multiprocessing.cpu_count() - 1) or 1
 

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -306,11 +306,11 @@ class Action(App):
                 variable = extracted.groupdict()["variable"]
                 try:
                     source = yaml.load(extracted.groupdict()["source"], Loader=Loader)
-                except yaml.YAMLError as _exc:  # noqa: F841
+                except yaml.YAMLError:
                     source = extracted.groupdict()["source"]
                 try:
                     current = yaml.load(extracted.groupdict()["current"], Loader=Loader)
-                except yaml.YAMLError as _exc:  # noqa: F841
+                except yaml.YAMLError:
                     current = extracted.groupdict()["current"]
                 try:
                     if isinstance(source, dict):
@@ -321,7 +321,7 @@ class Action(App):
                         parsed[variable]["via"] = source
                     parsed[variable]["current"] = current
                     parsed[variable]["__current_value"] = extracted.groupdict()["current"]
-                except KeyError as _exc:  # noqa: F841
+                except KeyError:
                     self._logger.error("variable '%s' not found in list output")
                     return None
             else:

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -321,7 +321,7 @@ class Action(App):
                         parsed[variable]["via"] = source
                     parsed[variable]["current"] = current
                     parsed[variable]["__current_value"] = extracted.groupdict()["current"]
-                except KeyError as exc:  # noqa: F841
+                except KeyError as _exc:  # noqa: F841
                     self._logger.error("variable '%s' not found in list output")
                     return None
             else:


### PR DESCRIPTION
Fix an unused variable in actions/config
Use the same approach in 2 other places. (improves the fix in #746)

Disable the import error in utils, since that directory isn't really a package, but instead catalog_collections is just a script that gets run, so a full or relative import couldn't be used in this case.