### PR TITLE
[lint] Fix pylint `no-member` and `not-an-iterable`

### DIFF
--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -423,11 +423,13 @@ class Action(App):
             if form.cancelled:
                 return
 
+            # pylint: disable=not-an-iterable
             inventories = [
                 field.value
                 for field in form.fields
                 if hasattr(field, "value") and field.value != ""
             ]
+            # pylint: enable=not-an-iterable
             if not inventories:
                 return
 

--- a/src/ansible_navigator/ui_framework/field_checks.py
+++ b/src/ansible_navigator/ui_framework/field_checks.py
@@ -36,6 +36,7 @@ class FieldChecks:
     @property
     def checked(self) -> Tuple[bool, ...]:
         """conveniently return just checked"""
+        # pylint: disable=not-an-iterable
         return tuple(option.name for option in self.options if option.checked)
 
     @property

--- a/src/ansible_navigator/ui_framework/field_radio.py
+++ b/src/ansible_navigator/ui_framework/field_radio.py
@@ -31,6 +31,7 @@ class FieldRadio:
     @property
     def checked(self):
         """conveniently return just checked"""
+        # pylint: disable=not-an-iterable
         return tuple(option.name for option in self.options if option.checked)
 
     @property

--- a/src/ansible_navigator/ui_framework/form.py
+++ b/src/ansible_navigator/ui_framework/form.py
@@ -28,28 +28,36 @@ class Form:
     def present(self, screen, ui_config):
         """present the form the to user and return the results"""
         if self.type is FormType.FORM:
+            # pylint: disable=no-member
             self.fields.append(
                 FieldButton(
                     name="submit", text="Submit", validator=FormValidators.all_true, color=10
                 )
             )
             self.fields.append(FieldButton(name="cancel", text="Cancel", color=9))
+            # pylint: enable=no-member
         elif self.type is FormType.NOTIFICATION:
+            # pylint: disable=no-member
             self.fields.append(
                 FieldButton(
                     name="submit", text=" Ok ", validator=FormValidators.no_validation, color=10
                 )
             )
+            # pylint: enable=no-member
         elif self.type is FormType.WORKING:
             pass
 
         FormPresenter(form=self, screen=screen, ui_config=ui_config).present()
         try:
+            # pylint: disable=not-an-iterable
             self.submitted = next(field for field in self.fields if field.name == "submit").pressed
+            # pylint: enable=not-an-iterable
         except StopIteration:
             self.submitted = False
         try:
+            # pylint: disable=not-an-iterable
             self.cancelled = next(field for field in self.fields if field.name == "cancel").pressed
+            # pylint: enable=not-an-iterable
         except StopIteration:
             self.cancelled = False
         return self

--- a/src/ansible_navigator/ui_framework/form_utils.py
+++ b/src/ansible_navigator/ui_framework/form_utils.py
@@ -54,7 +54,7 @@ def dict_to_form(form_data: Dict) -> Form:
             if pre_populate:
                 frm_field_text.pre_populate(pre_populate)
 
-            form.fields.append(frm_field_text)
+            form.fields.append(frm_field_text)  # pylint: disable=no-member
 
         elif field["type"] in ["checkbox", "radio"]:
             field_params["prompt"] = field["prompt"]
@@ -68,19 +68,19 @@ def dict_to_form(form_data: Dict) -> Form:
                 if min_selected:
                     field_params["min_selected"] = min_selected
                 frm_field_checks = FieldChecks(**field_params)
-                form.fields.append(frm_field_checks)
+                form.fields.append(frm_field_checks)  # pylint: disable=no-member
 
             elif field["type"] == "radio":
                 frm_field_radio = FieldRadio(**field_params)
-                form.fields.append(frm_field_radio)
+                form.fields.append(frm_field_radio)  # pylint: disable=no-member
 
         elif field["type"] == "information":
             frm_field_info = FieldInformation(name=field["name"], information=field["information"])
-            form.fields.append(frm_field_info)
+            form.fields.append(frm_field_info)  # pylint: disable=no-member
 
         elif field["type"] == "working":
             frm_field_working = FieldWorking(name=field["name"], messages=field["messages"])
-            form.fields.append(frm_field_working)
+            form.fields.append(frm_field_working)  # pylint: disable=no-member
 
     return form
 


### PR DESCRIPTION
In the case of fields and options, both are dynamically created via a default factory.

The docs for E1101 state:

False positives: This message may report object members that are created dynamically, but exist at the time they are accessed.

http://pylint-messages.wikidot.com/messages:e1101

Although I could not find a mention for not-an-iterable (E1133), the assumption here is that it is also a false positive
