### PR TITLE
pylint: consolidate tm_tokenize ignore

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -226,7 +226,6 @@ repos:
     files: \.py$
     entry: python -m pylint
     args:
-    - --ignore=tm_tokenize
     - |-
       --disable=
       consider-using-with,

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,9 @@
+[MASTER]
+# tm_tokenize is ignored as the code originates from outside our team and,
+# at this time, we do not want to alter it to match our standards.
+ignore=
+    tm_tokenize
+
 [MESSAGES CONTROL]
 
 disable=duplicate-code,unsubscriptable-object,fixme

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ description = Enforce quality standards under {basepython} ({envpython})
 install_command = pip install {opts} {packages}
 commands =
   pre-commit run -a {posargs}
-  pylint {[base]pkg_name} tests --ignore=tm_tokenize
+  pylint {[base]pkg_name} tests
   black -v --diff --check {toxinidir}
 
 [testenv:lint-vetting]


### PR DESCRIPTION
Avoid configuring same exceptions in two places while also documenting
the reasons why they were added.

This also allows external pylint execution to be in sync with
our linting.
