### PR TITLE
chore: add release drafting and label checks

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,2 @@
+# see https://github.com/ansible-community/devtools
+_extends: ansible-community/devtools

--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -1,0 +1,9 @@
+# See https://github.com/ansible-community/devtools/blob/main/.github/workflows/ack.yml
+name: ack
+on:
+  pull_request_target:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  ack:
+    uses: ansible-community/devtools/.github/workflows/ack.yml@main

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,12 @@
+# See https://github.com/ansible-community/devtools/blob/main/.github/workflows/push.yml
+name: push
+on:
+  push:
+    branches:
+      - main
+      - 'releases/**'
+      - 'stable/**'
+
+jobs:
+  ack:
+    uses: ansible-community/devtools/.github/workflows/push.yml@main


### PR DESCRIPTION
Ensure that we log draft changes on https://github.com/ansible/ansible-navigator/releases
so we will know what is included in next release and be able to produce
more informative releases.

These files are the same as other projects we own, molecule,
ansible-lint, ansible-compat as they rely on shared configuration from
devtools project.
