### PR TITLE
Store the settings file path for use later in the `:settings` action

### DIFF
--- a/src/ansible_navigator/configuration_subsystem/configurator.py
+++ b/src/ansible_navigator/configuration_subsystem/configurator.py
@@ -32,7 +32,6 @@ class Configurator:
         application_configuration: ApplicationConfiguration,
         apply_previous_cli_entries: Union[List, C] = C.NONE,
         initial: bool = False,
-        settings_file_path: str = None,
     ):
         """
         :param params: A list of parameters e.g. ['-x', 'value']
@@ -42,7 +41,6 @@ class Configurator:
                                            ['all'] will apply all previous
         :param initial: Save the resulting configuration as the 'initial' configuration
                         The 'initial' will be used as a source for apply_previous_cli
-        :param settings_file_path: The full path to a settings file
         """
         self._apply_previous_cli_entries = apply_previous_cli_entries
         self._config = application_configuration
@@ -50,7 +48,6 @@ class Configurator:
         self._messages: List[LogMessage] = []
         self._params = params
         self._initial = initial
-        self._settings_file_path = settings_file_path
         self._sanity_check()
         self._unaltered_entries = deepcopy(self._config.entries)
 
@@ -145,19 +142,18 @@ class Configurator:
                 self._messages.append(LogMessage(level=logging.INFO, message=message))
 
     def _apply_settings_file(self) -> None:
-        if self._settings_file_path:
-            with open(self._settings_file_path, "r", encoding="utf-8") as config_fh:
+        settings_file_path = self._config.internals.settings_file_path
+        if isinstance(settings_file_path, str):
+            with open(settings_file_path, "r", encoding="utf-8") as config_fh:
                 try:
                     config = yaml.load(config_fh, Loader=SafeLoader)
                 except (yaml.scanner.ScannerError, yaml.parser.ParserError) as exc:
-                    exit_msg = (
-                        f"Settings file found {self._settings_file_path}, but failed to load it."
-                    )
+                    exit_msg = f"Settings file found {settings_file_path}, but failed to load it."
                     self._exit_messages.append(ExitMessage(message=exit_msg))
                     exit_msg = f"  error was: '{' '.join(str(exc).splitlines())}'"
                     self._exit_messages.append(ExitMessage(message=exit_msg))
                     exit_msg = (
-                        f"Try checking the settings file '{self._settings_file_path}'"
+                        f"Try checking the settings file '{settings_file_path}'"
                         "and ensure it is properly formatted"
                     )
                     self._exit_messages.append(

--- a/src/ansible_navigator/configuration_subsystem/configurator.py
+++ b/src/ansible_navigator/configuration_subsystem/configurator.py
@@ -142,18 +142,20 @@ class Configurator:
                 self._messages.append(LogMessage(level=logging.INFO, message=message))
 
     def _apply_settings_file(self) -> None:
-        settings_file_path = self._config.internals.settings_file_path
-        if isinstance(settings_file_path, str):
-            with open(settings_file_path, "r", encoding="utf-8") as config_fh:
+        settings_filesystem_path = self._config.internals.settings_file_path
+        if isinstance(settings_filesystem_path, str):
+            with open(settings_filesystem_path, "r", encoding="utf-8") as config_fh:
                 try:
                     config = yaml.load(config_fh, Loader=SafeLoader)
                 except (yaml.scanner.ScannerError, yaml.parser.ParserError) as exc:
-                    exit_msg = f"Settings file found {settings_file_path}, but failed to load it."
+                    exit_msg = (
+                        f"Settings file found {settings_filesystem_path}, but failed to load it."
+                    )
                     self._exit_messages.append(ExitMessage(message=exit_msg))
                     exit_msg = f"  error was: '{' '.join(str(exc).splitlines())}'"
                     self._exit_messages.append(ExitMessage(message=exit_msg))
                     exit_msg = (
-                        f"Try checking the settings file '{settings_file_path}'"
+                        f"Try checking the settings file '{settings_filesystem_path}'"
                         "and ensure it is properly formatted"
                     )
                     self._exit_messages.append(
@@ -176,13 +178,13 @@ class Configurator:
                 except TypeError as exc:
                     exit_msg = (
                         "Errors encountered when loading settings file:"
-                        f" {self._settings_file_path}"
+                        f" {settings_filesystem_path}"
                         f" while loading entry {entry.name}, attempted: {settings_file_path}."
                         f"The resulting error was {str(exc)}"
                     )
                     self._exit_messages.append(ExitMessage(message=exit_msg))
                     exit_msg = (
-                        f"Try checking the settings file '{self._settings_file_path}'"
+                        f"Try checking the settings file '{settings_filesystem_path}'"
                         "and ensure it is properly formatted"
                     )
                     self._exit_messages.append(

--- a/src/ansible_navigator/configuration_subsystem/definitions.py
+++ b/src/ansible_navigator/configuration_subsystem/definitions.py
@@ -37,6 +37,7 @@ class Constants(Enum):
         " applying previous cli common entries, this indicates"
         " that it will only be used if the subcommand is the same"
     )
+    SEARCH_PATH = "Found using search path"
     SENTINEL = "indicates a nonvalue"
     USER_CFG = "user provided configuration file"
     USER_CLI = "cli parameters"

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -90,6 +90,7 @@ class Internals(SimpleNamespace):
     collection_doc_cache: Union[C, Dict] = C.NOT_SET
     initialization_exit_messages = initialization_exit_messages
     initialization_messages = initialization_messages
+    settings_file_path: Union[None, str] = None
     share_directory: str = generate_share_directory()
 
 

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -91,6 +91,7 @@ class Internals(SimpleNamespace):
     initialization_exit_messages = initialization_exit_messages
     initialization_messages = initialization_messages
     settings_file_path: Union[None, str] = None
+    settings_source: C
     share_directory: str = generate_share_directory()
 
 

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -91,7 +91,7 @@ class Internals(SimpleNamespace):
     initialization_exit_messages = initialization_exit_messages
     initialization_messages = initialization_messages
     settings_file_path: Union[None, str] = None
-    settings_source: C
+    settings_source: C = C.NOT_SET
     share_directory: str = generate_share_directory()
 
 

--- a/src/ansible_navigator/initialization.py
+++ b/src/ansible_navigator/initialization.py
@@ -30,7 +30,7 @@ def error_and_exit_early(exit_messages: List[ExitMessage]) -> NoReturn:
     sys.exit(1)
 
 
-def find_config() -> Tuple[List[LogMessage], List[ExitMessage], Union[None, str]]:
+def find_config() -> Tuple[List[LogMessage], List[ExitMessage], Union[None, str], C]:
     """
     Find a configuration file, logging each step.
     Return (log messages, path).
@@ -40,6 +40,7 @@ def find_config() -> Tuple[List[LogMessage], List[ExitMessage], Union[None, str]
     messages: List[LogMessage] = []
     exit_messages: List[ExitMessage] = []
     config_path = None
+    settings_source = C.NONE
 
     # Check if the configuration file path is set via an environment var
     cfg_env_var = "ANSIBLE_NAVIGATOR_CONFIG"
@@ -49,7 +50,7 @@ def find_config() -> Tuple[List[LogMessage], List[ExitMessage], Union[None, str]
     messages.extend(new_messages)
     exit_messages.extend(new_exit_messages)
     if exit_messages:
-        return messages, exit_messages, config_path
+        return messages, exit_messages, config_path, settings_source
 
     # Find the setting file
     new_messages, new_exit_messages, found_config_path = find_settings_file()
@@ -57,21 +58,23 @@ def find_config() -> Tuple[List[LogMessage], List[ExitMessage], Union[None, str]
     messages.extend(new_messages)
     exit_messages.extend(new_exit_messages)
     if exit_messages:
-        return messages, exit_messages, config_path
+        return messages, exit_messages, config_path, settings_source
 
     # Pick the environment variable set first, followed by found, followed by leave as none
     if env_config_path is not None:
         config_path = env_config_path
+        settings_source = C.ENVIRONMENT_VARIABLE
         message = f"Using settings file at {config_path} set by {cfg_env_var}"
         messages.append(LogMessage(level=logging.DEBUG, message=message))
     elif found_config_path is not None:
         config_path = found_config_path
+        settings_source = C.SEARCH_PATH
         message = f"Using settings file at {config_path} in search path"
         messages.append(LogMessage(level=logging.DEBUG, message=message))
     else:
         message = "No valid settings file found, using all default values for settings."
         messages.append(LogMessage(level=logging.DEBUG, message=message))
-    return messages, exit_messages, config_path
+    return messages, exit_messages, config_path, settings_source
 
 
 def get_and_check_collection_doc_cache(
@@ -158,7 +161,12 @@ def parse_and_update(
     messages: List[LogMessage] = []
     exit_messages: List[ExitMessage] = []
 
-    new_messages, new_exit_messages, args.internals.settings_file_path = find_config()
+    (
+        new_messages,
+        new_exit_messages,
+        args.internals.settings_file_path,
+        args.internals.settings_source,
+    ) = find_config()
     messages.extend(new_messages)
     exit_messages.extend(new_exit_messages)
     if exit_messages:

--- a/src/ansible_navigator/initialization.py
+++ b/src/ansible_navigator/initialization.py
@@ -158,7 +158,7 @@ def parse_and_update(
     messages: List[LogMessage] = []
     exit_messages: List[ExitMessage] = []
 
-    new_messages, new_exit_messages, config_path = find_config()
+    new_messages, new_exit_messages, args.internals.settings_file_path = find_config()
     messages.extend(new_messages)
     exit_messages.extend(new_exit_messages)
     if exit_messages:
@@ -166,7 +166,6 @@ def parse_and_update(
 
     configurator = Configurator(
         params=params,
-        settings_file_path=config_path,
         application_configuration=args,
         apply_previous_cli_entries=apply_previous_cli_entries,
         initial=initial,

--- a/tests/unit/configuration_subsystem/conftest.py
+++ b/tests/unit/configuration_subsystem/conftest.py
@@ -54,10 +54,10 @@ def _generate_config(params=None, setting_file_name=None, initial=True) -> Gener
 
     # make a deep copy here to ensure we do not modify the original
     application_configuration = deepcopy(NavigatorConfiguration)
+    application_configuration.internals.settings_file_path = settings_file_path or None
     configurator = Configurator(
         application_configuration=application_configuration,
         params=params,
-        settings_file_path=settings_file_path or None,
         initial=initial,
     )
     messages, exit_messages = configurator.configure()

--- a/tests/unit/configuration_subsystem/test_internals.py
+++ b/tests/unit/configuration_subsystem/test_internals.py
@@ -1,9 +1,8 @@
-"""Test the internals of a NavigatorConfiguration"""
+"""Test the internals of a NavigatorConfiguration."""
 
 import os
 
 from copy import deepcopy
-
 
 from ansible_navigator.configuration_subsystem import Constants
 from ansible_navigator.configuration_subsystem import NavigatorConfiguration
@@ -15,13 +14,17 @@ from .defaults import TEST_FIXTURE_DIR
 def test_settings_file_path_file_none():
     """Confirm a settings file path is not stored in the internals when not present."""
     args = deepcopy(NavigatorConfiguration)
-    _messages, _exit_messages = parse_and_update(params=[], args=args, initial=True)
+    parse_and_update(params=[], args=args, initial=True)
     assert args.internals.settings_file_path is None
     assert args.internals.settings_source == Constants.NONE
 
 
 def test_settings_file_path_file_system(monkeypatch):
-    """Confirm a settings file path is stored in the internals when searched."""
+    """Confirm a settings file path is stored in the internals when searched.
+
+    :param monkeypatch: Fixture providing these helper methods for safely patching and mocking
+        functionality in tests
+    """
     settings_file = "ansible-navigator.yml"
     settings_file_path = os.path.join(TEST_FIXTURE_DIR, settings_file)
     args = deepcopy(NavigatorConfiguration)
@@ -31,17 +34,21 @@ def test_settings_file_path_file_system(monkeypatch):
 
     monkeypatch.setattr(os, "getcwd", getcwd)
 
-    _messages, _exit_messages = parse_and_update(params=[], args=args, initial=True)
+    parse_and_update(params=[], args=args, initial=True)
     assert args.internals.settings_file_path == settings_file_path
     assert args.internals.settings_source == Constants.SEARCH_PATH
 
 
 def test_settings_file_path_environment_variable(monkeypatch):
-    """Confirm a settings file path is stored in the internals when set via environment variable."""
+    """Confirm a settings file path is stored in the internals when set via environment variable.
+
+    :param monkeypatch: Fixture providing these helper methods for safely patching and mocking
+        functionality in tests
+    """
     settings_file = "ansible-navigator.yml"
     settings_file_path = os.path.join(TEST_FIXTURE_DIR, settings_file)
     monkeypatch.setenv("ANSIBLE_NAVIGATOR_CONFIG", settings_file_path)
     args = deepcopy(NavigatorConfiguration)
-    _messages, _exit_messages = parse_and_update(params=[], args=args, initial=True)
+    parse_and_update(params=[], args=args, initial=True)
     assert args.internals.settings_file_path == settings_file_path
     assert args.internals.settings_source == Constants.ENVIRONMENT_VARIABLE

--- a/tests/unit/configuration_subsystem/test_internals.py
+++ b/tests/unit/configuration_subsystem/test_internals.py
@@ -7,7 +7,6 @@ from copy import deepcopy
 from ansible_navigator.configuration_subsystem import Constants
 from ansible_navigator.configuration_subsystem import NavigatorConfiguration
 from ansible_navigator.initialization import parse_and_update
-
 from .defaults import TEST_FIXTURE_DIR
 
 

--- a/tests/unit/configuration_subsystem/test_internals.py
+++ b/tests/unit/configuration_subsystem/test_internals.py
@@ -2,18 +2,45 @@
 
 import os
 
+from copy import deepcopy
+
 from .defaults import TEST_FIXTURE_DIR
 
+from ansible_navigator.configuration_subsystem import Constants
+from ansible_navigator.configuration_subsystem import NavigatorConfiguration
+from ansible_navigator.initialization import parse_and_update
 
-def test_settings_file_path_provided(generate_config):
-    """Test a settings file path is stored in the internals when provided"""
+
+def test_settings_file_path_file_none(monkeypatch):
+    """Confirm a settings file path is not stored in the internals when not present."""
+    args = deepcopy(NavigatorConfiguration)
+    _messages, _exit_messages = parse_and_update(params=[], args=args, initial=True)
+    assert args.internals.settings_file_path is None
+    assert args.internals.settings_source == Constants.NONE
+
+
+def test_settings_file_path_file_system(monkeypatch):
+    """Confirm a settings file path is stored in the internals when searched."""
     settings_file = "ansible-navigator.yml"
     settings_file_path = os.path.join(TEST_FIXTURE_DIR, settings_file)
-    response = generate_config(setting_file_name="ansible-navigator.yml")
-    assert response.application_configuration.internals.settings_file_path == settings_file_path
+    args = deepcopy(NavigatorConfiguration)
+
+    def getcwd():
+        return TEST_FIXTURE_DIR
+
+    monkeypatch.setattr(os, "getcwd", getcwd)
+
+    _messages, _exit_messages = parse_and_update(params=[], args=args, initial=True)
+    assert args.internals.settings_file_path == settings_file_path
+    assert args.internals.settings_source == Constants.SEARCH_PATH
 
 
-def test_settings_file_path_not_provided(generate_config):
-    """Test a settings file path is stored in the internals as None"""
-    response = generate_config()
-    assert response.application_configuration.internals.settings_file_path is None
+def test_settings_file_path_environment_variable(monkeypatch):
+    """Confirm a settings file path is stored in the internals when set via environment variable."""
+    settings_file = "ansible-navigator.yml"
+    settings_file_path = os.path.join(TEST_FIXTURE_DIR, settings_file)
+    monkeypatch.setenv("ANSIBLE_NAVIGATOR_CONFIG", settings_file_path)
+    args = deepcopy(NavigatorConfiguration)
+    _messages, _exit_messages = parse_and_update(params=[], args=args, initial=True)
+    assert args.internals.settings_file_path == settings_file_path
+    assert args.internals.settings_source == Constants.ENVIRONMENT_VARIABLE

--- a/tests/unit/configuration_subsystem/test_internals.py
+++ b/tests/unit/configuration_subsystem/test_internals.py
@@ -12,6 +12,7 @@ def test_settings_file_path_provided(generate_config):
     response = generate_config(setting_file_name="ansible-navigator.yml")
     assert response.application_configuration.internals.settings_file_path == settings_file_path
 
+
 def test_settings_file_path_not_provided(generate_config):
     """Test a settings file path is stored in the internals as None"""
     response = generate_config()

--- a/tests/unit/configuration_subsystem/test_internals.py
+++ b/tests/unit/configuration_subsystem/test_internals.py
@@ -4,14 +4,15 @@ import os
 
 from copy import deepcopy
 
-from .defaults import TEST_FIXTURE_DIR
 
 from ansible_navigator.configuration_subsystem import Constants
 from ansible_navigator.configuration_subsystem import NavigatorConfiguration
 from ansible_navigator.initialization import parse_and_update
 
+from .defaults import TEST_FIXTURE_DIR
 
-def test_settings_file_path_file_none(monkeypatch):
+
+def test_settings_file_path_file_none():
     """Confirm a settings file path is not stored in the internals when not present."""
     args = deepcopy(NavigatorConfiguration)
     _messages, _exit_messages = parse_and_update(params=[], args=args, initial=True)

--- a/tests/unit/configuration_subsystem/test_internals.py
+++ b/tests/unit/configuration_subsystem/test_internals.py
@@ -1,0 +1,18 @@
+"""Test the internals of a NavigatorConfiguration"""
+
+import os
+
+from .defaults import TEST_FIXTURE_DIR
+
+
+def test_settings_file_path_provided(generate_config):
+    """Test a settings file path is stored in the internals when provided"""
+    settings_file = "ansible-navigator.yml"
+    settings_file_path = os.path.join(TEST_FIXTURE_DIR, settings_file)
+    response = generate_config(setting_file_name="ansible-navigator.yml")
+    assert response.application_configuration.internals.settings_file_path == settings_file_path
+
+def test_settings_file_path_not_provided(generate_config):
+    """Test a settings file path is stored in the internals as None"""
+    response = generate_config()
+    assert response.application_configuration.internals.settings_file_path is None

--- a/tests/unit/configuration_subsystem/test_previous_cli.py
+++ b/tests/unit/configuration_subsystem/test_previous_cli.py
@@ -17,6 +17,7 @@ from ansible_navigator.configuration_subsystem.definitions import Constants as C
 from ansible_navigator.configuration_subsystem.definitions import SettingsEntry
 from ansible_navigator.configuration_subsystem.definitions import SettingsEntryValue
 from ansible_navigator.configuration_subsystem.definitions import SubCommand
+from ansible_navigator.configuration_subsystem.navigator_configuration import Internals
 from ansible_navigator.configuration_subsystem.navigator_configuration import (
     NavigatorConfiguration,
 )

--- a/tests/unit/configuration_subsystem/test_previous_cli.py
+++ b/tests/unit/configuration_subsystem/test_previous_cli.py
@@ -266,6 +266,7 @@ def test_apply_cli_subset_none():
     """Ensure subset none works for apply CLI"""
     test_config = ApplicationConfiguration(
         application_name="test_application",
+        internals=Internals(),
         post_processor=None,
         subcommands=[
             SubCommand(name="list", description="list"),

--- a/tests/unit/configuration_subsystem/test_sample_configurations.py
+++ b/tests/unit/configuration_subsystem/test_sample_configurations.py
@@ -47,6 +47,7 @@ def test_no_subcommand():
     """Ensure a configuration without no ``subparser`` entry fails"""
     test_config = ApplicationConfiguration(
         application_name="test_config1",
+        internals=Internals(),
         post_processor=None,
         subcommands=[
             SubCommand(name="subcommand1", description="subcommand1"),
@@ -61,6 +62,7 @@ def test_many_subcommand():
     """Ensure a configuration without a ``subparser`` entry fails"""
     test_config = ApplicationConfiguration(
         application_name="test_config1",
+        internals=Internals(),
         post_processor=None,
         subcommands=[
             SubCommand(name="subcommand1", description="subcommand1"),

--- a/tests/unit/configuration_subsystem/test_sample_configurations.py
+++ b/tests/unit/configuration_subsystem/test_sample_configurations.py
@@ -12,6 +12,7 @@ from ansible_navigator.configuration_subsystem.definitions import CliParameters
 from ansible_navigator.configuration_subsystem.definitions import SettingsEntry
 from ansible_navigator.configuration_subsystem.definitions import SettingsEntryValue
 from ansible_navigator.configuration_subsystem.definitions import SubCommand
+from ansible_navigator.configuration_subsystem.navigator_configuration import Internals
 from ansible_navigator.configuration_subsystem.navigator_post_processor import (
     NavigatorPostProcessor,
 )


### PR DESCRIPTION
In order to present the current settings file path in `:settings`, we'll keep it in the internals.

Additionally, keep the source of how it was found.

A couple quick tests to ensure it get added.
