### PR TITLE
pin `astroid` due to false `no-name-in-module` and `no-member` errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,11 @@ commands =
 deps =
   {[testenv]deps}
   -r{toxinidir}/docs/requirements.in
+  # astroid is a dep for pylint, > 2.9.0 introduces false no-name-in-module and no-member errors
+  # attempt to remove this when astroid 2.9.4 or later is released
+  # related: https://github.com/PyCQA/pylint/issues/5131
+  # related: https://github.com/ansible/ansible-navigator/issues/772
+  astroid == 2.9.0
   pylint
   pylint-pytest < 1.1.0
 


### PR DESCRIPTION
Related: https://github.com/ansible/ansible-navigator/issues/772