### PR TITLE
Cap the version `Sphinx` below 4.4.0

### DIFF
--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,6 +1,7 @@
 myst-parser[linkify] >= 0.15.1
 setuptools-scm >= 6.0.1
-Sphinx >= 4.1.2
+# https://github.com/sphinx-doc/sphinx/issues/10112
+Sphinx >= 4.1.2, < 4.4.0
 sphinx-ansible-theme >= 0.8.0
 sphinx-copybutton >= 0.4.0
 sphinx-notfound-page >= 0.7.1

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,7 +1,6 @@
 myst-parser[linkify] >= 0.15.1
 setuptools-scm >= 6.0.1
-# https://github.com/sphinx-doc/sphinx/issues/10112
-Sphinx >= 4.1.2, < 4.4.0
+Sphinx >= 4.1.2, < 4.4.0  # https://github.com/sphinx-doc/sphinx/issues/10112
 sphinx-ansible-theme >= 0.8.0
 sphinx-copybutton >= 0.4.0
 sphinx-notfound-page >= 0.7.1


### PR DESCRIPTION
The latest version of sphinx was causing the following errors, and therefore is being capped to version prior to the version causing the errors.

```
/home/docs/checkouts/readthedocs.org/user_builds/ansible-navigator/checkouts/774/docs/changelog.md:16: WARNING: hardcoded link 'https://github.com/twisted/towncrier' could be replaced by an extlink (try using ':gh:`twisted/towncrier`' instead)
/home/docs/checkouts/readthedocs.org/user_builds/ansible-navigator/checkouts/774/docs/installation.md:3: WARNING: hardcoded link 'https://github.com/containers/podman/issues/8016' could be replaced by an extlink (try using ':gh:`containers/podman/issues/8016`' instead)
```
Detailed information about the changes introduced in sphinx causing the errors can be found here:
Related: sphinx-doc/sphinx#10112

The following issue was created to revert this PR once the sphinx error is fixed or can be avoided:
See #776