### PR TITLE
Activate `pylint-pytest` plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,10 @@ skip_glob = ["tests/fixtures/common/collections*"] # Skip ansible content due to
     # tm_tokenize is virtually vendored and shouldn't be linted as such
     ignore = "tm_tokenize"
 
+    load-plugins = [
+      "pylint_pytest",  # suppresses false-positive violations in pytest tests
+    ]
+
     [tool.pylint.messages_control]
     disable = [
       "duplicate-code",


### PR DESCRIPTION
This patch is necessary because `pylint` does not autoactivate third-
party plugins just because they are installed in the same virtualenv.

It seems like this bit of the original configuration got lost over
time: the Python distribution package is present in the dependencies
and gets installed but `pylint` does not use it. With this change, it
becomes used again.