### PR TITLE
Correct parameters in docstrings so they match function signatures

### DIFF
--- a/src/ansible_navigator/actions/back.py
+++ b/src/ansible_navigator/actions/back.py
@@ -24,9 +24,7 @@ class Action:
         """Handle <ESC>
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         self._logger.debug("back requested")
         interaction.ui.scroll(0)

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -102,7 +102,8 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction or :data:`None`
+        :return: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction` or
+            :data:`None`
         """
         self._logger.debug("collections requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -101,9 +101,8 @@ class Action(App):
         """Handle :doc
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
+        :return: The pending interaction or none
         """
         self._logger.debug("collections requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -102,7 +102,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction or none
+        :return: The pending interaction or :data:`None`
         """
         self._logger.debug("collections requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -104,7 +104,8 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction or :data:`None`
+        :return: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction` or
+            :data:`None`
         """
         self._logger.debug("config requested in interactive mode")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -104,6 +104,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
+        :return: The pending interaction or :data:`None`
         """
         self._logger.debug("config requested in interactive mode")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -103,9 +103,7 @@ class Action(App):
         """Handle :doc
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         self._logger.debug("config requested in interactive mode")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -65,6 +65,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
+        :return: The pending interaction or :data:`None`
         """
         self._logger.debug("doc requested in interactive")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -64,9 +64,7 @@ class Action(App):
         """Handle :doc
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         self._logger.debug("doc requested in interactive")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -65,7 +65,8 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction or :data:`None`
+        :return: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction` or
+            :data:`None`
         """
         self._logger.debug("doc requested in interactive")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/filter.py
+++ b/src/ansible_navigator/actions/filter.py
@@ -23,9 +23,7 @@ class Action:
         """Handle :filter
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         self._logger.debug("filter requested")
         menu_filter = interaction.action.match.groupdict()["regex"]

--- a/src/ansible_navigator/actions/help_doc.py
+++ b/src/ansible_navigator/actions/help_doc.py
@@ -23,6 +23,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
+        :return: The pending interaction
         """
         self._logger.debug("help requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/help_doc.py
+++ b/src/ansible_navigator/actions/help_doc.py
@@ -23,7 +23,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction
+        :return: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction`
         """
         self._logger.debug("help requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/help_doc.py
+++ b/src/ansible_navigator/actions/help_doc.py
@@ -22,9 +22,7 @@ class Action(App):
         """Handle :help
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         self._logger.debug("help requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -116,7 +116,8 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction or :data:`None`
+        :return: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction` or
+            :data:`None`
         """
         self._logger.debug("images requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -116,6 +116,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
+        :return: The pending interaction or :data:`None`
         """
         self._logger.debug("images requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -115,9 +115,7 @@ class Action(App):
         """Handle :images
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         self._logger.debug("images requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -165,7 +165,8 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction or :data:`None`
+        :return: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction` or
+            :data:`None`
         """
         self._logger.debug("inventory requested in interactive mode")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -165,7 +165,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction or none
+        :return: The pending interaction or :data:`None`
         """
         self._logger.debug("inventory requested in interactive mode")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -164,9 +164,8 @@ class Action(App):
         """Handle :inventory
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
-        :param calling_app: The calling_app instance
-        :type calling_app: App
+        :param app: The app instance
+        :return: The pending interaction or none
         """
         self._logger.debug("inventory requested in interactive mode")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/log.py
+++ b/src/ansible_navigator/actions/log.py
@@ -22,7 +22,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction
+        :return: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction`
         """
         self._logger.debug("log requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/log.py
+++ b/src/ansible_navigator/actions/log.py
@@ -21,9 +21,7 @@ class Action(App):
         """Handle :log
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         self._logger.debug("log requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/log.py
+++ b/src/ansible_navigator/actions/log.py
@@ -22,6 +22,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
+        :return: The pending interaction
         """
         self._logger.debug("log requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/open_file.py
+++ b/src/ansible_navigator/actions/open_file.py
@@ -59,9 +59,7 @@ class Action:
         """Handle :open
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         self._logger.debug("open requested")
 

--- a/src/ansible_navigator/actions/quit.py
+++ b/src/ansible_navigator/actions/quit.py
@@ -27,7 +27,7 @@ class Action:
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction
+        :return: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction`
         """
         self._logger.debug("quit was requested as: %s", interaction.action.value)
         return interaction

--- a/src/ansible_navigator/actions/quit.py
+++ b/src/ansible_navigator/actions/quit.py
@@ -23,9 +23,11 @@ class Action:
     def run(self, interaction: Interaction, app: AppPublic) -> Interaction:
         """Handle a request to quit the application.
 
+        A request to quit is ultimately handled by the App so return immediately.
+
         :param interaction: The interaction from the user
         :param app: The app instance
+        :return: The pending interaction
         """
-        # : quit will be handled in the app
         self._logger.debug("quit was requested as: %s", interaction.action.value)
         return interaction

--- a/src/ansible_navigator/actions/quit.py
+++ b/src/ansible_navigator/actions/quit.py
@@ -21,12 +21,10 @@ class Action:
 
     # pylint: disable=unused-argument
     def run(self, interaction: Interaction, app: AppPublic) -> Interaction:
-        """Handle :doc
+        """Handle a request to quit the application.
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         # : quit will be handled in the app
         self._logger.debug("quit was requested as: %s", interaction.action.value)

--- a/src/ansible_navigator/actions/quit.py
+++ b/src/ansible_navigator/actions/quit.py
@@ -21,9 +21,11 @@ class Action:
 
     # pylint: disable=unused-argument
     def run(self, interaction: Interaction, app: AppPublic) -> Interaction:
-        """Handle a request to quit the application.
+        """Handle a request to quit the application from the user interface.
 
-        A request to quit is ultimately handled by the App so return immediately.
+        The application exit is ultimately handled by
+        :class:`~ansible_navigator.action_runner.ActionRunner` so return immediately,
+        passing the ``:quit`` request backwards through the stack of actions that are on the stack.
 
         :param interaction: The interaction from the user
         :param app: The app instance

--- a/src/ansible_navigator/actions/refresh.py
+++ b/src/ansible_navigator/actions/refresh.py
@@ -23,9 +23,7 @@ class Action:
         """Handle :refresh
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         # Just in case the user switched tasks with +,- etc
         # change previous, since this interaction is on the stack

--- a/src/ansible_navigator/actions/rerun.py
+++ b/src/ansible_navigator/actions/rerun.py
@@ -27,9 +27,7 @@ class Action:
         """Handle :rerun
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         self._logger.debug("rerun requested")
         this = copy.copy(app.steps.current)

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -261,7 +261,8 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction or :data:`None`
+        :return: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction` or
+            :data:`None`
         """
 
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -261,7 +261,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction or none
+        :return: The pending interaction or :data:`None`
         """
 
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -260,9 +260,8 @@ class Action(App):
         """run :run or :replay
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
+        :return: The pending interaction or none
         """
 
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/sample_form.py
+++ b/src/ansible_navigator/actions/sample_form.py
@@ -99,9 +99,8 @@ class Action(App):
         """Handle :doc
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
+        :return: The pending interaction
         """
         self._logger.debug("sample form requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/sample_form.py
+++ b/src/ansible_navigator/actions/sample_form.py
@@ -100,7 +100,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending :class:`interaction <~Interaction>`
+        :return: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction`
         """
         self._logger.debug("sample form requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/sample_form.py
+++ b/src/ansible_navigator/actions/sample_form.py
@@ -100,7 +100,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction
+        :return: The pending :class:`interaction <~Interaction>`
         """
         self._logger.debug("sample form requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/sample_notification.py
+++ b/src/ansible_navigator/actions/sample_notification.py
@@ -42,9 +42,8 @@ class Action(App):
         """Handle :doc
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
+        :return: The pending interaction
         """
         self._logger.debug("sample notification requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/sample_notification.py
+++ b/src/ansible_navigator/actions/sample_notification.py
@@ -43,7 +43,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction
+        :return: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction`
         """
         self._logger.debug("sample notification requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/sample_working.py
+++ b/src/ansible_navigator/actions/sample_working.py
@@ -25,9 +25,7 @@ class Action(App):
         """Handle :doc
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         self._logger.debug("sample working requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/save.py
+++ b/src/ansible_navigator/actions/save.py
@@ -23,9 +23,7 @@ class Action:
         """Handle :save
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         self._logger.debug("save requested")
         filename = interaction.action.match.groupdict()["filename"]

--- a/src/ansible_navigator/actions/select.py
+++ b/src/ansible_navigator/actions/select.py
@@ -26,9 +26,7 @@ class Action:
         """Handle :[0-n]
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         self._logger.debug("selection made")
         interaction.ui.scroll(0)

--- a/src/ansible_navigator/actions/serialize_json.py
+++ b/src/ansible_navigator/actions/serialize_json.py
@@ -23,9 +23,7 @@ class Action:
         """Handle :json
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         self._logger.debug("json requested")
         if interaction.ui is not None:

--- a/src/ansible_navigator/actions/serialize_yaml.py
+++ b/src/ansible_navigator/actions/serialize_yaml.py
@@ -23,7 +23,7 @@ class Action:
         """Handle :yaml
 
         :param interaction: The interaction from the user, action and value
-        :type interaction: dict
+        :param app: The app instance
         """
         self._logger.debug("yaml requested")
         if interaction.ui is not None:

--- a/src/ansible_navigator/actions/stdout.py
+++ b/src/ansible_navigator/actions/stdout.py
@@ -23,6 +23,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
+        :return: The pending interaction
         """
         self._logger.debug("stdout requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/stdout.py
+++ b/src/ansible_navigator/actions/stdout.py
@@ -23,7 +23,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction
+        :return: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction`
         """
         self._logger.debug("stdout requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/stdout.py
+++ b/src/ansible_navigator/actions/stdout.py
@@ -22,9 +22,7 @@ class Action(App):
         """Handle :stdout
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         self._logger.debug("stdout requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/template.py
+++ b/src/ansible_navigator/actions/template.py
@@ -30,9 +30,8 @@ class Action(App):
         """Handle :{{ }}
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
+        :return: The pending interaction or none
         """
         self._logger.debug("template requested '%s'", interaction.action.value)
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/template.py
+++ b/src/ansible_navigator/actions/template.py
@@ -31,7 +31,8 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction or :data:`None`
+        :return: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction` or
+            :data:`None`
         """
         self._logger.debug("template requested '%s'", interaction.action.value)
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/template.py
+++ b/src/ansible_navigator/actions/template.py
@@ -31,7 +31,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction or none
+        :return: The pending interaction or :data:`None`
         """
         self._logger.debug("template requested '%s'", interaction.action.value)
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/welcome.py
+++ b/src/ansible_navigator/actions/welcome.py
@@ -27,9 +27,8 @@ class Action(App):
         """Handle :welcome
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
+        :return: The pending interaction
         """
         self._logger.debug("welcome requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/welcome.py
+++ b/src/ansible_navigator/actions/welcome.py
@@ -28,7 +28,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending interaction
+        :return: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction`
         """
         self._logger.debug("welcome requested")
         self._prepare_to_run(app, interaction)

--- a/src/ansible_navigator/actions/write_file.py
+++ b/src/ansible_navigator/actions/write_file.py
@@ -29,9 +29,7 @@ class Action:
         """Handle :write
 
         :param interaction: The interaction from the user
-        :type interaction: Interaction
         :param app: The app instance
-        :type app: App
         """
         # pylint: disable=too-many-branches
         self._logger.debug("write requested as %s", interaction.action.value)

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -102,9 +102,10 @@ class NavigatorPostProcessor:
     """application post processor"""
 
     def __init__(self):
-        # Volume mounts accumulated from post processing various config entries.
-        # These get processed towards the end, in the (delayed)
-        # execution_environment_volume_mounts() post-processor.
+        """Initialize the post processor."""
+        #: Volume mounts accumulated from post processing various config entries.
+        #: These get processed towards the end, in the (delayed)
+        #: execution_environment_volume_mounts() post-processor.
         self.extra_volume_mounts: List[VolumeMount] = []
 
     @staticmethod

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -105,7 +105,7 @@ class NavigatorPostProcessor:
         """Initialize the post processor."""
         #: Volume mounts accumulated from post processing various config entries.
         #: These get processed towards the end, in the (delayed)
-        #: execution_environment_volume_mounts() post-processor.
+        #: :meth:`.execution_environment_volume_mounts` post-processor.
         self.extra_volume_mounts: List[VolumeMount] = []
 
     @staticmethod

--- a/src/ansible_navigator/runner/ansible_config.py
+++ b/src/ansible_navigator/runner/ansible_config.py
@@ -19,21 +19,16 @@ class AnsibleConfig(Base):
     ) -> Tuple[str, str]:
         """Run ansible-config command and get the configuration related details.
 
-        Args:
-            action (str): The configuration fetch action to perform. Valid values are \
-                          one of ``list``, ``dump``, ``view``. The ``list`` action \
-                          will fetch all the config options along with config description, \
-                         ``dump`` action will fetch all the active config and ``view`` \
-                         action will return the active configuration file view.
-            config_file (Optional, optional): Path to configuration file, defaults to \
-                                              first file found in precedence.. Defaults to ``None``.
-            only_changed (Optional, optional): The boolean value when set to ``True`` returns only \
-                                               the configurations that have changed from the \
-                                               default. This parameter is applicable only when \
-                                               ``action`` is set to ``dump``.. Defaults to `None`.
-
-        Returns:
-            Tuple[str, str]: Returns a tuple of response and error string (if any).
+        :param action: The configuration fetch action to perform. Valid values are one of
+            ``list``, ``dump``, ``view``. The ``list`` action will fetch all the config
+            options along with config description, ``dump`` action will fetch all the active
+            config and ``view`` action will return the active configuration file view.
+        :param config_file: Path to configuration file, defaults to first file found in
+            precedence.. Defaults to ``None``.
+        :param only_changed: The boolean value when set to ``True`` returns only the
+            configurations that have changed from the default. This parameter is applicable only
+            when ``action`` is set to ``dump``.. Defaults to `None`.
+        :return: A tuple of response and error string (if any).
         """
         return get_ansible_config(
             action, config_file=config_file, only_changed=only_changed, **self._runner_args

--- a/src/ansible_navigator/runner/ansible_config.py
+++ b/src/ansible_navigator/runner/ansible_config.py
@@ -24,7 +24,7 @@ class AnsibleConfig(Base):
             options along with config description, ``dump`` action will fetch all the active
             config and ``view`` action will return the active configuration file view.
         :param config_file: Path to configuration file, defaults to first file found in
-            precedence.. Defaults to ``None``.
+            precedence. Defaults to ``None``.
         :param only_changed: The boolean value when set to ``True`` returns only the
             configurations that have changed from the default. This parameter is applicable only
             when ``action`` is set to ``dump``.. Defaults to `None`.

--- a/src/ansible_navigator/runner/ansible_config.py
+++ b/src/ansible_navigator/runner/ansible_config.py
@@ -27,7 +27,7 @@ class AnsibleConfig(Base):
             precedence. Defaults to ``None``.
         :param only_changed: The boolean value when set to ``True`` returns only the
             configurations that have changed from the default. This parameter is applicable only
-            when ``action`` is set to ``dump``.. Defaults to `None`.
+            when ``action`` is set to ``dump``. Defaults to `None`.
         :return: A tuple of response and error string (if any).
         """
         return get_ansible_config(

--- a/src/ansible_navigator/runner/ansible_inventory.py
+++ b/src/ansible_navigator/runner/ansible_inventory.py
@@ -27,26 +27,18 @@ class AnsibleInventory(Base):
     ) -> Tuple[str, str]:
         """Run ansible-inventory command and get the inventory related details
 
-        Args:
-            action (str): Valid values are one of ``graph``, ``host``, ``list`` \
-                          ``graph`` create inventory graph, ``host`` returns specific \
-                          host info and works as inventory script and ``list`` output \
-                          all hosts info and also works as inventory script.
-            inventories (List): List of inventory host path.
-            response_format (Optional[str], optional): The output format for response. \
-                                                       Valid values can be one of ``json``, \
-                                                       ``yaml``, ``toml``. \
-                                                       If ``action`` is ``graph`` only allowed \
-                                                       value is ``json``.
-            host (Optional[str], optional): When ``action`` is set to ``host`` this parameter is \
-                                            used to get the host specific information..
-            playbook_dir (Optional[str], optional): This parameter is used to sets the relative \
-                                                    path for the inventory.
-            vault_ids (Optional[str], optional): The vault identity to use.
-            vault_password_file (Optional[str], optional): The vault identity to use.
-
-        Returns:
-            Tuple[str, str]: Returns a tuple of response and error string (if any).
+        :param action: Valid values are one of ``graph``, ``host``, ``list``, ``graph`` create
+            inventory graph, ``host`` returns specific host info and works as inventory script
+            and ``list`` output all hosts info and also works as inventory script.
+        :param inventories: List of inventory host paths.
+        :param response_format: The output format for response. Valid values can be one of ``json``,
+            ``yaml``, ``toml``. If ``action`` is ``graph`` only allowed value is ``json``.
+        :param host: When ``action`` is set to ``host`` this parameter is used to get the host
+            specific information..
+        :param playbook_dir: This parameter is used to sets the relative path for the inventory.
+        :param vault_ids: The vault identity to use.
+        :param vault_password_file: The vault identity to use.
+        :return: A tuple of response and error string (if any).
         """
         return get_inventory(
             action,

--- a/src/ansible_navigator/runner/ansible_inventory.py
+++ b/src/ansible_navigator/runner/ansible_inventory.py
@@ -34,7 +34,7 @@ class AnsibleInventory(Base):
         :param response_format: The output format for response. Valid values can be one of ``json``,
             ``yaml``, ``toml``. If ``action`` is ``graph`` only allowed value is ``json``.
         :param host: When ``action`` is set to ``host`` this parameter is used to get the host
-            specific information..
+            specific information.
         :param playbook_dir: This parameter is used to sets the relative path for the inventory.
         :param vault_ids: The vault identity to use.
         :param vault_password_file: The vault identity to use.

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -260,9 +260,7 @@ def ansi_to_curses(line: str) -> CursesLine:
     """Convert ansible color codes to curses colors
 
     :param line: A string with ansi colors
-    :type line: str
     :return: A list of str tuples [(x, s, c), (x, s, c)...]
-    :rtype: list
     """
     printable = []
     ansi_regex = re.compile(r"(\x1b\[[\d;]*m)")

--- a/src/ansible_navigator/ui_framework/menu_builder.py
+++ b/src/ansible_navigator/ui_framework/menu_builder.py
@@ -96,6 +96,7 @@ class MenuBuilder:
 
         :param colno: The column number
         :param menu_layout: A tuple of menu details:
+
             * ``menu_layout[0]``: ``List[int]``, the starting in for each column
             * ``menu_layout[1]``: ``List[str]``, the columns of the menu
             * ``menu_layout[2]``: ``List[int]``, the adjusted column widths
@@ -122,6 +123,7 @@ class MenuBuilder:
 
         :params dicts: A list of dicts from which the menu will be generated
         :param menu_layout: A tuple of menu details:
+
             * ``menu_layout[0]``: ``List[int]``, the starting in for each column
             * ``menu_layout[1]``: ``List[str]``, the columns of the menu
             * ``menu_layout[2]``: ``List[int]``, the adjusted column widths
@@ -135,6 +137,7 @@ class MenuBuilder:
 
         :param dyct: One dict from which the menu line will be generated
         :param menu_layout: A tuple of menu details:
+
             * ``menu_layout[0]``: ``List[int]``, the starting in for each column
             * ``menu_layout[1]``: ``List[str]``, the columns of the menu
             * ``menu_layout[2]``: ``List[int]``, the adjusted column widths
@@ -157,6 +160,7 @@ class MenuBuilder:
         :param coltext: The text to be placed at the given column
         :param dyct: The dict from which the menu line will be generated
         :param menu_layout: A tuple of menu details:
+        
             * ``menu_layout[0]``: ``List[int]``, the starting in for each column
             * ``menu_layout[1]``: ``List[str]``, the columns of the menu
             * ``menu_layout[2]``: ``List[int]``, the adjusted column widths

--- a/src/ansible_navigator/ui_framework/menu_builder.py
+++ b/src/ansible_navigator/ui_framework/menu_builder.py
@@ -81,14 +81,10 @@ class MenuBuilder:
         """Generate the menu header line
 
         :param menu_layout: A tuple of menu details
-        :type menu_layout: tuple
-        :param menu_layout[0]: the starting in for each column
-        :type menu_layout[0]: List[int]
-        :param menu_layout[1]: the columns of the menu
-        :type menu_layout[1]: List[str]
-        :param menu_layout[2]: the adjusted column widths
-        :type menu_layout[2]: List[int]
-        :return: the menu head line
+            menu_layout[0]: List[int], the starting in for each column
+            menu_layout[1]: List[str], the columns of the menu
+            menu_layout[2]: List[int], the adjusted column widths
+        :return: The menu header line
         """
         _col_starts, cols, _adj_colws = menu_layout
         return tuple(self._menu_header_line_part(colno, menu_layout) for colno in range(len(cols)))
@@ -99,14 +95,10 @@ class MenuBuilder:
 
         :param colno: The column number
         :param menu_layout: A tuple of menu details
-        :type menu_layout: tuple
-        :param menu_layout[0]: the starting in for each column
-        :type menu_layout[0]: List[int]
-        :param menu_layout[1]: the columns of the menu
-        :type menu_layout[1]: List[str]
-        :param menu_layout[2]: the adjusted column widths
-        :type menu_layout[2]: List[int]
-        :return: the menu head line
+            menu_layout[0]: List[int], the starting in for each column
+            menu_layout[1]: List[str], the columns of the menu
+            menu_layout[2]: List[int], the adjusted column widths
+        :return: The menu head line
         """
         col_starts, cols, adj_colws = menu_layout
         coltext = re.sub("^__", "", cols[colno])
@@ -129,15 +121,11 @@ class MenuBuilder:
 
         :params dicts: A list of dicts from which the menu will be generated
         :param menu_layout: A tuple of menu details
-        :param menu_layout[0]: the starting in for each column
-        :type menu_layout[0]: List[int]
-        :param menu_layout[1]: the columns of the menu
-        :type menu_layout[1]: List[str]
-        :param menu_layout[2]: the adjusted column widths
-        :type menu_layout[2]: List[int]
-        :param menu_layout[3]: the menu header, used to determine justification
-        :type memu_layout[3]: CursesLine
-        :return: the menu lines
+            menu_layout[0]: List[int], the starting in for each column
+            menu_layout[1]: List[str], the columns of the menu
+            menu_layout[2]: List[int], the adjusted column widths
+            menu_layout[3]: CursesLine, the menu header, used to determine justification
+        :return: The menu lines
         """
         return tuple(self._menu_line(dicts[idx], menu_layout) for idx in indices)
 
@@ -146,16 +134,11 @@ class MenuBuilder:
 
         :param dyct: One dict from which the menu line will be generated
         :param menu_layout: A tuple of menu details
-        :type menu_layout: tuple
-        :param menu_layout[0]: the starting in for each column
-        :type menu_layout[0]: List[int]
-        :param menu_layout[1]: the columns of the menu
-        :type menu_layout[1]: List[str]
-        :param menu_layout[2]: the adjusted column widths
-        :type menu_layout[2]: List[int]
-        :param menu_layout[3]: the menu header, used to determine justification
-        :type memu_layout[3]: CursesLine
-        :return: a menu line
+            menu_layout[0]: List[int], the starting in for each column
+            menu_layout[1]: List[str], the columns of the menu
+            menu_layout[2]: List[int], the adjusted column widths
+            menu_layout[3]: CursesLine, the menu header, used to determine justification
+        :return: A menu line
         """
         _col_starts, cols, _adj_colws, _header = menu_layout
         menu_line = (dyct.get(c) for c in cols)
@@ -171,18 +154,13 @@ class MenuBuilder:
 
         :param colno: The column number of the line part
         :param coltext: The text to be placed at the given column
-        :param dyct: the dict from which the menu line will be generated
+        :param dyct: The dict from which the menu line will be generated
         :param menu_layout: A tuple of menu details
-        :type menu_layout: tuple
-        :param menu_layout[0]: the starting in for each column
-        :type menu_layout[0]: List[int]
-        :param menu_layout[1]: the columns of the menu
-        :type menu_layout[1]: List[str]
-        :param menu_layout[2]: the adjusted column widths
-        :type menu_layout[2]: List[int]
-        :param menu_layout[3]: the menu header, used to determine justification
-        :type memu_layout[3]: CursesLine
-        :return: a menu line part
+            menu_layout[0]: List[int], the starting in for each column
+            menu_layout[1]: List[str], the columns of the menu
+            menu_layout[2]: List[int], the adjusted column widths
+            menu_layout[3]: CursesLine, the menu header, used to determine justification
+        :return: A menu line part
         """
         col_starts, cols, adj_colws, header = menu_layout
 

--- a/src/ansible_navigator/ui_framework/menu_builder.py
+++ b/src/ansible_navigator/ui_framework/menu_builder.py
@@ -80,10 +80,11 @@ class MenuBuilder:
     def _menu_header_line(self, menu_layout: Tuple[List, ...]) -> CursesLine:
         """Generate the menu header line
 
-        :param menu_layout: A tuple of menu details
-            menu_layout[0]: List[int], the starting in for each column
-            menu_layout[1]: List[str], the columns of the menu
-            menu_layout[2]: List[int], the adjusted column widths
+        :param menu_layout: A tuple of menu details:
+
+            * ``menu_layout[0]``: ``List[int]``, the starting in for each column
+            * ``menu_layout[1]``: ``List[str]``, the columns of the menu
+            * ``menu_layout[2]``: ``List[int]``, the adjusted column widths
         :return: The menu header line
         """
         _col_starts, cols, _adj_colws = menu_layout
@@ -94,10 +95,10 @@ class MenuBuilder:
         """Generate one part of the menu header line
 
         :param colno: The column number
-        :param menu_layout: A tuple of menu details
-            menu_layout[0]: List[int], the starting in for each column
-            menu_layout[1]: List[str], the columns of the menu
-            menu_layout[2]: List[int], the adjusted column widths
+        :param menu_layout: A tuple of menu details:
+            * ``menu_layout[0]``: ``List[int]``, the starting in for each column
+            * ``menu_layout[1]``: ``List[str]``, the columns of the menu
+            * ``menu_layout[2]``: ``List[int]``, the adjusted column widths
         :return: The menu head line
         """
         col_starts, cols, adj_colws = menu_layout
@@ -120,11 +121,11 @@ class MenuBuilder:
         """Generate all the menu lines
 
         :params dicts: A list of dicts from which the menu will be generated
-        :param menu_layout: A tuple of menu details
-            menu_layout[0]: List[int], the starting in for each column
-            menu_layout[1]: List[str], the columns of the menu
-            menu_layout[2]: List[int], the adjusted column widths
-            menu_layout[3]: CursesLine, the menu header, used to determine justification
+        :param menu_layout: A tuple of menu details:
+            * ``menu_layout[0]``: ``List[int]``, the starting in for each column
+            * ``menu_layout[1]``: ``List[str]``, the columns of the menu
+            * ``menu_layout[2]``: ``List[int]``, the adjusted column widths
+            * ``menu_layout[3]``: ``CursesLine``, the menu header, used to determine justification
         :return: The menu lines
         """
         return tuple(self._menu_line(dicts[idx], menu_layout) for idx in indices)
@@ -133,11 +134,11 @@ class MenuBuilder:
         """Generate one the menu line
 
         :param dyct: One dict from which the menu line will be generated
-        :param menu_layout: A tuple of menu details
-            menu_layout[0]: List[int], the starting in for each column
-            menu_layout[1]: List[str], the columns of the menu
-            menu_layout[2]: List[int], the adjusted column widths
-            menu_layout[3]: CursesLine, the menu header, used to determine justification
+        :param menu_layout: A tuple of menu details:
+            * ``menu_layout[0]``: ``List[int]``, the starting in for each column
+            * ``menu_layout[1]``: ``List[str]``, the columns of the menu
+            * ``menu_layout[2]``: ``List[int]``, the adjusted column widths
+            * ``menu_layout[3]``: ``CursesLine``, the menu header, used to determine justification
         :return: A menu line
         """
         _col_starts, cols, _adj_colws, _header = menu_layout
@@ -155,11 +156,11 @@ class MenuBuilder:
         :param colno: The column number of the line part
         :param coltext: The text to be placed at the given column
         :param dyct: The dict from which the menu line will be generated
-        :param menu_layout: A tuple of menu details
-            menu_layout[0]: List[int], the starting in for each column
-            menu_layout[1]: List[str], the columns of the menu
-            menu_layout[2]: List[int], the adjusted column widths
-            menu_layout[3]: CursesLine, the menu header, used to determine justification
+        :param menu_layout: A tuple of menu details:
+            * ``menu_layout[0]``: ``List[int]``, the starting in for each column
+            * ``menu_layout[1]``: ``List[str]``, the columns of the menu
+            * ``menu_layout[2]``: ``List[int]``, the adjusted column widths
+            * ``menu_layout[3]``: ``CursesLine``, the menu header, used to determine justification
         :return: A menu line part
         """
         col_starts, cols, adj_colws, header = menu_layout

--- a/src/ansible_navigator/ui_framework/menu_builder.py
+++ b/src/ansible_navigator/ui_framework/menu_builder.py
@@ -160,7 +160,7 @@ class MenuBuilder:
         :param coltext: The text to be placed at the given column
         :param dyct: The dict from which the menu line will be generated
         :param menu_layout: A tuple of menu details:
-        
+
             * ``menu_layout[0]``: ``List[int]``, the starting in for each column
             * ``menu_layout[1]``: ``List[str]``, the columns of the menu
             * ``menu_layout[2]``: ``List[int]``, the adjusted column widths

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -111,14 +111,14 @@ class UserInterface(CursesWindow):
         pbar_width: int = 8,
         status_width=12,
     ) -> None:
-        """initialize
+        """Initialize the user interface.
 
         :param screen_miny: The minimum screen height
-        :type screen_miny: int
+        :param kegexes: A callable producing a list og action regular expressions to match against
+        :param refresh: The screen refresh time is ms
+        :param ui_config: the current UI configuration
         :param pbar_width: The width of the progress bar
-        :type pbar_width: int
-        :param words_to_color: Words that get colored (regex, color_int)
-        :type words_to_color: list
+        :param status_width: The width of the status indicator
         """
         super().__init__(ui_config=ui_config)
         self._color_menu_item: Callable[[int, str, Dict[str, Any]], Tuple[int, int]]
@@ -176,7 +176,7 @@ class UserInterface(CursesWindow):
     def menu_filter(self, value: Union[str, None] = "") -> Union[Pattern, None]:
         """Set or return the menu filter.
 
-        :param args[0]: None or the menu_filter regex to set
+        :param value: None or the menu_filter regex to set
         :return: the current menu filter
         """
         if value != "":
@@ -299,16 +299,11 @@ class UserInterface(CursesWindow):
     ) -> None:
         """Add a scroll bar if the lines > viewport
 
-        :param footer_height: The height of the footer
-        :type footer_height: int
-        :param_len_heading: the height of the heading
-        :type len_heading: int
-        :param len_lines: the number of lines in the content
-        :type len_lines: int
-        :param body_start: where we are in the body
-        :type body_start: int
-        :param body_stop: the end of the body
-        :type body_stop: int
+        :param viewport_h: The height if the viewport
+        :param len_heading: The height of the heading
+        :param menu_size: The number of lines in the content
+        :param body_start: Where we are in the body
+        :param body_stop: The end of the body
         """
         start_scroll_bar = body_start / menu_size * viewport_h
         stop_scroll_bar = body_stop / menu_size * viewport_h
@@ -528,11 +523,9 @@ class UserInterface(CursesWindow):
         add colors as needed, maintain a mapping of RGB colors
         to curses colors in self._rgb_to_curses_color_idx
 
-        :params lines: the lines to transform
-        :type lines: list of lists of dicts
+        :params lines: The lines to transform
             Lines[LinePart[{"color": RGB, "chars": text, "column": n},...]]
         :return: the lines ready for curses
-        :type: CursesLines
         """
         if curses.COLORS > 16 and self._term_osc4_supprt:
             unique_colors = list(
@@ -720,11 +713,8 @@ class UserInterface(CursesWindow):
         """Check columns in a dictionary against a regex
 
         :param obj: The dict to check
-        :type obj: dict
         :param columns: The dicts keys to check
-        :type columns: list
         :return: True if a match else False
-        :rtype: bool
         """
         for key in columns:
             if self._search_value(self.menu_filter(), obj[key]):
@@ -752,13 +742,8 @@ class UserInterface(CursesWindow):
         """build the menu
 
         :param current: A dict
-        :type current: dict
         :param columns: The keys from the dictionary to use as columns
-        :type columns: list
-        :param distribute: method for width deficit
-        :type distribute: str
         :return: The heading and menu items
-        :rtype: CursesLines, CursesLines
         """
         menu_builder = MenuBuilder(
             pbar_width=self._pbar_width,
@@ -774,13 +759,9 @@ class UserInterface(CursesWindow):
         """Show a menu on the screen
 
         :param current: A dict
-        :type current: dict
         :param columns: The keys from the dictionary to use as columns
-        :type columns: list
         :param await_input: Should we wait for user input?
-        :type await_input: bool
-        :return: interaction with the user
-        :rtype: Interaction
+        :return: Interaction with the user
         """
 
         while True:

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -297,7 +297,7 @@ class UserInterface(CursesWindow):
     def _scroll_bar(
         self, viewport_h: int, len_heading: int, menu_size: int, body_start: int, body_stop: int
     ) -> None:
-        """Add a scroll bar if the lines > viewport
+        """Add a scroll bar if the length of the content is longer than the viewport height.
 
         :param viewport_h: The height if the viewport
         :param len_heading: The height of the heading

--- a/src/ansible_navigator/ui_framework/utils.py
+++ b/src/ansible_navigator/ui_framework/utils.py
@@ -12,12 +12,9 @@ def convert_percentage(dyct: dict, keys: List, pbar_width: int) -> None:
     not recursive
     80% = 80%|XXXXXXXX  |
 
-    :param dicts: a list of dictionaries
-    :type dicts: list[dict]
+    :param dyct: The dictionary to update
     :param keys: The keys to convert in each dictionary
-    :type keys: List[str]
     :param pbar_width: The width of the progress bar
-    :type pbar_width: int
     """
     for key in keys:
         value = dyct.get(key)

--- a/src/ansible_navigator/utils.py
+++ b/src/ansible_navigator/utils.py
@@ -444,9 +444,8 @@ def templar(string: str, template_vars: Mapping) -> Tuple[List[str], Any]:
     always to and from json so we return an object if it is
 
     :param string: The template string
-    :type string: str
     :param template_vars: The vars used to render the template
-    :type template_vars: dict
+    :return: A list of errors and either the result of templating or original string
     """
     errors = []
     # hide the jinja that may be in the template_vars

--- a/tests/unit/configuration_subsystem/test_navigator_post_processor.py
+++ b/tests/unit/configuration_subsystem/test_navigator_post_processor.py
@@ -27,5 +27,9 @@ from ansible_navigator.configuration_subsystem.navigator_post_processor import (
     ),
 )
 def test_navigator_volume_mount_to_string(volmount, expected):
-    """Make sure volume mount ``to_string`` is sane."""
+    """Make sure volume mount ``to_string`` is sane.
+
+    :param volmount: The volume mount to test
+    :param expected: The expected string resulting from the conversion of the mount to a string
+    """
     assert volmount.to_string() == expected

--- a/tests/unit/runner/__init__.py
+++ b/tests/unit/runner/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the runner subsystem which provides the ansible-runner integration."""

--- a/tests/unit/test_circular_imports.py
+++ b/tests/unit/test_circular_imports.py
@@ -27,7 +27,8 @@ import ansible_navigator
 def _find_all_importables(pkg: ModuleType) -> List[str]:
     """Find all importables in the project.
 
-    Return them in order.
+    :param pkg: The package in which importables will be found
+    :return: A sorted list of the importables
     """
     return sorted(
         set(
@@ -43,7 +44,12 @@ def _discover_path_importables(
     pkg_pth: Path,
     pkg_name: str,
 ) -> Generator[str, None, None]:
-    """Yield all importables under a given path and package."""
+    """Yield all importables under a given path and package.
+
+    :param pkg_pth: The path to the package to walk
+    :param pkg_name: The name of the package
+    :yields: A generator of package directory paths and prefixes
+    """
     for dir_path, _d, file_names in os.walk(pkg_pth):
         pkg_dir_path = Path(dir_path)
 
@@ -75,6 +81,8 @@ def test_no_warnings(import_path: str) -> None:
     by circular imports.
 
     DeprecationWarnings related to distutils in ansible_runner are ignored
+
+    :param import_path: The path that should be imported and checked for warnings
     """
     imp_cmd = (
         sys.executable,

--- a/tests/unit/test_circular_imports.py
+++ b/tests/unit/test_circular_imports.py
@@ -82,7 +82,7 @@ def test_no_warnings(import_path: str) -> None:
 
     DeprecationWarnings related to distutils in ansible_runner are ignored
 
-    :param import_path: The path to be imported and smoke-checked for warnings and crushes
+    :param import_path: The path to be imported and smoke-checked for warnings and crashes
     """
     imp_cmd = (
         sys.executable,

--- a/tests/unit/test_circular_imports.py
+++ b/tests/unit/test_circular_imports.py
@@ -82,7 +82,7 @@ def test_no_warnings(import_path: str) -> None:
 
     DeprecationWarnings related to distutils in ansible_runner are ignored
 
-    :param import_path: The path that should be imported and checked for warnings
+    :param import_path: The path to be imported and smoke-checked for warnings and crushes
     """
     imp_cmd = (
         sys.executable,

--- a/tests/unit/test_circular_imports.py
+++ b/tests/unit/test_circular_imports.py
@@ -48,7 +48,7 @@ def _discover_path_importables(
 
     :param pkg_pth: The path to the package to walk
     :param pkg_name: The name of the package
-    :yields: A generator of package directory paths and prefixes
+    :yields: Package directory paths
     """
     for dir_path, _d, file_names in os.walk(pkg_pth):
         pkg_dir_path = Path(dir_path)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,4 @@
-"""Test the utilities functions in utils.
-"""
+"""Test the functions exposed in the :mod:`~ansible_navigator.utils` subpackage."""
 import os
 
 from typing import List

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,4 +1,4 @@
-""" tests for the utilities in utils
+"""Test the utilities functions in utils.
 """
 import os
 


### PR DESCRIPTION
This PR updates doc strings across a number of files.

This PR does:
- Update doc strings across a number of files in an effort to improve and correct them. After, they more closely follow PEP257
- A majority of the changes correct parameters
- Other changes to correct errors in description
- Some minor formatting improvements
- Attempt to only fix errors that were not exempted from the current configuration of flake8 
- Remove some `type` information from docstrings in which it was found to be inaccurate. In the future we should be able to use the type information from the function signature for documentation

This PR does not:
- Attempt to fix everything thing incorrect in each doc string, but instead eliminate a specific error found by a linter (darglint) that is being vetted

This PR should:
- Allow users of `tox -e lint-vetting` to see new docstring errors reported by darglint as this PR should clean the current ones being reported.


Before these changes:
```
2     C812 missing trailing comma
1     D104 Missing docstring in public package
1     D107 Missing docstring in __init__
1     D210 No whitespaces allowed surrounding docstring text
1     DAR003 Incorrect indentation: ~<
16    DAR101 Missing parameter(s) in Docstring: - action
28    DAR102 Excess parameter(s) in Docstring: + calling_app
33    DAR103 Parameter type mismatch:  ~app: expected AppPublic but was App
3     DAR201 Missing "Returns" in Docstring: - return
1     DAR203 Return type mismatch:  ~Return: expected CursesLine but was list
1     DAR301 Missing "Yields" in Docstring: - yield
1     E800 Found commented out code
29    I001 isort found an import in the wrong position
6     I004 isort found an unexpected blank line in imports
10    I005 isort found an unexpected missing import
130   Q000 Double quotes found but single quotes preferred
7     S101 Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
1     S404 Consider possible security implications associated with the subprocess module.
1     S603 subprocess call - check for execution of untrusted input.
2     S604 Function call with shell=True parameter identified, possible security issue.
2     WPS111 Found too short name: p < 2
2     WPS115 Found upper-case constant in a class: KEGEX
2     WPS201 Found module with too many imports: 13 > 12
6     WPS210 Found too many local variables: 6 > 5
3     WPS220 Found too deep nesting: 24 > 20
2     WPS221 Found line with high Jones Complexity: 16 > 14
3     WPS226 Found string literal over-use: test_option > 3
9     WPS305 Found `f` string
1     WPS316 Found context manager with too many assignments
6     WPS317 Found incorrect multi-line parameters
2     WPS323 Found `%` string formatting
4     WPS324 Found inconsistent `return` statement
14    WPS436 Found protected module import: _curses
3     WPS450 Found protected object import: _CursesWindow
1     WPS602 Found using `@staticmethod`

```

After these changes:

```
2     C812 missing trailing comma
1     E800 Found commented out code
29    I001 isort found an import in the wrong position
6     I004 isort found an unexpected blank line in imports
10    I005 isort found an unexpected missing import
130   Q000 Double quotes found but single quotes preferred
7     S101 Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
1     S404 Consider possible security implications associated with the subprocess module.
1     S603 subprocess call - check for execution of untrusted input.
2     S604 Function call with shell=True parameter identified, possible security issue.
2     WPS111 Found too short name: p < 2
2     WPS115 Found upper-case constant in a class: KEGEX
2     WPS201 Found module with too many imports: 13 > 12
6     WPS210 Found too many local variables: 6 > 5
3     WPS220 Found too deep nesting: 24 > 20
2     WPS221 Found line with high Jones Complexity: 16 > 14
3     WPS226 Found string literal over-use: test_option > 3
9     WPS305 Found `f` string
1     WPS316 Found context manager with too many assignments
6     WPS317 Found incorrect multi-line parameters
2     WPS323 Found `%` string formatting
4     WPS324 Found inconsistent `return` statement
14    WPS436 Found protected module import: _curses
3     WPS450 Found protected object import: _CursesWindow
1     WPS602 Found using `@staticmethod`
```
