### PR TITLE
Change the order of relative imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ lines_after_imports = 2 # Ensures consistency for cases when there's variable vs
 lines_between_types = 1 # Separate import/from with 1 line, minimizing changes at time of implementation
 no_lines_before = "LOCALFOLDER"  # Keeps local imports bundled with first-party
 profile = "black" # Avoid conflict with black
-reverse_relative = true # Import local prior to parent
 skip_glob = ["tests/fixtures/common/collections*"] # Skip ansible content due to ansible-test sanity ruleset
 
 [tool.pylint]

--- a/src/ansible_navigator/actions/__init__.py
+++ b/src/ansible_navigator/actions/__init__.py
@@ -3,10 +3,10 @@ from typing import Any
 from typing import Callable
 from typing import Union
 
-from . import _actions as actions
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
+from . import _actions as actions
 
 
 get: Callable[[str], Any] = actions.get_factory(__package__)

--- a/src/ansible_navigator/actions/back.py
+++ b/src/ansible_navigator/actions/back.py
@@ -1,11 +1,11 @@
 """ESC, (step back)"""
 import logging
 
-from . import _actions as actions
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..steps import Step
 from ..ui_framework import Interaction
+from . import _actions as actions
 
 
 @actions.register

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -13,8 +13,6 @@ from typing import List
 from typing import Tuple
 from typing import Union
 
-from . import _actions as actions
-from . import run_action
 from ..app import App
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
@@ -25,6 +23,8 @@ from ..ui_framework import CursesLines
 from ..ui_framework import Interaction
 from ..ui_framework import nonblocking_notification
 from ..ui_framework import warning_notification
+from . import _actions as actions
+from . import run_action
 
 
 def color_menu(colno: int, colname: str, entry: Dict[str, Any]) -> Tuple[int, int]:

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -12,8 +12,6 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
-from . import _actions as actions
-from . import run_action
 from .._yaml import Loader
 from .._yaml import yaml
 from ..app import App
@@ -27,6 +25,8 @@ from ..ui_framework import CursesLines
 from ..ui_framework import Interaction
 from ..ui_framework import nonblocking_notification
 from ..ui_framework import warning_notification
+from . import _actions as actions
+from . import run_action
 
 
 def color_menu(colno: int, colname: str, entry: Dict[str, Any]) -> Tuple[int, int]:

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -12,7 +12,6 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
-from . import _actions as actions
 from ..app import App
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
@@ -22,6 +21,7 @@ from ..runner import Command
 from ..ui_framework import CursesLinePart
 from ..ui_framework import CursesLines
 from ..ui_framework import Interaction
+from . import _actions as actions
 
 
 @actions.register

--- a/src/ansible_navigator/actions/exec.py
+++ b/src/ansible_navigator/actions/exec.py
@@ -7,11 +7,11 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
-from . import _actions as actions
 from ..app import App
 from ..configuration_subsystem import ApplicationConfiguration
 from ..configuration_subsystem.definitions import Constants
 from ..runner import Command
+from . import _actions as actions
 
 
 GeneratedCommand = Tuple[str, Optional[List[str]]]

--- a/src/ansible_navigator/actions/filter.py
+++ b/src/ansible_navigator/actions/filter.py
@@ -1,10 +1,10 @@
 """:filter"""
 import logging
 
-from . import _actions as actions
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
+from . import _actions as actions
 
 
 @actions.register

--- a/src/ansible_navigator/actions/help_doc.py
+++ b/src/ansible_navigator/actions/help_doc.py
@@ -1,11 +1,11 @@
 """:help"""
 import os
 
-from . import _actions as actions
 from ..app import App
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
+from . import _actions as actions
 
 
 @actions.register

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -10,8 +10,6 @@ from typing import List
 from typing import Tuple
 from typing import Union
 
-from . import _actions as actions
-from . import run_action
 from ..app import App
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
@@ -23,6 +21,8 @@ from ..ui_framework import CursesLines
 from ..ui_framework import Interaction
 from ..ui_framework import nonblocking_notification
 from ..ui_framework import warning_notification
+from . import _actions as actions
+from . import run_action
 
 
 def filter_content_keys(obj: Dict[Any, Any]) -> Dict[Any, Any]:

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -12,8 +12,6 @@ from typing import List
 from typing import Tuple
 from typing import Union
 
-from . import _actions as actions
-from . import run_action
 from ..app import App
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
@@ -25,6 +23,8 @@ from ..ui_framework import CursesLines
 from ..ui_framework import Interaction
 from ..ui_framework import dict_to_form
 from ..ui_framework import warning_notification
+from . import _actions as actions
+from . import run_action
 
 
 def color_menu(colno: int, colname: str, entry: Dict[str, Any]) -> Tuple[int, int]:

--- a/src/ansible_navigator/actions/log.py
+++ b/src/ansible_navigator/actions/log.py
@@ -1,9 +1,9 @@
 """:log"""
-from . import _actions as actions
 from ..app import App
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
+from . import _actions as actions
 
 
 @actions.register

--- a/src/ansible_navigator/actions/open_file.py
+++ b/src/ansible_navigator/actions/open_file.py
@@ -10,13 +10,13 @@ from typing import Callable
 from typing import Dict
 from typing import List
 
-from . import _actions as actions
 from .._yaml import human_dump
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
 from ..ui_framework import Menu
 from ..utils import remove_dbl_un
+from . import _actions as actions
 
 
 class SuspendCurses:

--- a/src/ansible_navigator/actions/quit.py
+++ b/src/ansible_navigator/actions/quit.py
@@ -2,10 +2,10 @@
 """
 import logging
 
-from . import _actions as actions
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
+from . import _actions as actions
 
 
 @actions.register

--- a/src/ansible_navigator/actions/refresh.py
+++ b/src/ansible_navigator/actions/refresh.py
@@ -1,10 +1,10 @@
 """refresh"""
 import logging
 
-from . import _actions as actions
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
+from . import _actions as actions
 
 
 @actions.register

--- a/src/ansible_navigator/actions/rerun.py
+++ b/src/ansible_navigator/actions/rerun.py
@@ -2,10 +2,10 @@
 import copy
 import logging
 
-from . import _actions as actions
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
+from . import _actions as actions
 
 
 # pylint: disable=protected-access

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -20,8 +20,6 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
-from . import _actions as actions
-from . import run_action
 from ..app import App
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
@@ -37,6 +35,8 @@ from ..utils import abs_user_path
 from ..utils import human_time
 from ..utils import remove_ansi
 from ..utils import round_half_up
+from . import _actions as actions
+from . import run_action
 
 
 RESULT_TO_COLOR = [

--- a/src/ansible_navigator/actions/sample_form.py
+++ b/src/ansible_navigator/actions/sample_form.py
@@ -1,6 +1,5 @@
 """:quit
 """
-from . import _actions as actions
 from .._yaml import yaml
 from ..app import App
 from ..app_public import AppPublic
@@ -8,6 +7,7 @@ from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
 from ..ui_framework import dict_to_form
 from ..ui_framework import form_to_dict
+from . import _actions as actions
 
 
 FORM = """

--- a/src/ansible_navigator/actions/sample_notification.py
+++ b/src/ansible_navigator/actions/sample_notification.py
@@ -1,6 +1,5 @@
 """:sample_notification, this is a blocking form
 """
-from . import _actions as actions
 from .._yaml import yaml
 from ..app import App
 from ..app_public import AppPublic
@@ -8,6 +7,7 @@ from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
 from ..ui_framework import dict_to_form
 from ..ui_framework import form_to_dict
+from . import _actions as actions
 
 
 FORM = """

--- a/src/ansible_navigator/actions/sample_working.py
+++ b/src/ansible_navigator/actions/sample_working.py
@@ -2,12 +2,12 @@
 """
 import time
 
-from . import _actions as actions
 from ..app import App
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
 from ..ui_framework import nonblocking_notification
+from . import _actions as actions
 
 
 @actions.register

--- a/src/ansible_navigator/actions/save.py
+++ b/src/ansible_navigator/actions/save.py
@@ -1,10 +1,10 @@
 """:save"""
 import logging
 
-from . import _actions as actions
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
+from . import _actions as actions
 
 
 @actions.register

--- a/src/ansible_navigator/actions/select.py
+++ b/src/ansible_navigator/actions/select.py
@@ -1,10 +1,10 @@
 r""":\d+[0-9] etc"""
 import logging
 
-from . import _actions as actions
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
+from . import _actions as actions
 
 
 # pylint: disable=protected-access

--- a/src/ansible_navigator/actions/serialize_json.py
+++ b/src/ansible_navigator/actions/serialize_json.py
@@ -1,10 +1,10 @@
 """:json"""
 import logging
 
-from . import _actions as actions
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
+from . import _actions as actions
 
 
 @actions.register

--- a/src/ansible_navigator/actions/serialize_yaml.py
+++ b/src/ansible_navigator/actions/serialize_yaml.py
@@ -1,10 +1,10 @@
 """:yaml"""
 import logging
 
-from . import _actions as actions
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
+from . import _actions as actions
 
 
 @actions.register

--- a/src/ansible_navigator/actions/stdout.py
+++ b/src/ansible_navigator/actions/stdout.py
@@ -1,10 +1,10 @@
 """:stdout"""
 
-from . import _actions as actions
 from ..app import App
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
+from . import _actions as actions
 
 
 @actions.register

--- a/src/ansible_navigator/actions/template.py
+++ b/src/ansible_navigator/actions/template.py
@@ -4,7 +4,6 @@ import html
 from collections.abc import Mapping
 from typing import Union
 
-from . import _actions as actions
 from ..app import App
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
@@ -12,6 +11,7 @@ from ..ui_framework import Interaction
 from ..ui_framework import warning_notification
 from ..utils import remove_dbl_un
 from ..utils import templar
+from . import _actions as actions
 
 
 @actions.register

--- a/src/ansible_navigator/actions/welcome.py
+++ b/src/ansible_navigator/actions/welcome.py
@@ -1,11 +1,11 @@
 """:welcome"""
 import os
 
-from . import _actions as actions
 from ..app import App
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
+from . import _actions as actions
 
 
 WELCOME = """

--- a/src/ansible_navigator/actions/write_file.py
+++ b/src/ansible_navigator/actions/write_file.py
@@ -4,12 +4,12 @@ import logging
 import os
 import re
 
-from . import _actions as actions
 from .._yaml import human_dump
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
 from ..utils import remove_dbl_un
+from . import _actions as actions
 
 
 @actions.register

--- a/src/ansible_navigator/configuration_subsystem/configurator.py
+++ b/src/ansible_navigator/configuration_subsystem/configurator.py
@@ -9,15 +9,15 @@ from typing import List
 from typing import Tuple
 from typing import Union
 
-from .definitions import ApplicationConfiguration
-from .definitions import Constants as C
-from .parser import Parser
 from .._yaml import SafeLoader
 from .._yaml import yaml
 from ..utils import ExitMessage
 from ..utils import ExitPrefix
 from ..utils import LogMessage
 from ..utils import oxfordcomma
+from .definitions import ApplicationConfiguration
+from .definitions import Constants as C
+from .parser import Parser
 
 
 class Configurator:

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -9,6 +9,12 @@ from typing import List
 from typing import Tuple
 from typing import Union
 
+from .._version import __version__ as VERSION
+from ..utils import ExitMessage
+from ..utils import LogMessage
+from ..utils import abs_user_path
+from ..utils import get_share_directory
+from ..utils import oxfordcomma
 from .definitions import ApplicationConfiguration
 from .definitions import CliParameters
 from .definitions import Constants as C
@@ -16,12 +22,6 @@ from .definitions import SettingsEntry
 from .definitions import SettingsEntryValue
 from .definitions import SubCommand
 from .navigator_post_processor import NavigatorPostProcessor
-from .._version import __version__ as VERSION
-from ..utils import ExitMessage
-from ..utils import LogMessage
-from ..utils import abs_user_path
-from ..utils import get_share_directory
-from ..utils import oxfordcomma
 
 
 APP_NAME = "ansible_navigator"

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -13,10 +13,6 @@ from pathlib import Path
 from typing import List
 from typing import Tuple
 
-from .definitions import ApplicationConfiguration
-from .definitions import CliParameters
-from .definitions import Constants as C
-from .definitions import SettingsEntry
 from ..utils import ExitMessage
 from ..utils import ExitPrefix
 from ..utils import LogMessage
@@ -26,6 +22,10 @@ from ..utils import flatten_list
 from ..utils import oxfordcomma
 from ..utils import str2bool
 from ..utils import to_list
+from .definitions import ApplicationConfiguration
+from .definitions import CliParameters
+from .definitions import Constants as C
+from .definitions import SettingsEntry
 
 
 def _post_processor(func):

--- a/src/ansible_navigator/configuration_subsystem/parser.py
+++ b/src/ansible_navigator/configuration_subsystem/parser.py
@@ -9,10 +9,10 @@ from typing import Dict
 from typing import Tuple
 from typing import Union
 
-from .definitions import ApplicationConfiguration
-from .definitions import Constants as C
 from .._version import __version__
 from ..utils import oxfordcomma
+from .definitions import ApplicationConfiguration
+from .definitions import Constants as C
 
 
 class Parser:

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -11,10 +11,10 @@ import re
 
 from itertools import chain
 
-from .curses_defs import CursesLine
-from .curses_defs import CursesLinePart
 from ..tm_tokenize.grammars import Grammars
 from ..tm_tokenize.tokenize import tokenize
+from .curses_defs import CursesLine
+from .curses_defs import CursesLinePart
 
 
 CURSES_STYLES = {

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -22,6 +22,8 @@ from typing import Pattern
 from typing import Tuple
 from typing import Union
 
+from .._yaml import human_dump
+from ..utils import templar
 from .colorize import Colorize
 from .colorize import rgb_to_ansi
 from .curses_defs import CursesLine
@@ -35,8 +37,6 @@ from .form_handler_text import FormHandlerText
 from .form_utils import warning_notification
 from .menu_builder import MenuBuilder
 from .ui_config import UIConfig
-from .._yaml import human_dump
-from ..utils import templar
 
 
 STND_KEYS = {"^f/PgUp": "page up", "^b/PgDn": "page down", "\u2191\u2193": "scroll", "esc": "back"}

--- a/tests/integration/actions/collections/base.py
+++ b/tests/integration/actions/collections/base.py
@@ -8,11 +8,11 @@ from typing import Optional
 
 import pytest
 
+from ....defaults import FIXTURES_COLLECTION_DIR
 from ..._common import copytree
 from ..._common import fixture_path_from_request
 from ..._common import update_fixtures
 from ..._tmux_session import TmuxSession
-from ....defaults import FIXTURES_COLLECTION_DIR
 
 
 class BaseClass:

--- a/tests/integration/actions/config/base.py
+++ b/tests/integration/actions/config/base.py
@@ -6,12 +6,12 @@ import os
 
 import pytest
 
+from ....defaults import FIXTURES_DIR
 from ..._common import fixture_path_from_request
 from ..._common import update_fixtures
 from ..._interactions import SearchFor
 from ..._interactions import Step
 from ..._tmux_session import TmuxSession
-from ....defaults import FIXTURES_DIR
 
 
 CONFIG_FIXTURE = os.path.join(FIXTURES_DIR, "integration", "actions", "config", "ansible.cfg")

--- a/tests/integration/actions/config/test_direct_interactive_ee.py
+++ b/tests/integration/actions/config/test_direct_interactive_ee.py
@@ -2,12 +2,12 @@
 """
 import pytest
 
-from .base import BaseClass
-from .base import base_steps
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import BaseClass
+from .base import base_steps
 
 
 CLI = Command(subcommand="config", execution_environment=True).join()

--- a/tests/integration/actions/config/test_direct_interactive_noee.py
+++ b/tests/integration/actions/config/test_direct_interactive_noee.py
@@ -2,12 +2,12 @@
 """
 import pytest
 
-from .base import BaseClass
-from .base import base_steps
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import BaseClass
+from .base import base_steps
 
 
 CLI = Command(subcommand="config", execution_environment=False).join()

--- a/tests/integration/actions/config/test_stdout_tmux.py
+++ b/tests/integration/actions/config/test_stdout_tmux.py
@@ -1,12 +1,12 @@
 """Tests for ``config`` from CLI, stdout."""
 import pytest
 
-from .base import CONFIG_FIXTURE
-from .base import BaseClass
 from ..._interactions import Command
 from ..._interactions import SearchFor
 from ..._interactions import Step
 from ..._interactions import add_indicies
+from .base import CONFIG_FIXTURE
+from .base import BaseClass
 
 
 class StdoutCommand(Command):

--- a/tests/integration/actions/config/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/config/test_welcome_interactive_ee.py
@@ -2,12 +2,12 @@
 """
 import pytest
 
-from .base import BaseClass
-from .base import base_steps
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import BaseClass
+from .base import base_steps
 
 
 CLI = Command(execution_environment=True).join()

--- a/tests/integration/actions/config/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/config/test_welcome_interactive_noee.py
@@ -2,12 +2,12 @@
 """
 import pytest
 
-from .base import BaseClass
-from .base import base_steps
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import BaseClass
+from .base import base_steps
 
 
 CLI = Command(execution_environment=False).join()

--- a/tests/integration/actions/config/test_welcome_interactive_param_use.py
+++ b/tests/integration/actions/config/test_welcome_interactive_param_use.py
@@ -2,11 +2,11 @@
 """
 import pytest
 
-from .base import BaseClass
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import BaseClass
 
 
 CLI = Command(execution_environment=False).join()

--- a/tests/integration/actions/config/test_welcome_interactive_specified_config.py
+++ b/tests/integration/actions/config/test_welcome_interactive_specified_config.py
@@ -2,12 +2,12 @@
 """
 import pytest
 
-from .base import CONFIG_FIXTURE
-from .base import BaseClass
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import CONFIG_FIXTURE
+from .base import BaseClass
 
 
 CLI = Command(execution_environment=False).join()

--- a/tests/integration/actions/doc/base.py
+++ b/tests/integration/actions/doc/base.py
@@ -8,10 +8,10 @@ from typing import Optional
 
 import pytest
 
+from ....defaults import FIXTURES_COLLECTION_DIR
 from ..._common import fixture_path_from_request
 from ..._common import update_fixtures
 from ..._tmux_session import TmuxSession
-from ....defaults import FIXTURES_COLLECTION_DIR
 
 
 class BaseClass:

--- a/tests/integration/actions/exec/base.py
+++ b/tests/integration/actions/exec/base.py
@@ -10,12 +10,12 @@ from typing import Union
 
 import pytest
 
+from ....defaults import FIXTURES_DIR
 from ..._common import fixture_path_from_request
 from ..._common import update_fixtures
 from ..._interactions import SearchFor
 from ..._interactions import Step
 from ..._tmux_session import TmuxSession
-from ....defaults import FIXTURES_DIR
 
 
 TEST_FIXTURE_DIR = Path(FIXTURES_DIR, "integration", "actions", "exec")

--- a/tests/integration/actions/exec/test_stdout_config_cli.py
+++ b/tests/integration/actions/exec/test_stdout_config_cli.py
@@ -2,11 +2,11 @@
 
 import pytest
 
-from .base import BaseClass
 from ..._interactions import Command
 from ..._interactions import SearchFor
 from ..._interactions import Step
 from ..._interactions import add_indicies
+from .base import BaseClass
 
 
 class StdoutCommand(Command):

--- a/tests/integration/actions/exec/test_stdout_config_file.py
+++ b/tests/integration/actions/exec/test_stdout_config_file.py
@@ -2,12 +2,12 @@
 
 import pytest
 
-from .base import TEST_CONFIG_FILE
-from .base import BaseClass
 from ..._interactions import Command
 from ..._interactions import SearchFor
 from ..._interactions import Step
 from ..._interactions import add_indicies
+from .base import TEST_CONFIG_FILE
+from .base import BaseClass
 
 
 class StdoutCommand(Command):

--- a/tests/integration/actions/images/base.py
+++ b/tests/integration/actions/images/base.py
@@ -6,12 +6,12 @@ import os
 
 import pytest
 
+from ....defaults import DEFAULT_CONTAINER_IMAGE
 from ..._common import fixture_path_from_request
 from ..._common import update_fixtures
 from ..._interactions import SearchFor
 from ..._interactions import Step
 from ..._tmux_session import TmuxSession
-from ....defaults import DEFAULT_CONTAINER_IMAGE
 
 
 IMAGE_SHORT = DEFAULT_CONTAINER_IMAGE.rsplit("/", maxsplit=1)[-1].split(":")[0]

--- a/tests/integration/actions/images/test_direct_interactive_ee.py
+++ b/tests/integration/actions/images/test_direct_interactive_ee.py
@@ -2,13 +2,13 @@
 """
 import pytest
 
-from .base import IMAGE_SHORT
-from .base import BaseClass
-from .base import base_steps
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import IMAGE_SHORT
+from .base import BaseClass
+from .base import base_steps
 
 
 CLI = Command(subcommand="images", execution_environment=True).join()

--- a/tests/integration/actions/images/test_direct_interactive_noee.py
+++ b/tests/integration/actions/images/test_direct_interactive_noee.py
@@ -2,13 +2,13 @@
 """
 import pytest
 
-from .base import IMAGE_SHORT
-from .base import BaseClass
-from .base import base_steps
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import IMAGE_SHORT
+from .base import BaseClass
+from .base import base_steps
 
 
 # this is misleading b/c images will use an EE, but not for automation

--- a/tests/integration/actions/images/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/images/test_welcome_interactive_ee.py
@@ -2,13 +2,13 @@
 """
 import pytest
 
-from .base import IMAGE_SHORT
-from .base import BaseClass
-from .base import base_steps
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import IMAGE_SHORT
+from .base import BaseClass
+from .base import base_steps
 
 
 CLI = Command(execution_environment=True).join()

--- a/tests/integration/actions/images/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/images/test_welcome_interactive_noee.py
@@ -2,13 +2,13 @@
 """
 import pytest
 
-from .base import IMAGE_SHORT
-from .base import BaseClass
-from .base import base_steps
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import IMAGE_SHORT
+from .base import BaseClass
+from .base import base_steps
 
 
 # this is misleading b/c images will use an EE, but not for automation

--- a/tests/integration/actions/inventory/base.py
+++ b/tests/integration/actions/inventory/base.py
@@ -6,12 +6,12 @@ import os
 
 import pytest
 
+from ....defaults import FIXTURES_DIR
 from ..._common import fixture_path_from_request
 from ..._common import update_fixtures
 from ..._interactions import SearchFor
 from ..._interactions import Step
 from ..._tmux_session import TmuxSession
-from ....defaults import FIXTURES_DIR
 
 
 TEST_FIXTURE_DIR = os.path.join(FIXTURES_DIR, "integration", "actions", "inventory")

--- a/tests/integration/actions/inventory/test_direct_interactive_ee.py
+++ b/tests/integration/actions/inventory/test_direct_interactive_ee.py
@@ -2,13 +2,13 @@
 """
 import pytest
 
-from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
-from .base import BaseClass
-from .base import base_steps
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
+from .base import BaseClass
+from .base import base_steps
 
 
 cmdline = f"-i {ANSIBLE_INVENTORY_FIXTURE_DIR}"

--- a/tests/integration/actions/inventory/test_direct_interactive_noee.py
+++ b/tests/integration/actions/inventory/test_direct_interactive_noee.py
@@ -2,13 +2,13 @@
 """
 import pytest
 
-from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
-from .base import BaseClass
-from .base import base_steps
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
+from .base import BaseClass
+from .base import base_steps
 
 
 cmdline = f"-i {ANSIBLE_INVENTORY_FIXTURE_DIR}"

--- a/tests/integration/actions/inventory/test_stdout_tmux.py
+++ b/tests/integration/actions/inventory/test_stdout_tmux.py
@@ -1,12 +1,12 @@
 """Tests for inventory from CLI, stdout."""
 import pytest
 
-from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
-from .base import BaseClass
 from ..._interactions import Command
 from ..._interactions import SearchFor
 from ..._interactions import Step
 from ..._interactions import add_indicies
+from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
+from .base import BaseClass
 
 
 class StdoutCommand(Command):

--- a/tests/integration/actions/inventory/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/inventory/test_welcome_interactive_ee.py
@@ -2,13 +2,13 @@
 """
 import pytest
 
-from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
-from .base import BaseClass
-from .base import base_steps
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
+from .base import BaseClass
+from .base import base_steps
 
 
 CLI = Command(execution_environment=True).join()

--- a/tests/integration/actions/inventory/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/inventory/test_welcome_interactive_noee.py
@@ -2,13 +2,13 @@
 """
 import pytest
 
-from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
-from .base import BaseClass
-from .base import base_steps
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
+from .base import BaseClass
+from .base import base_steps
 
 
 CLI = Command(execution_environment=False).join()

--- a/tests/integration/actions/replay/base.py
+++ b/tests/integration/actions/replay/base.py
@@ -6,10 +6,10 @@ import os
 
 import pytest
 
+from ....defaults import FIXTURES_DIR
 from ..._common import fixture_path_from_request
 from ..._common import update_fixtures
 from ..._tmux_session import TmuxSession
-from ....defaults import FIXTURES_DIR
 
 
 TEST_FIXTURE_DIR = os.path.join(FIXTURES_DIR, "integration/actions/replay")

--- a/tests/integration/actions/run/base.py
+++ b/tests/integration/actions/run/base.py
@@ -8,12 +8,12 @@ from typing import Optional
 
 import pytest
 
+from ....defaults import FIXTURES_DIR
 from ..._common import fixture_path_from_request
 from ..._common import update_fixtures
 from ..._interactions import SearchFor
 from ..._interactions import Step
 from ..._tmux_session import TmuxSession
-from ....defaults import FIXTURES_DIR
 
 
 # run playbook

--- a/tests/integration/actions/run/test_direct_interactive_ee.py
+++ b/tests/integration/actions/run/test_direct_interactive_ee.py
@@ -2,14 +2,14 @@
 """
 import pytest
 
-from .base import BaseClass
-from .base import base_steps
-from .base import inventory_path
-from .base import playbook_path
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import BaseClass
+from .base import base_steps
+from .base import inventory_path
+from .base import playbook_path
 
 
 cmdline = f"{playbook_path} -i {inventory_path}"

--- a/tests/integration/actions/run/test_direct_interactive_noee.py
+++ b/tests/integration/actions/run/test_direct_interactive_noee.py
@@ -2,14 +2,14 @@
 """
 import pytest
 
-from .base import BaseClass
-from .base import base_steps
-from .base import inventory_path
-from .base import playbook_path
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import BaseClass
+from .base import base_steps
+from .base import inventory_path
+from .base import playbook_path
 
 
 cmdline = f"{playbook_path} -i {inventory_path}"

--- a/tests/integration/actions/run/test_stdout_tmux.py
+++ b/tests/integration/actions/run/test_stdout_tmux.py
@@ -1,13 +1,13 @@
 """Tests for run from CLI, stdout."""
 import pytest
 
-from .base import BaseClass
-from .base import inventory_path
-from .base import playbook_path
 from ..._interactions import Command
 from ..._interactions import SearchFor
 from ..._interactions import Step
 from ..._interactions import add_indicies
+from .base import BaseClass
+from .base import inventory_path
+from .base import playbook_path
 
 
 class StdoutCommand(Command):

--- a/tests/integration/actions/run/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/run/test_welcome_interactive_ee.py
@@ -2,14 +2,14 @@
 """
 import pytest
 
-from .base import BaseClass
-from .base import base_steps
-from .base import inventory_path
-from .base import playbook_path
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import BaseClass
+from .base import base_steps
+from .base import inventory_path
+from .base import playbook_path
 
 
 CLI = Command(execution_environment=True).join()

--- a/tests/integration/actions/run/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/run/test_welcome_interactive_noee.py
@@ -2,14 +2,14 @@
 """
 import pytest
 
-from .base import BaseClass
-from .base import base_steps
-from .base import inventory_path
-from .base import playbook_path
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import BaseClass
+from .base import base_steps
+from .base import inventory_path
+from .base import playbook_path
 
 
 CLI = Command(execution_environment=False).join()

--- a/tests/integration/actions/stdout/base.py
+++ b/tests/integration/actions/stdout/base.py
@@ -6,10 +6,10 @@ import os
 
 import pytest
 
+from ....defaults import FIXTURES_DIR
 from ..._common import fixture_path_from_request
 from ..._common import update_fixtures
 from ..._tmux_session import TmuxSession
-from ....defaults import FIXTURES_DIR
 
 
 TEST_FIXTURE_DIR = os.path.join(FIXTURES_DIR, "integration/actions/stdout")

--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -8,12 +8,12 @@ from typing import Optional
 
 import pytest
 
+from ....defaults import FIXTURES_DIR
 from ..._common import fixture_path_from_request
 from ..._common import update_fixtures
 from ..._interactions import SearchFor
 from ..._interactions import Step
 from ..._tmux_session import TmuxSession
-from ....defaults import FIXTURES_DIR
 
 
 # run playbook

--- a/tests/integration/actions/templar/test_direct_interactive_ee.py
+++ b/tests/integration/actions/templar/test_direct_interactive_ee.py
@@ -2,14 +2,14 @@
 """
 import pytest
 
-from .base import BaseClass
-from .base import base_steps
-from .base import inventory_path
-from .base import playbook_path
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import BaseClass
+from .base import base_steps
+from .base import inventory_path
+from .base import playbook_path
 
 
 cmdline = f"{playbook_path} -i {inventory_path}"

--- a/tests/integration/actions/templar/test_direct_interactive_noee.py
+++ b/tests/integration/actions/templar/test_direct_interactive_noee.py
@@ -2,14 +2,14 @@
 """
 import pytest
 
-from .base import BaseClass
-from .base import base_steps
-from .base import inventory_path
-from .base import playbook_path
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import BaseClass
+from .base import base_steps
+from .base import inventory_path
+from .base import playbook_path
 
 
 cmdline = f"{playbook_path} -i {inventory_path}"

--- a/tests/integration/actions/templar/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/templar/test_welcome_interactive_ee.py
@@ -2,14 +2,14 @@
 """
 import pytest
 
-from .base import BaseClass
-from .base import base_steps
-from .base import inventory_path
-from .base import playbook_path
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import BaseClass
+from .base import base_steps
+from .base import inventory_path
+from .base import playbook_path
 
 
 CLI = Command(execution_environment=True).join()

--- a/tests/integration/actions/templar/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/templar/test_welcome_interactive_noee.py
@@ -2,14 +2,14 @@
 """
 import pytest
 
-from .base import BaseClass
-from .base import base_steps
-from .base import inventory_path
-from .base import playbook_path
 from ..._interactions import Command
 from ..._interactions import Step
 from ..._interactions import add_indicies
 from ..._interactions import step_id
+from .base import BaseClass
+from .base import base_steps
+from .base import inventory_path
+from .base import playbook_path
 
 
 CLI = Command(execution_environment=False).join()

--- a/tests/integration/test_execution_environment.py
+++ b/tests/integration/test_execution_environment.py
@@ -8,8 +8,8 @@ from unittest import mock
 import pytest
 
 from ansible_navigator import cli
-from ._cli2runner import Cli2Runner
 from ..defaults import FIXTURES_DIR
+from ._cli2runner import Cli2Runner
 
 
 test_data = [

--- a/tests/integration/test_execution_environment_image.py
+++ b/tests/integration/test_execution_environment_image.py
@@ -8,9 +8,9 @@ from unittest import mock
 import pytest
 
 from ansible_navigator import cli
-from ._cli2runner import Cli2Runner
 from ..defaults import DEFAULT_CONTAINER_IMAGE
 from ..defaults import FIXTURES_DIR
+from ._cli2runner import Cli2Runner
 
 
 test_data = [

--- a/tests/integration/test_pass_environment_variable.py
+++ b/tests/integration/test_pass_environment_variable.py
@@ -8,8 +8,8 @@ from unittest import mock
 import pytest
 
 from ansible_navigator import cli
-from ._cli2runner import Cli2Runner
 from ..defaults import FIXTURES_DIR
+from ._cli2runner import Cli2Runner
 
 
 test_data = [

--- a/tests/integration/test_set_environment_variable.py
+++ b/tests/integration/test_set_environment_variable.py
@@ -8,8 +8,8 @@ from unittest import mock
 import pytest
 
 from ansible_navigator import cli
-from ._cli2runner import Cli2Runner
 from ..defaults import FIXTURES_DIR
+from ._cli2runner import Cli2Runner
 
 
 test_data = [


### PR DESCRIPTION
This modifies the order of relative import statements.

Fixes: #780

Prior to this change the order was
```
import .sibling
import ..parent
import ...grandparent
```
after this change
```
import ...grandparent
import ..parent
import .sibling
```

The resulting order is the default for `isort` which decreases the amount of custom configuration within the repo and results in a sorting order starting with "least local" to "most local".

This follow on work after #777, which was intended to minimize the changes in the repo related to the cleanup. #779 was also implemented to help detect any issues arising from a change in order.

Some conversation and history about the ordering can be found here: https://github.com/PyCQA/isort/issues/417