### PR TITLE
Changes to make the use of trailing commas consistent throughout the project

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -62,76 +62,76 @@ per-file-ignores =
   docs/_ext/single_sourced_data.py: D400, D403, DAR101, DAR201, N817, P103, Q000, WPS110, WPS111, WPS201, WPS202, WPS210, WPS213, WPS221, WPS229, WPS231, WPS237, WPS305, WPS318, WPS323, WPS331, WPS336, WPS347, WPS407, WPS432, WPS440, WPS441, WPS453, WPS504
   docs/_ext/spelling_stub_ext.py: DAR101, DAR201
   setup.py: D210, D400, Q000, WPS111, WPS221
-  share/ansible_navigator/utils/catalog_collections.py: C812, D107, D200, D400, D401, D403, DAR101, DAR201, Q000, S404, S602, WPS110, WPS111, WPS121, WPS122, WPS201, WPS202, WPS210, WPS211, WPS220, WPS221, WPS226, WPS229, WPS231, WPS232, WPS237, WPS305, WPS306, WPS331, WPS336, WPS338, WPS349, WPS420, WPS426, WPS432, WPS433, WPS437, WPS440, WPS458, WPS529, WPS602
-  share/ansible_navigator/utils/image_introspect.py: C812, D101, D102, D107, D205, D209, D400, D401, D403, DAR101, DAR201, Q000, S404, S602, WPS110, WPS111, WPS121, WPS122, WPS202, WPS210, WPS220, WPS221, WPS226, WPS229, WPS231, WPS305, WPS306, WPS335, WPS338, WPS440, WPS441, WPS510, WPS602
+  share/ansible_navigator/utils/catalog_collections.py: D107, D200, D400, D401, D403, DAR101, DAR201, Q000, S404, S602, WPS110, WPS111, WPS121, WPS122, WPS201, WPS202, WPS210, WPS211, WPS220, WPS221, WPS226, WPS229, WPS231, WPS232, WPS237, WPS305, WPS306, WPS331, WPS336, WPS338, WPS349, WPS420, WPS426, WPS432, WPS433, WPS437, WPS440, WPS458, WPS529, WPS602
+  share/ansible_navigator/utils/image_introspect.py: D101, D102, D107, D205, D209, D400, D401, D403, DAR101, DAR201, Q000, S404, S602, WPS110, WPS111, WPS121, WPS122, WPS202, WPS210, WPS220, WPS221, WPS226, WPS229, WPS231, WPS305, WPS306, WPS335, WPS338, WPS440, WPS441, WPS510, WPS602
   share/ansible_navigator/utils/key_value_store.py: D105, D107, D200, D400, D403, DAR101, DAR201, DAR301, DAR401, Q000, WPS110, WPS214, WPS526, WPS600, WPS603
-  src/ansible_navigator/action_runner.py: C812, D107, D200, D400, D403, DAR101, Q000, WPS231, WPS300, WPS437
+  src/ansible_navigator/action_runner.py: D107, D200, D400, D403, DAR101, Q000, WPS231, WPS300, WPS437
   src/ansible_navigator/actions/_actions.py: D210, D400, D401, DAR101, DAR201, Q000, WPS111, WPS202, WPS221, WPS305, WPS407, WPS433, WPS440, WPS458
-  src/ansible_navigator/actions/back.py: C812, D107, D400, DAR101, Q000, WPS115, WPS300, WPS306, WPS323, WPS450
-  src/ansible_navigator/actions/collections.py: C409, C414, C812, D102, D107, D201, D202, D205, D400, D403, DAR101, DAR201, Q000, WPS110, WPS111, WPS115, WPS121, WPS122, WPS201, WPS204, WPS210, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS323, WPS336, WPS338, WPS440, WPS441, WPS450, WPS504, WPS505, WPS529
-  src/ansible_navigator/actions/config.py: C405, C409, C812, D107, D201, D202, D205, D400, D403, DAR101, DAR201, DAR401, Q000, WPS110, WPS111, WPS115, WPS201, WPS204, WPS210, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS232, WPS300, WPS305, WPS323, WPS331, WPS336, WPS436, WPS440, WPS450, WPS502
-  src/ansible_navigator/actions/doc.py: C812, D107, D202, D400, D403, DAR101, DAR201, DAR401, N817, Q000, WPS110, WPS111, WPS115, WPS201, WPS210, WPS213, WPS220, WPS221, WPS229, WPS231, WPS232, WPS300, WPS305, WPS323, WPS331, WPS347, WPS450, WPS503
+  src/ansible_navigator/actions/back.py: D107, D400, DAR101, Q000, WPS115, WPS300, WPS306, WPS323, WPS450
+  src/ansible_navigator/actions/collections.py: C409, C414, D102, D107, D201, D202, D205, D400, D403, DAR101, DAR201, Q000, WPS110, WPS111, WPS115, WPS121, WPS122, WPS201, WPS204, WPS210, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS323, WPS336, WPS338, WPS440, WPS441, WPS450, WPS504, WPS505, WPS529
+  src/ansible_navigator/actions/config.py: C405, C409, D107, D201, D202, D205, D400, D403, DAR101, DAR201, DAR401, Q000, WPS110, WPS111, WPS115, WPS201, WPS204, WPS210, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS232, WPS300, WPS305, WPS323, WPS331, WPS336, WPS436, WPS440, WPS450, WPS502
+  src/ansible_navigator/actions/doc.py: D107, D202, D400, D403, DAR101, DAR201, DAR401, N817, Q000, WPS110, WPS111, WPS115, WPS201, WPS210, WPS213, WPS220, WPS221, WPS229, WPS231, WPS232, WPS300, WPS305, WPS323, WPS331, WPS347, WPS450, WPS503
   src/ansible_navigator/actions/filter.py: D107, D400, DAR101, Q000, WPS115, WPS300, WPS306, WPS323, WPS450
-  src/ansible_navigator/actions/help_doc.py: C812, D107, D400, DAR101, DAR201, Q000, WPS115, WPS300, WPS360, WPS450
-  src/ansible_navigator/actions/images.py: C812, D107, D201, D400, D403, DAR101, DAR201, Q000, WPS110, WPS111, WPS115, WPS121, WPS122, WPS201, WPS210, WPS212, WPS213, WPS214, WPS221, WPS223, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS323, WPS331, WPS336, WPS338, WPS349, WPS450, WPS504, WPS510, WPS529
-  src/ansible_navigator/actions/__init__.py: C812, D400, Q000, WPS300, WPS410, WPS412, WPS450
-  src/ansible_navigator/actions/inventory.py: C409, C812, D102, D107, D202, D205, D400, D403, DAR101, DAR201, N806, Q000, WPS110, WPS111, WPS112, WPS115, WPS201, WPS210, WPS212, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS300, WPS305, WPS323, WPS324, WPS331, WPS336, WPS338, WPS450, WPS510, WPS600
+  src/ansible_navigator/actions/help_doc.py: D107, D400, DAR101, DAR201, Q000, WPS115, WPS300, WPS360, WPS450
+  src/ansible_navigator/actions/images.py: D107, D201, D400, D403, DAR101, DAR201, Q000, WPS110, WPS111, WPS115, WPS121, WPS122, WPS201, WPS210, WPS212, WPS213, WPS214, WPS221, WPS223, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS323, WPS331, WPS336, WPS338, WPS349, WPS450, WPS504, WPS510, WPS529
+  src/ansible_navigator/actions/__init__.py: D400, Q000, WPS300, WPS410, WPS412, WPS450
+  src/ansible_navigator/actions/inventory.py: C409, D102, D107, D202, D205, D400, D403, DAR101, DAR201, N806, Q000, WPS110, WPS111, WPS112, WPS115, WPS201, WPS210, WPS212, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS300, WPS305, WPS323, WPS324, WPS331, WPS336, WPS338, WPS450, WPS510, WPS600
   src/ansible_navigator/actions/log.py: D107, D400, DAR101, DAR201, Q000, WPS115, WPS231, WPS232, WPS300, WPS360, WPS450
   src/ansible_navigator/actions/open_file.py: D105, D107, D400, DAR101, DAR201, Q000, S605, WPS110, WPS111, WPS115, WPS201, WPS210, WPS221, WPS231, WPS300, WPS306, WPS323, WPS338, WPS436, WPS440, WPS450
   src/ansible_navigator/actions/quit.py: D107, D200, D400, DAR101, DAR201, Q000, WPS115, WPS300, WPS306, WPS323, WPS360, WPS450
   src/ansible_navigator/actions/refresh.py: D107, D400, DAR101, Q000, WPS115, WPS300, WPS306, WPS450
   src/ansible_navigator/actions/replay.py: D200, D400, WPS115, WPS300, WPS450
   src/ansible_navigator/actions/rerun.py: D107, D400, DAR101, Q000, WPS115, WPS300, WPS306, WPS360, WPS450
-  src/ansible_navigator/actions/run.py: B014, C409, C812, D107, D200, D202, D205, D209, D400, D401, D403, DAR101, DAR201, DAR401, N806, Q000, WPS110, WPS111, WPS115, WPS201, WPS204, WPS210, WPS213, WPS214, WPS219, WPS220, WPS221, WPS226, WPS229, WPS231, WPS232, WPS237, WPS300, WPS305, WPS323, WPS328, WPS331, WPS336, WPS337, WPS338, WPS407, WPS420, WPS440, WPS450, WPS504, WPS510
+  src/ansible_navigator/actions/run.py: B014, C409, D107, D200, D202, D205, D209, D400, D401, D403, DAR101, DAR201, DAR401, N806, Q000, WPS110, WPS111, WPS115, WPS201, WPS204, WPS210, WPS213, WPS214, WPS219, WPS220, WPS221, WPS226, WPS229, WPS231, WPS232, WPS237, WPS300, WPS305, WPS323, WPS328, WPS331, WPS336, WPS337, WPS338, WPS407, WPS420, WPS440, WPS450, WPS504, WPS510
   src/ansible_navigator/actions/sample_form.py: D107, D200, D400, DAR101, DAR201, Q000, WPS115, WPS300, WPS323, WPS360, WPS436, WPS450
   src/ansible_navigator/actions/sample_notification.py: D107, D200, D400, DAR101, DAR201, Q000, WPS115, WPS300, WPS323, WPS360, WPS436, WPS450
   src/ansible_navigator/actions/sample_working.py: D107, D200, D400, DAR101, Q000, WPS115, WPS300, WPS360, WPS450
   src/ansible_navigator/actions/save.py: D107, D400, DAR101, Q000, WPS115, WPS300, WPS306, WPS450
-  src/ansible_navigator/actions/select.py: C812, D107, D400, DAR101, Q000, WPS115, WPS300, WPS306, WPS323, WPS450
+  src/ansible_navigator/actions/select.py: D107, D400, DAR101, Q000, WPS115, WPS300, WPS306, WPS323, WPS450
   src/ansible_navigator/actions/serialize_json.py: D107, D400, DAR101, Q000, WPS115, WPS300, WPS306, WPS323, WPS360, WPS450
   src/ansible_navigator/actions/serialize_yaml.py: D107, D400, DAR101, Q000, WPS115, WPS300, WPS306, WPS323, WPS360, WPS450
   src/ansible_navigator/actions/stdout.py: D107, D400, DAR101, DAR201, Q000, WPS110, WPS115, WPS231, WPS232, WPS300, WPS360, WPS450
-  src/ansible_navigator/actions/template.py: C812, D107, D400, DAR101, DAR201, Q000, WPS110, WPS111, WPS115, WPS210, WPS213, WPS221, WPS231, WPS232, WPS300, WPS323, WPS360, WPS450
-  src/ansible_navigator/actions/welcome.py: C812, D107, D400, DAR101, DAR201, Q000, WPS115, WPS300, WPS360, WPS450
-  src/ansible_navigator/actions/write_file.py: C812, D107, D400, DAR101, DAR201, Q000, WPS110, WPS111, WPS115, WPS210, WPS221, WPS231, WPS232, WPS300, WPS306, WPS323, WPS436, WPS440, WPS450
+  src/ansible_navigator/actions/template.py: D107, D400, DAR101, DAR201, Q000, WPS110, WPS111, WPS115, WPS210, WPS213, WPS221, WPS231, WPS232, WPS300, WPS323, WPS360, WPS450
+  src/ansible_navigator/actions/welcome.py: D107, D400, DAR101, DAR201, Q000, WPS115, WPS300, WPS360, WPS450
+  src/ansible_navigator/actions/write_file.py: D107, D400, DAR101, DAR201, Q000, WPS110, WPS111, WPS115, WPS210, WPS221, WPS231, WPS232, WPS300, WPS306, WPS323, WPS436, WPS440, WPS450
   src/ansible_navigator/app_public.py: D204, D205, D211, D400, WPS300
-  src/ansible_navigator/app.py: C812, D107, D200, D205, D209, D400, D401, D403, DAR101, DAR201, DAR401, N817, Q000, WPS110, WPS111, WPS201, WPS214, WPS221, WPS300, WPS306, WPS338, WPS347, WPS602
+  src/ansible_navigator/app.py: D107, D200, D205, D209, D400, D401, D403, DAR101, DAR201, DAR401, N817, Q000, WPS110, WPS111, WPS201, WPS214, WPS221, WPS300, WPS306, WPS338, WPS347, WPS602
   src/ansible_navigator/cli.py: B010, D200, D400, D403, DAR101, DAR201, Q000, WPS201, WPS210, WPS213, WPS221, WPS229, WPS237, WPS300, WPS305, WPS323, WPS331, WPS336, WPS440
-  src/ansible_navigator/command_runner/command_runner.py: C812, D107, D400, D403, DAR101, DAR201, Q000, S404, S602, WPS110, WPS121, WPS122, WPS229, WPS306, WPS440, WPS602
+  src/ansible_navigator/command_runner/command_runner.py: D107, D400, D403, DAR101, DAR201, Q000, S404, S602, WPS110, WPS121, WPS122, WPS229, WPS306, WPS440, WPS602
   src/ansible_navigator/command_runner/__init__.py: D210, D400, WPS300, WPS412
-  src/ansible_navigator/configuration_subsystem/configurator.py: B010, C812, D200, D202, D205, D400, D401, D403, DAR101, DAR201, N817, Q000, WPS110, WPS111, WPS201, WPS210, WPS211, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS232, WPS237, WPS300, WPS305, WPS306, WPS336, WPS337, WPS338, WPS347, WPS436, WPS440, WPS510
+  src/ansible_navigator/configuration_subsystem/configurator.py: B010, D200, D202, D205, D400, D401, D403, DAR101, DAR201, N817, Q000, WPS110, WPS111, WPS201, WPS210, WPS211, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS232, WPS237, WPS300, WPS305, WPS306, WPS336, WPS337, WPS338, WPS347, WPS436, WPS440, WPS510
   src/ansible_navigator/configuration_subsystem/definitions.py: D200, D204, D400, D401, DAR101, DAR201, DAR401, Q000, WPS110, WPS115, WPS221, WPS226, WPS237, WPS300, WPS305, WPS331, WPS338, WPS613
   src/ansible_navigator/configuration_subsystem/__init__.py: D200, D400, WPS300, WPS412
   src/ansible_navigator/configuration_subsystem/navigator_configuration.py: D200, D205, D400, DAR201, N812, N817, Q000, WPS111, WPS201, WPS204, WPS221, WPS226, WPS237, WPS300, WPS305, WPS347, WPS436
-  src/ansible_navigator/configuration_subsystem/navigator_post_processor.py: B009, B014, C812, D200, D400, DAR101, DAR201, N817, Q000, WPS111, WPS201, WPS204, WPS210, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS306, WPS336, WPS337, WPS338, WPS347, WPS420, WPS440, WPS441, WPS448, WPS510, WPS602
-  src/ansible_navigator/configuration_subsystem/parser.py: C812, D107, D200, D400, DAR101, DAR201, N817, Q000, WPS111, WPS221, WPS237, WPS300, WPS305, WPS306, WPS323, WPS336, WPS347, WPS436, WPS450, WPS504, WPS507, WPS602
+  src/ansible_navigator/configuration_subsystem/navigator_post_processor.py: B009, B014, D200, D400, DAR101, DAR201, N817, Q000, WPS111, WPS201, WPS204, WPS210, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS306, WPS336, WPS337, WPS338, WPS347, WPS420, WPS440, WPS441, WPS448, WPS510, WPS602
+  src/ansible_navigator/configuration_subsystem/parser.py: D107, D200, D400, DAR101, DAR201, N817, Q000, WPS111, WPS221, WPS237, WPS300, WPS305, WPS306, WPS323, WPS336, WPS347, WPS436, WPS450, WPS504, WPS507, WPS602
   src/ansible_navigator/image_manager/__init__.py: D210, D400, WPS300, WPS412
-  src/ansible_navigator/image_manager/inspector.py: C812, D107, D400, D403, DAR101, DAR201, Q000, WPS110, WPS114, WPS210, WPS221, WPS300, WPS305, WPS306, WPS602
+  src/ansible_navigator/image_manager/inspector.py: D107, D400, D403, DAR101, DAR201, Q000, WPS110, WPS114, WPS210, WPS221, WPS300, WPS305, WPS306, WPS602
   src/ansible_navigator/image_manager/puller.py: D107, D400, D403, DAR201, DAR401, Q000, S404, S603, WPS110, WPS111, WPS213, WPS214, WPS221, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS306, WPS338
-  src/ansible_navigator/initialization.py: C812, D202, D205, D400, D403, DAR101, DAR201, N812, N817, Q000, WPS110, WPS111, WPS201, WPS204, WPS210, WPS213, WPS221, WPS226, WPS237, WPS300, WPS301, WPS305, WPS336, WPS347, WPS436, WPS504, WPS529, WPS609
+  src/ansible_navigator/initialization.py: D202, D205, D400, D403, DAR101, DAR201, N812, N817, Q000, WPS110, WPS111, WPS201, WPS204, WPS210, WPS213, WPS221, WPS226, WPS237, WPS300, WPS301, WPS305, WPS336, WPS347, WPS436, WPS504, WPS529, WPS609
   src/ansible_navigator/__init__.py: D200, D400, WPS300, WPS412, WPS436
   src/ansible_navigator/__main__.py: Q000, RST304, WPS300
-  src/ansible_navigator/runner/ansible_config.py: C812, C815, D205, D400, WPS300
+  src/ansible_navigator/runner/ansible_config.py: C815, D205, D400, WPS300
   src/ansible_navigator/runner/ansible_doc.py: C815, D205, D400, DAR101, DAR201, Q000, WPS211, WPS221, WPS234, WPS300
   src/ansible_navigator/runner/ansible_inventory.py: C815, D205, D400, WPS211, WPS300
-  src/ansible_navigator/runner/base.py: C812, D202, D205, D400, D401, D403, DAR101, DAR201, Q000, RST203, RST301, WPS110, WPS111, WPS211, WPS214, WPS306, WPS323, WPS337, WPS338, WPS602, WPS603, WPS605
+  src/ansible_navigator/runner/base.py: D202, D205, D400, D401, D403, DAR101, DAR201, Q000, RST203, RST301, WPS110, WPS111, WPS211, WPS214, WPS306, WPS323, WPS337, WPS338, WPS602, WPS603, WPS605
   src/ansible_navigator/runner/command_async.py: D400, DAR101, DAR201, Q000, WPS300, WPS323, WPS338, WPS414
-  src/ansible_navigator/runner/command_base.py: C812, D205, D211, D400, D401, DAR101, Q000, RST201, RST301, WPS110, WPS111, WPS211, WPS300, WPS305, WPS323
+  src/ansible_navigator/runner/command_base.py: D205, D211, D400, D401, DAR101, Q000, RST201, RST301, WPS110, WPS111, WPS211, WPS300, WPS305, WPS323
   src/ansible_navigator/runner/command.py: D202, D205, D400, D403, DAR201, WPS300, WPS331
   src/ansible_navigator/runner/__init__.py: D200, D400, WPS300, WPS412
   src/ansible_navigator/steps.py: D107, D200, D211, D400, D401, D403, DAR101, DAR201, DAR401, Q000, WPS110, WPS211, WPS214, WPS230, WPS237, WPS305, WPS306, WPS602
-  src/ansible_navigator/tm_tokenize/compiler.py: C812, D100, D101, D102, D107, Q000, S101, WPS111, WPS201, WPS214, WPS221, WPS226, WPS231, WPS300, WPS305, WPS306, WPS331, WPS338, WPS420, WPS429, WPS450, WPS503
+  src/ansible_navigator/tm_tokenize/compiler.py: D100, D101, D102, D107, Q000, S101, WPS111, WPS201, WPS214, WPS221, WPS226, WPS231, WPS300, WPS305, WPS306, WPS331, WPS338, WPS420, WPS429, WPS450, WPS503
   src/ansible_navigator/tm_tokenize/fchainmap.py: D100, D101, D105, D107, Q000, WPS300, WPS420, WPS428, WPS436, WPS500, WPS503
   src/ansible_navigator/tm_tokenize/grammars.py: D100, D101, D102, D107, Q000, WPS110, WPS111, WPS201, WPS210, WPS226, WPS234, WPS300, WPS306, WPS331, WPS338, WPS361, WPS420, WPS429, WPS440, WPS450, WPS529
   src/ansible_navigator/tm_tokenize/region.py: D100, D101, Q000
-  src/ansible_navigator/tm_tokenize/reg.py: C812, D100, D103, Q000, WPS111, WPS201, WPS211, WPS221, WPS234, WPS237, WPS300, WPS305, WPS306, WPS407, WPS436, WPS450
-  src/ansible_navigator/tm_tokenize/rules.py: C812, D100, D101, D102, D400, Q000, WPS111, WPS201, WPS202, WPS210, WPS211, WPS214, WPS221, WPS231, WPS300, WPS305, WPS338, WPS362, WPS428, WPS429, WPS436, WPS437, WPS441, WPS450, WPS503, WPS529
+  src/ansible_navigator/tm_tokenize/reg.py: D100, D103, Q000, WPS111, WPS201, WPS211, WPS221, WPS234, WPS237, WPS300, WPS305, WPS306, WPS407, WPS436, WPS450
+  src/ansible_navigator/tm_tokenize/rules.py: D100, D101, D102, D400, Q000, WPS111, WPS201, WPS202, WPS210, WPS211, WPS214, WPS221, WPS231, WPS300, WPS305, WPS338, WPS362, WPS428, WPS429, WPS436, WPS437, WPS441, WPS450, WPS503, WPS529
   src/ansible_navigator/tm_tokenize/state.py: D100, D101, D102, Q000, WPS221, WPS300
-  src/ansible_navigator/tm_tokenize/tokenize.py: C812, D100, D201, D400, D403, DAR101, DAR201, Q000, WPS210, WPS300
+  src/ansible_navigator/tm_tokenize/tokenize.py: D100, D201, D400, D403, DAR101, DAR201, Q000, WPS210, WPS300
   src/ansible_navigator/tm_tokenize/_types.py: WPS440
   src/ansible_navigator/tm_tokenize/utils.py: D100, D400, D403, DAR101, DAR201, Q000, WPS100, WPS111, WPS609
-  src/ansible_navigator/ui_framework/colorize.py: C812, D107, D200, D205, D400, D403, DAR101, DAR201, Q000, WPS110, WPS111, WPS114, WPS202, WPS204, WPS210, WPS220, WPS221, WPS226, WPS231, WPS232, WPS300, WPS306, WPS323, WPS331, WPS338, WPS355, WPS407, WPS420, WPS432, WPS440, WPS518
-  src/ansible_navigator/ui_framework/curses_window.py: C812, D107, D200, D202, D205, D209, D400, D401, D403, DAR101, DAR201, Q000, WPS110, WPS111, WPS210, WPS213, WPS220, WPS221, WPS229, WPS231, WPS300, WPS306, WPS323, WPS349, WPS407, WPS420, WPS436, WPS450
+  src/ansible_navigator/ui_framework/colorize.py: D107, D200, D205, D400, D403, DAR101, DAR201, Q000, WPS110, WPS111, WPS114, WPS202, WPS204, WPS210, WPS220, WPS221, WPS226, WPS231, WPS232, WPS300, WPS306, WPS323, WPS331, WPS338, WPS355, WPS407, WPS420, WPS432, WPS440, WPS518
+  src/ansible_navigator/ui_framework/curses_window.py: D107, D200, D202, D205, D209, D400, D401, D403, DAR101, DAR201, Q000, WPS110, WPS111, WPS210, WPS213, WPS220, WPS221, WPS229, WPS231, WPS300, WPS306, WPS323, WPS349, WPS407, WPS420, WPS436, WPS450
   src/ansible_navigator/ui_framework/field_button.py: D200, D205, D400, D403, DAR101, DAR201, Q000, WPS300, WPS306, WPS502, WPS601
   src/ansible_navigator/ui_framework/field_checks.py: D200, D204, D205, D400, D403, DAR101, DAR201, Q000, WPS201, WPS300, WPS306, WPS338, WPS502, WPS601
   src/ansible_navigator/ui_framework/field_information.py: D200, D204, D205, D400, D403, DAR101, DAR201, Q000, WPS300, WPS306, WPS601
@@ -145,31 +145,31 @@ per-file-ignores =
   src/ansible_navigator/ui_framework/form_handler_options.py: D107, D200, D201, D400, D403, DAR101, DAR201, Q000, WPS110, WPS210, WPS220, WPS223, WPS231, WPS232, WPS237, WPS300, WPS305, WPS336, WPS510, WPS525
   src/ansible_navigator/ui_framework/form_handler_text.py: C409, D107, D200, D205, D300, D400, D403, DAR101, DAR201, Q000, Q002, WPS110, WPS223, WPS231, WPS232, WPS300, WPS338, WPS504, WPS510
   src/ansible_navigator/ui_framework/form_handler_working.py: D107, D205, D400, D403, DAR101, DAR201, Q000, WPS110, WPS300, WPS602
-  src/ansible_navigator/ui_framework/form_presenter.py: C409, C812, D107, D200, D400, D403, DAR201, Q000, WPS110, WPS111, WPS201, WPS210, WPS213, WPS214, WPS221, WPS231, WPS237, WPS300, WPS305, WPS331, WPS338, WPS432, WPS440, WPS441, WPS510, WPS602
-  src/ansible_navigator/ui_framework/form.py: C812, D200, D205, D400, D403, DAR101, DAR201, Q000, WPS221, WPS300, WPS306, WPS420, WPS601
+  src/ansible_navigator/ui_framework/form_presenter.py: C409, D107, D200, D400, D403, DAR201, Q000, WPS110, WPS111, WPS201, WPS210, WPS213, WPS214, WPS221, WPS231, WPS237, WPS300, WPS305, WPS331, WPS338, WPS432, WPS440, WPS441, WPS510, WPS602
+  src/ansible_navigator/ui_framework/form.py: D200, D205, D400, D403, DAR101, DAR201, Q000, WPS221, WPS300, WPS306, WPS420, WPS601
   src/ansible_navigator/ui_framework/form_utils.py: D200, D205, D400, D403, DAR101, DAR201, Q000, WPS110, WPS201, WPS204, WPS210, WPS219, WPS226, WPS231, WPS232, WPS300, WPS432, WPS437, WPS440, WPS441, WPS510, WPS529
   src/ansible_navigator/ui_framework/__init__.py: D200, D400, WPS201, WPS300, WPS412
-  src/ansible_navigator/ui_framework/menu_builder.py: C409, C812, D107, D200, D400, D401, D403, DAR101, DAR201, Q000, WPS111, WPS201, WPS210, WPS211, WPS214, WPS221, WPS300, WPS306, WPS337, WPS349, WPS440, WPS441, WPS602
+  src/ansible_navigator/ui_framework/menu_builder.py: C409, D107, D200, D400, D401, D403, DAR101, DAR201, Q000, WPS111, WPS201, WPS210, WPS211, WPS214, WPS221, WPS300, WPS306, WPS337, WPS349, WPS440, WPS441, WPS602
   src/ansible_navigator/ui_framework/sentinels.py: D102, D105, D205, D400, Q000, WPS221, WPS306, WPS608
-  src/ansible_navigator/ui_framework/ui.py: C401, C408, C409, C812, D200, D202, D205, D211, D400, D403, DAR101, DAR201, DAR401, Q000, WPS110, WPS111, WPS201, WPS210, WPS211, WPS213, WPS214, WPS220, WPS221, WPS223, WPS226, WPS231, WPS232, WPS237, WPS300, WPS305, WPS323, WPS331, WPS338, WPS349, WPS404, WPS407, WPS432, WPS436, WPS437, WPS440, WPS504, WPS510, WPS602
+  src/ansible_navigator/ui_framework/ui.py: C401, C408, C409, D200, D202, D205, D211, D400, D403, DAR101, DAR201, DAR401, Q000, WPS110, WPS111, WPS201, WPS210, WPS211, WPS213, WPS214, WPS220, WPS221, WPS223, WPS226, WPS231, WPS232, WPS237, WPS300, WPS305, WPS323, WPS331, WPS338, WPS349, WPS404, WPS407, WPS432, WPS436, WPS437, WPS440, WPS504, WPS510, WPS602
   src/ansible_navigator/ui_framework/utils.py: D200, D205, D400, D403, DAR101, DAR201, Q000, WPS100, WPS110, WPS111, WPS210, WPS221, WPS336, WPS349
-  src/ansible_navigator/ui_framework/validators.py: B006, C812, D200, D400, D401, D403, DAR101, DAR201, DAR401, Q000, S311, WPS110, WPS111, WPS214, WPS221, WPS229, WPS237, WPS300, WPS305, WPS306, WPS334, WPS336, WPS337, WPS404, WPS420, WPS432, WPS504, WPS510, WPS602
-  src/ansible_navigator/utils.py: C408, C812, D105, D200, D202, D205, D400, D401, D403, DAR101, DAR201, DAR401, E302, Q000, RST304, WPS100, WPS110, WPS111, WPS115, WPS122, WPS201, WPS202, WPS204, WPS210, WPS212, WPS213, WPS221, WPS226, WPS229, WPS231, WPS237, WPS305, WPS323, WPS331, WPS336, WPS338, WPS425, WPS430, WPS432, WPS440, WPS507, WPS510
+  src/ansible_navigator/ui_framework/validators.py: B006, D200, D400, D401, D403, DAR101, DAR201, DAR401, Q000, S311, WPS110, WPS111, WPS214, WPS221, WPS229, WPS237, WPS300, WPS305, WPS306, WPS334, WPS336, WPS337, WPS404, WPS420, WPS432, WPS504, WPS510, WPS602
+  src/ansible_navigator/utils.py: C408, D105, D200, D202, D205, D400, D401, D403, DAR101, DAR201, DAR401, E302, Q000, RST304, WPS100, WPS110, WPS111, WPS115, WPS122, WPS201, WPS202, WPS204, WPS210, WPS212, WPS213, WPS221, WPS226, WPS229, WPS231, WPS237, WPS305, WPS323, WPS331, WPS336, WPS338, WPS425, WPS430, WPS432, WPS440, WPS507, WPS510
   src/ansible_navigator/_version.py: D210, D400, D412, Q000, WPS410
   src/ansible_navigator/_yaml.py: D210, D400, D401, DAR101, DAR201, Q000, WPS110, WPS229, WPS433, WPS437, WPS440, WPS458
   tests/conftest.py: D210, D400, D401, D403, DAR101, DAR201, DAR301, DAR401, PT003, Q000, S103, S404, S603, WPS300, WPS339, WPS432, WPS454
-  tests/defaults.py: C812, D200, Q000, WPS221
+  tests/defaults.py: D200, Q000, WPS221
   tests/fixtures/common/collections/ansible_collections/testorg/coll_1/plugins/lookup/lookup_1.py: WPS114, WPS422
   tests/fixtures/common/collections/ansible_collections/testorg/coll_1/plugins/modules/mod_1.py: WPS114, WPS422
   tests/fixtures/common/collections/ansible_collections/testorg/coll_2/plugins/lookup/lookup_2.py: WPS114, WPS422
   tests/fixtures/common/collections/ansible_collections/testorg/coll_2/plugins/modules/mod_2.py: WPS114, WPS422
-  tests/integration/_action_run_test.py: C812, D107, D205, D400, D401, D403, DAR101, DAR201, DAR401, N817, Q000, WPS110, WPS111, WPS201, WPS210, WPS211, WPS305, WPS306, WPS347
-  tests/integration/actions/collections/base.py: C812, D200, D202, D400, D403, DAR101, DAR301, DAR401, PT005, Q000, S101, WPS110, WPS115, WPS210, WPS211, WPS300, WPS305, WPS306, WPS336, WPS337, WPS338, WPS436, WPS602
+  tests/integration/_action_run_test.py: D107, D205, D400, D401, D403, DAR101, DAR201, DAR401, N817, Q000, WPS110, WPS111, WPS201, WPS210, WPS211, WPS305, WPS306, WPS347
+  tests/integration/actions/collections/base.py: D200, D202, D400, D403, DAR101, DAR301, DAR401, PT005, Q000, S101, WPS110, WPS115, WPS210, WPS211, WPS300, WPS305, WPS306, WPS336, WPS337, WPS338, WPS436, WPS602
   tests/integration/actions/collections/test_direct_interactive_ee.py: D200, D400, PT006, Q000, WPS115, WPS226, WPS300
   tests/integration/actions/collections/test_direct_interactive_noee.py: D200, D400, PT006, Q000, WPS115, WPS226, WPS300
   tests/integration/actions/collections/test_welcome_interactive_ee.py: D200, D400, PT006, Q000, WPS115, WPS226, WPS300
   tests/integration/actions/collections/test_welcome_interactive_noee.py: D200, D400, PT006, Q000, WPS115, WPS226, WPS300
-  tests/integration/actions/config/base.py: C812, D200, D202, D400, D403, DAR101, DAR301, DAR401, Q000, S101, WPS110, WPS111, WPS115, WPS210, WPS231, WPS300, WPS305, WPS306, WPS336, WPS337, WPS432, WPS436
+  tests/integration/actions/config/base.py: D200, D202, D400, D403, DAR101, DAR301, DAR401, Q000, S101, WPS110, WPS111, WPS115, WPS210, WPS231, WPS300, WPS305, WPS306, WPS336, WPS337, WPS432, WPS436
   tests/integration/actions/config/test_direct_interactive_ee.py: D200, D400, Q000, WPS115, WPS300, WPS436
   tests/integration/actions/config/test_direct_interactive_noee.py: D200, D400, Q000, WPS115, WPS300, WPS436
   tests/integration/actions/config/test_stdout_tmux.py: D210, D400, D403, DAR101, DAR201, Q000, WPS110, WPS115, WPS226, WPS300, WPS305, WPS436
@@ -177,79 +177,79 @@ per-file-ignores =
   tests/integration/actions/config/test_welcome_interactive_noee.py: D200, D400, Q000, WPS115, WPS300, WPS436
   tests/integration/actions/config/test_welcome_interactive_param_use.py: D200, D400, Q000, WPS115, WPS300, WPS436
   tests/integration/actions/config/test_welcome_interactive_specified_config.py: D200, D400, Q000, WPS115, WPS300, WPS336, WPS436
-  tests/integration/actions/doc/base.py: C812, D200, D400, D403, DAR101, DAR301, DAR401, Q000, S101, WPS110, WPS115, WPS210, WPS211, WPS220, WPS231, WPS232, WPS300, WPS305, WPS306, WPS335, WPS336, WPS337, WPS432, WPS436, WPS441, WPS602
-  tests/integration/actions/doc/test_direct_interactive_ee.py: C812, D200, D400, PT006, Q000, WPS115, WPS300, WPS326
-  tests/integration/actions/doc/test_direct_interactive_noee.py: C812, D200, D400, PT006, Q000, WPS115, WPS300
+  tests/integration/actions/doc/base.py: D200, D400, D403, DAR101, DAR301, DAR401, Q000, S101, WPS110, WPS115, WPS210, WPS211, WPS220, WPS231, WPS232, WPS300, WPS305, WPS306, WPS335, WPS336, WPS337, WPS432, WPS436, WPS441, WPS602
+  tests/integration/actions/doc/test_direct_interactive_ee.py: D200, D400, PT006, Q000, WPS115, WPS300, WPS326
+  tests/integration/actions/doc/test_direct_interactive_noee.py: D200, D400, PT006, Q000, WPS115, WPS300
   tests/integration/actions/doc/test_stdout.py: D200, D400, PT006, Q000, WPS114, WPS115, WPS202, WPS226, WPS300, WPS326
-  tests/integration/actions/doc/test_welcome_interactive_ee.py: C812, D200, D400, PT006, Q000, WPS115, WPS300, WPS326
-  tests/integration/actions/doc/test_welcome_interactive_noee.py: C812, D200, D400, PT006, Q000, WPS115, WPS300
-  tests/integration/actions/images/base.py: C812, D200, D202, D400, D403, DAR101, DAR301, DAR401, Q000, S101, WPS110, WPS115, WPS210, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436
+  tests/integration/actions/doc/test_welcome_interactive_ee.py: D200, D400, PT006, Q000, WPS115, WPS300, WPS326
+  tests/integration/actions/doc/test_welcome_interactive_noee.py: D200, D400, PT006, Q000, WPS115, WPS300
+  tests/integration/actions/images/base.py: D200, D202, D400, D403, DAR101, DAR301, DAR401, Q000, S101, WPS110, WPS115, WPS210, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436
   tests/integration/actions/images/test_direct_interactive_ee.py: D200, D400, Q000, WPS115, WPS300, WPS436
   tests/integration/actions/images/test_direct_interactive_noee.py: D200, D400, Q000, WPS115, WPS300, WPS436
-  tests/integration/actions/images/test_welcome_interactive_ee.py: C812, D200, D400, Q000, WPS115, WPS300, WPS436
-  tests/integration/actions/images/test_welcome_interactive_noee.py: C812, D200, D400, Q000, WPS115, WPS300, WPS436
-  tests/integration/actions/inventory/base.py: C812, D200, D201, D400, D403, DAR101, DAR301, DAR401, Q000, S101, WPS110, WPS115, WPS210, WPS226, WPS231, WPS232, WPS300, WPS306, WPS336, WPS337, WPS432, WPS436, WPS602
+  tests/integration/actions/images/test_welcome_interactive_ee.py: D200, D400, Q000, WPS115, WPS300, WPS436
+  tests/integration/actions/images/test_welcome_interactive_noee.py: D200, D400, Q000, WPS115, WPS300, WPS436
+  tests/integration/actions/inventory/base.py: D200, D201, D400, D403, DAR101, DAR301, DAR401, Q000, S101, WPS110, WPS115, WPS210, WPS226, WPS231, WPS232, WPS300, WPS306, WPS336, WPS337, WPS432, WPS436, WPS602
   tests/integration/actions/inventory/test_direct_interactive_ee.py: D200, D400, Q000, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/inventory/test_direct_interactive_noee.py: D200, D400, Q000, WPS115, WPS300, WPS305, WPS436
-  tests/integration/actions/inventory/test_stdout_tmux.py: C812, D400, D403, DAR101, DAR201, Q000, WPS110, WPS115, WPS226, WPS300, WPS305, WPS436
+  tests/integration/actions/inventory/test_stdout_tmux.py: D400, D403, DAR101, DAR201, Q000, WPS110, WPS115, WPS226, WPS300, WPS305, WPS436
   tests/integration/actions/inventory/test_welcome_interactive_ee.py: D200, D400, Q000, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/inventory/test_welcome_interactive_noee.py: D200, D400, Q000, WPS115, WPS300, WPS305, WPS436
-  tests/integration/actions/replay/base.py: C812, D200, D201, D400, D403, DAR101, DAR301, Q000, S101, WPS110, WPS115, WPS211, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436, WPS602
+  tests/integration/actions/replay/base.py: D200, D201, D400, D403, DAR101, DAR301, Q000, S101, WPS110, WPS115, WPS211, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436, WPS602
   tests/integration/actions/replay/test_direct_interactive_ee.py: D200, D400, PT006, Q000, WPS115, WPS226, WPS300, WPS305, WPS326
   tests/integration/actions/replay/test_direct_interactive_noee.py: D200, D400, PT006, Q000, WPS115, WPS226, WPS300, WPS305
   tests/integration/actions/replay/test_welcome_interactive_ee.py: D200, D400, PT006, Q000, WPS115, WPS226, WPS300, WPS305
   tests/integration/actions/replay/test_welcome_interactive_noee.py: D200, D400, PT006, Q000, WPS115, WPS226, WPS300, WPS305
-  tests/integration/actions/run/base.py: C812, D200, D202, D400, D403, DAR101, DAR301, Q000, S101, WPS110, WPS115, WPS210, WPS220, WPS226, WPS231, WPS232, WPS300, WPS306, WPS335, WPS336, WPS337, WPS432, WPS436, WPS602
+  tests/integration/actions/run/base.py: D200, D202, D400, D403, DAR101, DAR301, Q000, S101, WPS110, WPS115, WPS210, WPS220, WPS226, WPS231, WPS232, WPS300, WPS306, WPS335, WPS336, WPS337, WPS432, WPS436, WPS602
   tests/integration/actions/run/test_direct_interactive_ee.py: D200, D400, Q000, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/run/test_direct_interactive_noee.py: D200, D400, Q000, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/run/test_stdout_tmux.py: D210, D400, D403, DAR101, DAR201, Q000, WPS110, WPS115, WPS226, WPS300, WPS305, WPS436
   tests/integration/actions/run/test_welcome_interactive_ee.py: D200, D400, Q000, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/run/test_welcome_interactive_noee.py: D200, D400, Q000, WPS115, WPS300, WPS305, WPS436
-  tests/integration/actions/stdout/base.py: C812, D200, D201, D400, D403, DAR101, DAR301, Q000, S101, WPS110, WPS115, WPS211, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436, WPS602
+  tests/integration/actions/stdout/base.py: D200, D201, D400, D403, DAR101, DAR301, Q000, S101, WPS110, WPS115, WPS211, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436, WPS602
   tests/integration/actions/stdout/test_direct_interactive_ee.py: D200, D400, PT006, Q000, WPS115, WPS226, WPS300, WPS305, WPS326
   tests/integration/actions/stdout/test_direct_interactive_noee.py: D200, D400, PT006, Q000, WPS115, WPS226, WPS300, WPS305, WPS326
   tests/integration/actions/stdout/test_welcome_interactive_ee.py: D200, D400, PT006, Q000, WPS115, WPS226, WPS300, WPS305, WPS326
   tests/integration/actions/stdout/test_welcome_interactive_noee.py: D200, D400, PT006, Q000, WPS115, WPS226, WPS300, WPS305
-  tests/integration/actions/templar/base.py: C812, D200, D202, D400, D403, DAR101, DAR301, Q000, S101, WPS110, WPS115, WPS210, WPS220, WPS231, WPS232, WPS300, WPS306, WPS335, WPS336, WPS337, WPS432, WPS436, WPS602
+  tests/integration/actions/templar/base.py: D200, D202, D400, D403, DAR101, DAR301, Q000, S101, WPS110, WPS115, WPS210, WPS220, WPS231, WPS232, WPS300, WPS306, WPS335, WPS336, WPS337, WPS432, WPS436, WPS602
   tests/integration/actions/templar/test_direct_interactive_ee.py: D200, D400, Q000, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/templar/test_direct_interactive_noee.py: D200, D400, Q000, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/templar/test_welcome_interactive_ee.py: D200, D400, Q000, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/templar/test_welcome_interactive_noee.py: D200, D400, Q000, WPS115, WPS300, WPS305, WPS436
-  tests/integration/_cli2runner.py: C812, D200, D400, D401, D403, DAR101, DAR401, Q000, WPS115, WPS211, WPS214, WPS226, WPS306, WPS338, WPS454
-  tests/integration/_common.py: B005, C812, D103, D200, D400, D401, D403, DAR101, DAR201, DAR401, Q000, WPS210, WPS211, WPS231, WPS300, WPS305, WPS440
+  tests/integration/_cli2runner.py: D200, D400, D401, D403, DAR101, DAR401, Q000, WPS115, WPS211, WPS214, WPS226, WPS306, WPS338, WPS454
+  tests/integration/_common.py: B005, D103, D200, D400, D401, D403, DAR101, DAR201, DAR401, Q000, WPS210, WPS211, WPS231, WPS300, WPS305, WPS440
   tests/integration/conftest.py: D205, D400, D401, D403, DAR101, DAR201, DAR301, PT001, PT003, PT004, PT022, Q000, S108, WPS300, WPS407, WPS433, WPS436
   tests/integration/_interactions.py: D200, D204, D400, D403, DAR101, DAR201, Q000, WPS110, WPS115, WPS305, WPS336, WPS437, WPS503
-  tests/integration/test_execution_environment_image.py: C812, D200, D205, D400, D403, DAR101, Q000, S101, WPS110, WPS111, WPS115, WPS210, WPS211, WPS220, WPS221, WPS226, WPS300, WPS301, WPS305, WPS436
-  tests/integration/test_execution_environment.py: C812, D200, D205, D400, D403, DAR101, Q000, S101, WPS110, WPS111, WPS115, WPS210, WPS211, WPS220, WPS221, WPS300, WPS301, WPS305, WPS436
-  tests/integration/test_pass_environment_variable.py: C812, D200, D205, D400, D403, DAR101, Q000, S101, WPS110, WPS111, WPS115, WPS210, WPS211, WPS220, WPS221, WPS226, WPS300, WPS301, WPS305, WPS436
-  tests/integration/test_set_environment_variable.py: C812, D200, D205, D400, D403, DAR101, Q000, S101, WPS110, WPS111, WPS115, WPS210, WPS211, WPS220, WPS221, WPS300, WPS301, WPS305, WPS436
+  tests/integration/test_execution_environment_image.py: D200, D205, D400, D403, DAR101, Q000, S101, WPS110, WPS111, WPS115, WPS210, WPS211, WPS220, WPS221, WPS226, WPS300, WPS301, WPS305, WPS436
+  tests/integration/test_execution_environment.py: D200, D205, D400, D403, DAR101, Q000, S101, WPS110, WPS111, WPS115, WPS210, WPS211, WPS220, WPS221, WPS300, WPS301, WPS305, WPS436
+  tests/integration/test_pass_environment_variable.py: D200, D205, D400, D403, DAR101, Q000, S101, WPS110, WPS111, WPS115, WPS210, WPS211, WPS220, WPS221, WPS226, WPS300, WPS301, WPS305, WPS436
+  tests/integration/test_set_environment_variable.py: D200, D205, D400, D403, DAR101, Q000, S101, WPS110, WPS111, WPS115, WPS210, WPS211, WPS220, WPS221, WPS300, WPS301, WPS305, WPS436
   tests/integration/test_stdout_exit_codes.py: D200, D400, D403, DAR101, DAR201, Q000, S101, WPS110, WPS226, WPS300, WPS305
-  tests/integration/_tmux_session.py: C812, D105, D107, D205, D400, D403, DAR101, DAR201, DAR401, Q000, WPS110, WPS210, WPS211, WPS213, WPS220, WPS221, WPS226, WPS231, WPS232, WPS300, WPS305, WPS306, WPS436, WPS440
+  tests/integration/_tmux_session.py: D105, D107, D205, D400, D403, DAR101, DAR201, DAR401, Q000, WPS110, WPS210, WPS211, WPS213, WPS220, WPS221, WPS226, WPS231, WPS232, WPS300, WPS305, WPS306, WPS436, WPS440
   tests/unit/actions/test_config.py: D200, D400, D403, Q000, S101, WPS110, WPS204, WPS218, WPS221, WPS226, WPS305
   tests/unit/actions/test_inventory.py: D200, D400, D403, Q000, S101, WPS110, WPS204, WPS218, WPS221, WPS226, WPS305
-  tests/unit/actions/test_run.py: C812, D200, D400, DAR101, DAR201, N813, PT019, Q000, S101, S108, WPS110, WPS121, WPS122, WPS201, WPS226, WPS237, WPS305, WPS425, WPS432, WPS437
+  tests/unit/actions/test_run.py: D200, D400, DAR101, DAR201, N813, PT019, Q000, S101, S108, WPS110, WPS121, WPS122, WPS201, WPS226, WPS237, WPS305, WPS425, WPS432, WPS437
   tests/unit/configuration_subsystem/conftest.py: D200, D400, D403, DAR101, DAR201, Q000, WPS110, WPS201, WPS210, WPS300, WPS436
-  tests/unit/configuration_subsystem/data.py: C812, D205, D400, D403, DAR101, DAR201, Q000, S108, WPS226, WPS331, WPS407
+  tests/unit/configuration_subsystem/data.py: D205, D400, D403, DAR101, DAR201, Q000, S108, WPS226, WPS331, WPS407
   tests/unit/configuration_subsystem/defaults.py: D200, D400, Q000, WPS300
   tests/unit/configuration_subsystem/test_broken_settings.py: D200, D400, DAR101, Q000, S101
   tests/unit/configuration_subsystem/test_configurator.py: D200, D205, D209, D400, DAR101, N817, PT019, Q000, S101, WPS111, WPS118, WPS347, WPS458, WPS520
   tests/unit/configuration_subsystem/test_container_engine_auto.py: D200, DAR101, Q000, S101, WPS430, WPS520
-  tests/unit/configuration_subsystem/test_entries_sanity.py: C812, D200, D400, DAR101, N817, Q000, S101, WPS110, WPS111, WPS202, WPS221, WPS226, WPS300, WPS347
+  tests/unit/configuration_subsystem/test_entries_sanity.py: D200, D400, DAR101, N817, Q000, S101, WPS110, WPS111, WPS202, WPS221, WPS226, WPS300, WPS347
   tests/unit/configuration_subsystem/test_fixture_sanity.py: D205, D400, Q000, S101, WPS110, WPS210, WPS300, WPS436
   tests/unit/configuration_subsystem/test_invalid_params.py: D200, D202, D400, DAR101, PT006, PT019, Q000, S101, WPS110, WPS202, WPS204, WPS226, WPS300, WPS305, WPS420, WPS430, WPS510
   tests/unit/configuration_subsystem/test_mode_subcommand_action.py: D205, D400, Q000, S101, WPS226, WPS336, WPS437, WPS510
-  tests/unit/configuration_subsystem/test_precedence.py: C812, D205, D400, DAR101, N817, PT006, PT019, Q000, S101, WPS110, WPS111, WPS118, WPS201, WPS210, WPS211, WPS218, WPS226, WPS231, WPS232, WPS300, WPS347, WPS440, WPS458, WPS520, WPS529
-  tests/unit/configuration_subsystem/test_previous_cli.py: C812, D202, D205, D400, N817, PT019, Q000, S101, S108, WPS110, WPS111, WPS121, WPS204, WPS210, WPS218, WPS226, WPS347, WPS440, WPS458, WPS520
+  tests/unit/configuration_subsystem/test_precedence.py: D205, D400, DAR101, N817, PT006, PT019, Q000, S101, WPS110, WPS111, WPS118, WPS201, WPS210, WPS211, WPS218, WPS226, WPS231, WPS232, WPS300, WPS347, WPS440, WPS458, WPS520, WPS529
+  tests/unit/configuration_subsystem/test_previous_cli.py: D202, D205, D400, N817, PT019, Q000, S101, S108, WPS110, WPS111, WPS121, WPS204, WPS210, WPS218, WPS226, WPS347, WPS440, WPS458, WPS520
   tests/unit/configuration_subsystem/test_sample_configurations.py: D205, D400, Q000, S101, WPS219, WPS221, WPS226, WPS428, WPS437
   tests/unit/configuration_subsystem/utils.py: D200, D400, DAR101, DAR201, Q000, WPS100, WPS110, WPS305, WPS336, WPS510
-  tests/unit/image_manager/test_image_puller.py: C812, D400, D403, DAR101, DAR201, Q000, S101, WPS110, WPS226, WPS300, WPS305
+  tests/unit/image_manager/test_image_puller.py: D400, D403, DAR101, DAR201, Q000, S101, WPS110, WPS226, WPS300, WPS305
   tests/unit/runner/test_api.py: D200, D202, D400, D403, DAR101, PT006, Q000, S101, S108, WPS226, WPS437
-  tests/unit/test_cli.py: C812, D200, D202, D205, D400, D403, DAR101, DAR201, PT006, PT019, Q000, S101, S108, WPS110, WPS210, WPS226, WPS300, WPS305, WPS360
-  tests/unit/test_image_introspection.py: C812, D200, D400, D403, DAR101, DAR201, Q000, S101, WPS111, WPS204, WPS210, WPS218, WPS221, WPS226, WPS305
+  tests/unit/test_cli.py: D200, D202, D205, D400, D403, DAR101, DAR201, PT006, PT019, Q000, S101, S108, WPS110, WPS210, WPS226, WPS300, WPS305, WPS360
+  tests/unit/test_image_introspection.py: D200, D400, D403, DAR101, DAR201, Q000, S101, WPS111, WPS204, WPS210, WPS218, WPS221, WPS226, WPS305
   tests/unit/test_log_append.py: D200, D400, D403, DAR101, Q000, S101, WPS324, WPS430
-  tests/unit/test_utils.py: C812, D200, D202, D400, D403, DAR101, PT006, Q000, S101, WPS110, WPS202, WPS221, WPS226, WPS237, WPS305, WPS336, WPS407, WPS430, WPS432
+  tests/unit/test_utils.py: D200, D202, D400, D403, DAR101, PT006, Q000, S101, WPS110, WPS202, WPS221, WPS226, WPS237, WPS305, WPS336, WPS407, WPS430, WPS432
   tests/unit/test_yaml.py: D200, S101, WPS301, WPS436
-  tests/unit/ui_framework/test_colorize.py: C812, D200, D205, D209, D400, DAR101, Q000, S101, WPS110, WPS204, WPS218, WPS221, WPS226, WPS436
+  tests/unit/ui_framework/test_colorize.py: D200, D205, D209, D400, DAR101, Q000, S101, WPS110, WPS204, WPS218, WPS221, WPS226, WPS436
   src/ansible_navigator/tm_tokenize/__init__.py: D104
   src/ansible_navigator/ui_framework/curses_defs.py: D200, D400
   src/ansible_navigator/ui_framework/ui_config.py: D205, D400

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,6 @@ repos:
   - id: add-trailing-comma
     args:
     - --py36-plus
-    exclude: |
-      (?x)
-      ^
-        .*
-      $
     stages: ["manual"]
 
 - repo: https://github.com/PyCQA/isort

--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -78,7 +78,11 @@ class CollectionCatalog:
                     plugin_type = "module"
                 for (dirpath, _dirnames, filenames) in os.walk(path):
                     self._process_plugin_dir(
-                        plugin_type, filenames, file_chksums, dirpath, collection
+                        plugin_type,
+                        filenames,
+                        file_chksums,
+                        dirpath,
+                        collection,
                     )
 
     @staticmethod
@@ -98,7 +102,12 @@ class CollectionCatalog:
         return res
 
     def _process_plugin_dir(
-        self, plugin_type: str, filenames: List, file_chksums: Dict, dirpath: str, collection: Dict
+        self,
+        plugin_type: str,
+        filenames: List,
+        file_chksums: Dict,
+        dirpath: str,
+        collection: Dict,
     ) -> None:
         # pylint: disable=too-many-arguments
         """process each plugin within one plugin directory"""
@@ -242,7 +251,7 @@ def identify_missing(collections: Dict, collection_cache: KeyValueStore) -> Tupl
             if chksum not in handled:
                 if chksum not in collection_cache:
                     missing.append(
-                        (collection["known_as"], chksum, f"{collection['path']}{details['path']}")
+                        (collection["known_as"], chksum, f"{collection['path']}{details['path']}"),
                     )
                 handled.add(chksum)
     return handled, missing, plugin_count
@@ -261,7 +270,10 @@ def parse_args():
 
     parser.add_argument("-a", dest="adjacent", help="prepended to dirs")
     parser.add_argument(
-        "-c", dest="collection_cache_path", help="path to collection cache", required=True
+        "-c",
+        dest="collection_cache_path",
+        help="path to collection cache",
+        required=True,
     )
     parsed_args = parser.parse_args()
 
@@ -300,7 +312,10 @@ def retrieve_collections_paths() -> Dict:
 
 
 def retrieve_docs(
-    collection_cache: KeyValueStore, errors: List, missing: List, stats: Dict
+    collection_cache: KeyValueStore,
+    errors: List,
+    missing: List,
+    stats: Dict,
 ) -> None:
     # pylint: disable=too-many-locals
     """extract the docs from the plugins"""

--- a/share/ansible_navigator/utils/image_introspect.py
+++ b/share/ansible_navigator/utils/image_introspect.py
@@ -105,7 +105,8 @@ class CommandRunner:
         processes = []
         for _proc in range(worker_count):
             proc = multiprocessing.Process(
-                target=worker, args=(self._pending_queue, self._completed_queue)
+                target=worker,
+                args=(self._pending_queue, self._completed_queue),
             )
             processes.append(proc)
             proc.start()
@@ -168,7 +169,7 @@ class AnsibleCollections(CmdParser):
                 id="ansible_collections",
                 command=command,
                 parse=self.parse,
-            )
+            ),
         ]
 
     @staticmethod
@@ -222,7 +223,7 @@ class PythonPackages(CmdParser):
         pre.parse(pre)
         pkgs = " ".join(pkg for pkg in pre.details[0])
         return [
-            Command(id="python_packages", command=f"python3 -m pip show {pkgs}", parse=self.parse)
+            Command(id="python_packages", command=f"python3 -m pip show {pkgs}", parse=self.parse),
         ]
 
     def parse(self, command):

--- a/src/ansible_navigator/_yaml.py
+++ b/src/ansible_navigator/_yaml.py
@@ -60,7 +60,10 @@ class HumanDumper(Dumper):
     """
 
     def represent_scalar(
-        self, tag: str, value: str, style: Union[str, None] = None
+        self,
+        tag: str,
+        value: str,
+        style: Union[str, None] = None,
     ) -> yaml.nodes.ScalarNode:
         """Represent all multiline strings as block scalars to improve readability for humans.
 

--- a/src/ansible_navigator/action_runner.py
+++ b/src/ansible_navigator/action_runner.py
@@ -81,7 +81,11 @@ class ActionRunner(App):
         name, action = self._action_match(self._args.app)
         if name and action:
             interaction = Interaction(
-                name=name, action=action, menu=None, content=None, ui=self._ui._ui
+                name=name,
+                action=action,
+                menu=None,
+                content=None,
+                ui=self._ui._ui,
             )
             self._run_app(interaction)
 

--- a/src/ansible_navigator/actions/__init__.py
+++ b/src/ansible_navigator/actions/__init__.py
@@ -16,11 +16,12 @@ names = actions.names_factory(__package__)
 kegexes: Callable = actions.kegexes_factory(__package__)
 
 run_action_stdout: Callable[[str, ApplicationConfiguration], int] = actions.run_stdout_factory(
-    __package__
+    __package__,
 )
 
 run_action: Callable[
-    [str, AppPublic, Interaction], Union[None, Interaction]
+    [str, AppPublic, Interaction],
+    Union[None, Interaction],
 ] = actions.run_interactive_factory(__package__)
 
 

--- a/src/ansible_navigator/actions/back.py
+++ b/src/ansible_navigator/actions/back.py
@@ -39,7 +39,10 @@ class Action:
                 if step.type == "menu" and app.steps.current.type == "menu":
                     interaction.ui.menu_filter(None)
             self._logger.debug(
-                "Stepping back in %s from %s to %s", app.name, step.name, app.steps.current.name
+                "Stepping back in %s from %s to %s",
+                app.name,
+                step.name,
+                app.steps.current.name,
             )
         else:
             self._logger.debug("Return to %s, at last step", app.name)

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -61,9 +61,9 @@ def content_heading(obj: Any, screen_w: int) -> Union[CursesLines, None]:
                     string=string,
                     color=2,
                     decoration=curses.A_UNDERLINE,
-                )
-            ]
-        )
+                ),
+            ],
+        ),
     )
     return tuple(heading)
 
@@ -110,12 +110,12 @@ class Action(App):
         notification = nonblocking_notification(
             messages=[
                 "Collecting collection content, this may take a minute the first time...",
-            ]
+            ],
         )
         interaction.ui.show(notification)
 
         params = [self._name] + shlex.split(
-            self._interaction.action.match.groupdict()["params"] or ""
+            self._interaction.action.match.groupdict()["params"] or "",
         )
 
         self._update_args(params=params, attach_cdc=True)
@@ -280,7 +280,7 @@ class Action(App):
 
         if isinstance(self._args.execution_environment_volume_mounts, list):
             kwargs.update(
-                {"container_volume_mounts": self._args.execution_environment_volume_mounts}
+                {"container_volume_mounts": self._args.execution_environment_volume_mounts},
             )
 
         if isinstance(self._args.container_options, list):
@@ -308,11 +308,11 @@ class Action(App):
             container_volume_mounts = [f"{share_directory}/utils:{share_directory}/utils"]
             if os.path.exists(self._adjacent_collection_dir):
                 container_volume_mounts.append(
-                    f"{self._adjacent_collection_dir}:{self._adjacent_collection_dir}:z"
+                    f"{self._adjacent_collection_dir}:{self._adjacent_collection_dir}:z",
                 )
 
             container_volume_mounts.append(
-                f"{self._collection_cache_path}:{self._collection_cache_path}:z"
+                f"{self._collection_cache_path}:{self._collection_cache_path}:z",
             )
             kwargs.update({"container_volume_mounts": container_volume_mounts})
 
@@ -321,7 +321,7 @@ class Action(App):
             python_exec_path = sys.executable
 
         self._logger.debug(
-            f"Invoke runner with executable_cmd: {python_exec_path}" + f" and kwargs: {kwargs}"
+            f"Invoke runner with executable_cmd: {python_exec_path}" + f" and kwargs: {kwargs}",
         )
         _runner = Command(executable_cmd=python_exec_path, **kwargs)
         output, error, _ = _runner.run()
@@ -355,7 +355,8 @@ class Action(App):
             self._logger.error("%s %s", error["path"], error["error"])
 
         self._collections = sorted(
-            list(parsed["collections"].values()), key=lambda i: i["known_as"]
+            list(parsed["collections"].values()),
+            key=lambda i: i["known_as"],
         )
         for collection in self._collections:
             collection["__name"] = collection["known_as"]

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -68,9 +68,9 @@ def content_heading(obj: Any, screen_w: int) -> Union[CursesLines, None]:
                     string=string,
                     color=color,
                     decoration=curses.A_UNDERLINE,
-                )
-            ]
-        )
+                ),
+            ],
+        ),
     )
     return tuple(heading)
 
@@ -109,12 +109,12 @@ class Action(App):
         notification = nonblocking_notification(
             messages=[
                 "Collecting the ansible configuration, this may take a minute...",
-            ]
+            ],
         )
         interaction.ui.show(notification)
 
         self._update_args(
-            [self._name] + shlex.split(self._interaction.action.match.groupdict()["params"] or "")
+            [self._name] + shlex.split(self._interaction.action.match.groupdict()["params"] or ""),
         )
 
         self._run_runner()
@@ -223,7 +223,7 @@ class Action(App):
 
         if isinstance(self._args.execution_environment_volume_mounts, list):
             kwargs.update(
-                {"container_volume_mounts": self._args.execution_environment_volume_mounts}
+                {"container_volume_mounts": self._args.execution_environment_volume_mounts},
             )
 
         if isinstance(self._args.container_options, list):

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -71,7 +71,7 @@ class Action(App):
         self._prepare_to_run(app, interaction)
 
         self._update_args(
-            [self._name] + shlex.split(self._interaction.action.match.groupdict()["params"] or "")
+            [self._name] + shlex.split(self._interaction.action.match.groupdict()["params"] or ""),
         )
 
         plugin_name_source = self._args.entry("plugin_name").value.source
@@ -112,7 +112,8 @@ class Action(App):
         while True:
             app.update()
             next_interaction: Interaction = interaction.ui.show(
-                content_heading=self.generate_content_heading, obj=plugin_doc
+                content_heading=self.generate_content_heading,
+                obj=plugin_doc,
             )
             if next_interaction.name != "refresh":
                 break
@@ -158,7 +159,7 @@ class Action(App):
 
         if isinstance(self._args.execution_environment_volume_mounts, list):
             kwargs.update(
-                {"container_volume_mounts": self._args.execution_environment_volume_mounts}
+                {"container_volume_mounts": self._args.execution_environment_volume_mounts},
             )
 
         if isinstance(self._args.container_options, list):
@@ -178,7 +179,9 @@ class Action(App):
             self._logger.debug("doc playbook dir set to: %s", playbook_dir)
 
             plugin_doc, plugin_doc_err = self._runner.fetch_plugin_doc(
-                [self._plugin_name], plugin_type=self._plugin_type, playbook_dir=playbook_dir
+                [self._plugin_name],
+                plugin_type=self._plugin_type,
+                playbook_dir=playbook_dir,
             )
             if plugin_doc_err:
                 self._logger.error(
@@ -220,7 +223,9 @@ class Action(App):
             return stdout_return
 
     def _extract_plugin_doc(
-        self, out: Union[Dict[Any, Any], str], err: Union[Dict[Any, Any], str]
+        self,
+        out: Union[Dict[Any, Any], str],
+        err: Union[Dict[Any, Any], str],
     ) -> Optional[Dict[Any, Any]]:
         # pylint: disable=too-many-branches
         plugin_doc = {}
@@ -238,7 +243,8 @@ class Action(App):
                 except json.JSONDecodeError as exc:
                     if self._args.mode == "interactive":
                         self._logger.info(
-                            "Parsing of ansible-doc output failed for '%s'", self._plugin_name
+                            "Parsing of ansible-doc output failed for '%s'",
+                            self._plugin_name,
                         )
                     self._logger.debug("json decode error: %s", str(exc))
                     self._logger.debug("tried: %s", out)

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -120,18 +120,18 @@ class Action(App):
         self._prepare_to_run(app, interaction)
 
         self._update_args(
-            [self._name] + shlex.split(self._interaction.action.match.groupdict()["params"] or "")
+            [self._name] + shlex.split(self._interaction.action.match.groupdict()["params"] or ""),
         )
 
         notification = nonblocking_notification(
-            messages=["Collecting available images, this may take a minute..."]
+            messages=["Collecting available images, this may take a minute..."],
         )
         interaction.ui.show(notification)
 
         self._collect_image_list()
         if not self._images.value:
             messages = [
-                "No images were found, or the configured container engine was not available."
+                "No images were found, or the configured container engine was not available.",
             ]
             messages.append("Please check the log (:log) for errors.")
             warning = warning_notification(messages=messages)
@@ -173,7 +173,8 @@ class Action(App):
                 )
             elif self.steps.current.type == "content":
                 content_heading = partial(
-                    self.generate_content_heading, name=self.steps.previous.name
+                    self.generate_content_heading,
+                    name=self.steps.previous.name,
                 )
                 result = self._interaction.ui.show(
                     obj=self.steps.current.value,
@@ -229,7 +230,8 @@ class Action(App):
                 tipe="menu",
                 select_func=self._build_python_content,
                 value=sorted(
-                    self._images.selected["python"]["details"], key=lambda i: i["name"].lower()
+                    self._images.selected["python"]["details"],
+                    key=lambda i: i["name"].lower(),
                 ),
             )
 
@@ -240,7 +242,8 @@ class Action(App):
                 tipe="menu",
                 select_func=self._build_system_content,
                 value=sorted(
-                    self._images.selected["system"]["details"], key=lambda i: i["name"].lower()
+                    self._images.selected["system"]["details"],
+                    key=lambda i: i["name"].lower(),
                 ),
             )
 
@@ -262,32 +265,32 @@ class Action(App):
             {
                 image_name: "Image information",
                 "description": "Information collected from image inspection",
-            }
+            },
         ]
         if self.steps.current.selected["execution_environment"]:
             menu.append(
                 {
                     image_name: "General information",
                     "description": "OS and python version information",
-                }
+                },
             )
             menu.append(
                 {
                     image_name: "Ansible version and collections",
                     "description": "Information about ansible and ansible collections",
-                }
+                },
             )
             menu.append(
                 {
                     image_name: "Python packages",
                     "description": "Information about python and python packages",
-                }
+                },
             )
             menu.append(
                 {
                     image_name: "Operating system packages",
                     "description": "Information about operating system packages",
-                }
+                },
             )
             menu.append({image_name: "Everything", "description": "All image information"})
         for menu_entry in menu:
@@ -368,20 +371,22 @@ class Action(App):
             kwargs.update({"container_options": self._args.container_options})
 
         self._logger.debug(
-            f"Invoke runner with executable_cmd: {python_exec_path}" + f" and kwargs: {kwargs}"
+            f"Invoke runner with executable_cmd: {python_exec_path}" + f" and kwargs: {kwargs}",
         )
         _runner = Command(executable_cmd=python_exec_path, **kwargs)
         output, error, _ = _runner.run()
         if error:
             self._logger.error(
-                "Image introspection failed (runner), the return value was: %s", error
+                "Image introspection failed (runner), the return value was: %s",
+                error,
             )
             self.notify_failed()
             return False
         parsed = self._parse(output)
         if parsed is None:
             self._logger.error(
-                "Image introspection failed (parsed), the return value was: %s", output[0:1000]
+                "Image introspection failed (parsed), the return value was: %s",
+                output[0:1000],
             )
             self.notify_failed()
             return False
@@ -396,13 +401,14 @@ class Action(App):
                 "ansible": {
                     "collections": parsed["ansible_collections"],
                     "version": parsed["ansible_version"],
-                }
+                },
             }
             self._images.selected["python"] = parsed["python_packages"]
             self._images.selected["system"] = parsed["system_packages"]
         except KeyError:
             self._logger.exception(
-                "Image introspection failed (keys), the return value was: %s", output[0:1000]
+                "Image introspection failed (keys), the return value was: %s",
+                output[0:1000],
             )
             self.notify_failed()
             return False

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -70,9 +70,9 @@ def content_heading(obj: Any, screen_w: int) -> Union[CursesLines, None]:
                     string=string,
                     color=0,
                     decoration=curses.A_UNDERLINE,
-                )
-            ]
-        )
+                ),
+            ],
+        ),
     )
     return tuple(heading)
 
@@ -146,7 +146,7 @@ class Action(App):
                             os.path.getmtime(e)
                             for e in glob.glob(os.path.join(inventory, "**"), recursive=True)
                         )
-                    )
+                    ),
                 )
             elif os.path.isfile(inventory):
                 mtimes.append(os.path.getmtime(inventory))
@@ -264,7 +264,8 @@ class Action(App):
             description="Explore each inventory group and group members members",
         )
         hosts = MenuEntry(
-            title="Browse hosts", description="Explore the inventory with a list of all hosts"
+            title="Browse hosts",
+            description="Explore the inventory with a list of all hosts",
         )
 
         step = Step(
@@ -292,7 +293,7 @@ class Action(App):
             menu = Menu()
             taxonomy = "\u25B8".join(
                 ["all"]
-                + [step.selected["__name"] for step in self.steps if step.name == "group_menu"]
+                + [step.selected["__name"] for step in self.steps if step.name == "group_menu"],
             )
 
             columns = ["__name", "__taxonomy", "__type"]
@@ -381,7 +382,7 @@ class Action(App):
     def _build_inventory_list(self) -> None:
 
         self._update_args(
-            [self._name] + shlex.split(self._interaction.action.match.groupdict()["params"] or "")
+            [self._name] + shlex.split(self._interaction.action.match.groupdict()["params"] or ""),
         )
 
         if isinstance(self._args.inventory, list):
@@ -516,7 +517,7 @@ class Action(App):
 
         if isinstance(self._args.execution_environment_volume_mounts, list):
             kwargs.update(
-                {"container_volume_mounts": self._args.execution_environment_volume_mounts}
+                {"container_volume_mounts": self._args.execution_environment_volume_mounts},
             )
 
         if isinstance(self._args.container_options, list):

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -48,7 +48,8 @@ RESULT_TO_COLOR = [
 ]
 
 get_color = lambda word: next(  # noqa: E731
-    (x[1] for x in RESULT_TO_COLOR if re.match(x[0], word)), 0
+    (x[1] for x in RESULT_TO_COLOR if re.match(x[0], word)),
+    0,
 )
 
 
@@ -110,13 +111,13 @@ def content_heading(obj: Any, screen_w: int) -> Union[CursesLines, None]:
         detail = f"PLAY [{obj['play']}:{obj['__number']}] "
         stars = "*" * (screen_w - len(detail))
         heading.append(
-            tuple([CursesLinePart(column=0, string=detail + stars, color=0, decoration=0)])
+            tuple([CursesLinePart(column=0, string=detail + stars, color=0, decoration=0)]),
         )
 
         detail = f"TASK [{obj['task']}] "
         stars = "*" * (screen_w - len(detail))
         heading.append(
-            tuple([CursesLinePart(column=0, string=detail + stars, color=0, decoration=0)])
+            tuple([CursesLinePart(column=0, string=detail + stars, color=0, decoration=0)]),
         )
 
         if obj["__changed"] is True:
@@ -141,9 +142,9 @@ def content_heading(obj: Any, screen_w: int) -> Union[CursesLines, None]:
                         string=string,
                         color=color,
                         decoration=curses.A_UNDERLINE,
-                    )
-                ]
-            )
+                    ),
+                ],
+            ),
         )
         return tuple(heading)
     return None
@@ -228,7 +229,7 @@ class Action(App):
                 self._args.mode == "stdout",
                 self._args.playbook_artifact_enable,
                 self._args.app != "replay",
-            )
+            ),
         ):
             return "stdout_w_artifact"
         return self._args.mode
@@ -295,7 +296,8 @@ class Action(App):
                     self.steps.append(self._plays)
                 else:
                     self._logger.debug(
-                        "No steps remaining for '%s' returning to calling app", self._name
+                        "No steps remaining for '%s' returning to calling app",
+                        self._name,
                     )
                     break
 
@@ -319,7 +321,7 @@ class Action(App):
         # Ensure the playbook and inventory are valid
 
         self._update_args(
-            ["run"] + shlex.split(self._interaction.action.match.groupdict()["params_run"] or "")
+            ["run"] + shlex.split(self._interaction.action.match.groupdict()["params_run"] or ""),
         )
 
         if isinstance(self._args.playbook, str):
@@ -365,7 +367,7 @@ class Action(App):
         if self.mode == "interactive":
             self._update_args(
                 ["replay"]
-                + shlex.split(self._interaction.action.match.groupdict()["params_replay"] or "")
+                + shlex.split(self._interaction.action.match.groupdict()["params_replay"] or ""),
             )
 
         artifact_file = self._args.playbook_artifact_replay
@@ -409,7 +411,8 @@ class Action(App):
                 return False
         else:
             self._logger.error(
-                "Incompatible artifact version, got '%s', compatible = '1.y.z'", version
+                "Incompatible artifact version, got '%s', compatible = '1.y.z'",
+                version,
             )
             return False
 
@@ -575,7 +578,7 @@ class Action(App):
 
         if isinstance(self._args.execution_environment_volume_mounts, list):
             kwargs.update(
-                {"container_volume_mounts": self._args.execution_environment_volume_mounts}
+                {"container_volume_mounts": self._args.execution_environment_volume_mounts},
             )
 
         if isinstance(self._args.container_options, list):
@@ -699,10 +702,10 @@ class Action(App):
                 {
                     tot: len([t for t in play["tasks"] if t["__result"].lower() == tot[2:]])
                     for tot in total
-                }
+                },
             )
             self._plays.value[idx]["__changed"] = len(
-                [t for t in play["tasks"] if t["__changed"] is True]
+                [t for t in play["tasks"] if t["__changed"] is True],
             )
             task_count = len(play["tasks"])
             self._plays.value[idx]["__task_count"] = task_count

--- a/src/ansible_navigator/actions/select.py
+++ b/src/ansible_navigator/actions/select.py
@@ -38,5 +38,7 @@ class Action:
         app.steps.append(app.steps.current.select_func())  # add next
         app.steps.append(this)  # put this back on stack
         self._logger.debug(
-            "Requested next step in %s will be %s", app.name, app.steps.previous.name
+            "Requested next step in %s will be %s",
+            app.name,
+            app.steps.previous.name,
         )

--- a/src/ansible_navigator/actions/template.py
+++ b/src/ansible_navigator/actions/template.py
@@ -67,7 +67,8 @@ class Action(App):
         interaction.ui.scroll(0)
 
         errors, templated = templar(
-            string=str(interaction.action.value), template_vars=template_vars
+            string=str(interaction.action.value),
+            template_vars=template_vars,
         )
         if errors:
             msgs = ["Errors encountered while templating input"] + errors

--- a/src/ansible_navigator/actions/write_file.py
+++ b/src/ansible_navigator/actions/write_file.py
@@ -40,14 +40,16 @@ class Action:
         if match["append"]:
             if not os.path.exists(filename) and not match["force"]:
                 self._logger.warning(
-                    "Append operation failed because %s does not exist, force with !", filename
+                    "Append operation failed because %s does not exist, force with !",
+                    filename,
                 )
                 return None
             fmode = "a"
         else:
             if os.path.exists(filename) and not match["force"]:
                 self._logger.warning(
-                    "Write operation failed because %s exists, force with !", filename
+                    "Write operation failed because %s exists, force with !",
+                    filename,
                 )
                 return None
             fmode = "w"

--- a/src/ansible_navigator/app.py
+++ b/src/ansible_navigator/app.py
@@ -87,7 +87,7 @@ class App:
                 "[HINT] Start an additional instance of ansible-navigator"
                 + " in a new terminal with mode 'stdout'.",
                 f"      e.g. 'ansible-navigator {self._name} --mode stdout",
-            ]
+            ],
         )
         interaction.ui.show(warning)
 
@@ -147,7 +147,10 @@ class App:
         """
 
     def _update_args(
-        self, params: List, apply_previous_cli_entries: C = C.ALL, attach_cdc: bool = False
+        self,
+        params: List,
+        apply_previous_cli_entries: C = C.ALL,
+        attach_cdc: bool = False,
     ) -> None:
         """Update the current args.
 

--- a/src/ansible_navigator/command_runner/command_runner.py
+++ b/src/ansible_navigator/command_runner/command_runner.py
@@ -90,7 +90,8 @@ class CommandRunner:
         processes = []
         for _proc in range(worker_count):
             proc = multiprocessing.Process(
-                target=worker, args=(self._pending_queue, self._completed_queue)
+                target=worker,
+                args=(self._pending_queue, self._completed_queue),
             )
             processes.append(proc)
             proc.start()

--- a/src/ansible_navigator/configuration_subsystem/configurator.py
+++ b/src/ansible_navigator/configuration_subsystem/configurator.py
@@ -161,7 +161,7 @@ class Configurator:
                         "and ensure it is properly formatted"
                     )
                     self._exit_messages.append(
-                        ExitMessage(message=exit_msg, prefix=ExitPrefix.HINT)
+                        ExitMessage(message=exit_msg, prefix=ExitPrefix.HINT),
                     )
                     return
             for entry in self._config.entries:
@@ -190,7 +190,7 @@ class Configurator:
                         "and ensure it is properly formatted"
                     )
                     self._exit_messages.append(
-                        ExitMessage(message=exit_msg, prefix=ExitPrefix.HINT)
+                        ExitMessage(message=exit_msg, prefix=ExitPrefix.HINT),
                     )
                     return
                 except KeyError:
@@ -265,7 +265,7 @@ class Configurator:
                     ]
                     exit_msg = f"Try again with {oxfordcomma(choices, 'or')}"
                     self._exit_messages.append(
-                        ExitMessage(message=exit_msg, prefix=ExitPrefix.HINT)
+                        ExitMessage(message=exit_msg, prefix=ExitPrefix.HINT),
                     )
 
     def _apply_previous_cli_to_current(self) -> None:
@@ -274,7 +274,8 @@ class Configurator:
 
         # _apply_previous_cli_entries must be ALL or a list of entries
         if self._apply_previous_cli_entries is not C.ALL and not isinstance(
-            self._apply_previous_cli_entries, list
+            self._apply_previous_cli_entries,
+            list,
         ):
             return
 

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -435,7 +435,7 @@ NavigatorConfiguration = ApplicationConfiguration(
             short_description="Specify the name for artifacts created from completed playbooks",
             subcommands=["run"],
             value=SettingsEntryValue(
-                default="{playbook_dir}/{playbook_name}-artifact-{ts_utc}.json"
+                default="{playbook_dir}/{playbook_name}-artifact-{ts_utc}.json",
             ),
         ),
         SettingsEntry(

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -39,7 +39,7 @@ def _post_processor(func):
             LogMessage(
                 level=logging.DEBUG,
                 message=f"Completed post processing for {name}. (changed={changed})",
-            )
+            ),
         )
         if changed:
             messages.append(LogMessage(level=logging.DEBUG, message=f" before: '{before}'"))
@@ -109,7 +109,8 @@ class NavigatorPostProcessor:
 
     @staticmethod
     def _true_or_false(
-        entry: SettingsEntry, config: ApplicationConfiguration
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         messages: List[LogMessage] = []
@@ -125,7 +126,8 @@ class NavigatorPostProcessor:
     @staticmethod
     @_post_processor
     def ansible_runner_artifact_dir(
-        entry: SettingsEntry, config: ApplicationConfiguration
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         """Post process ansible_runner_artifact_dir path"""
@@ -138,7 +140,8 @@ class NavigatorPostProcessor:
     @staticmethod
     @_post_processor
     def ansible_runner_rotate_artifacts_count(
-        entry: SettingsEntry, config: ApplicationConfiguration
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         """Post process ansible_runner_rotate_artifacts_count"""
@@ -155,7 +158,8 @@ class NavigatorPostProcessor:
     @staticmethod
     @_post_processor
     def ansible_runner_timeout(
-        entry: SettingsEntry, config: ApplicationConfiguration
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         """Post process ansible_runner_timeout"""
@@ -172,7 +176,8 @@ class NavigatorPostProcessor:
     @staticmethod
     @_post_processor
     def collection_doc_cache_path(
-        entry: SettingsEntry, config: ApplicationConfiguration
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         """Post process collection doc cache path"""
@@ -195,7 +200,8 @@ class NavigatorPostProcessor:
     @staticmethod
     @_post_processor
     def container_engine(
-        entry: SettingsEntry, config: ApplicationConfiguration
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         """Post process container_engine"""
@@ -211,7 +217,9 @@ class NavigatorPostProcessor:
 
     @_post_processor
     def display_color(
-        self, entry: SettingsEntry, config: ApplicationConfiguration
+        self,
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         """Post process displacy_color"""
         messages: List[LogMessage] = []
@@ -225,7 +233,9 @@ class NavigatorPostProcessor:
 
     @_post_processor
     def editor_console(
-        self, entry: SettingsEntry, config: ApplicationConfiguration
+        self,
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         """Post process editor_console"""
         return self._true_or_false(entry, config)
@@ -289,7 +299,8 @@ class NavigatorPostProcessor:
     @staticmethod
     @_post_processor
     def execution_environment_image(
-        entry: SettingsEntry, config: ApplicationConfiguration
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         """Post process execution_environment_image"""
@@ -301,7 +312,9 @@ class NavigatorPostProcessor:
 
     @_post_processor
     def execution_environment_volume_mounts(
-        self, entry: SettingsEntry, config: ApplicationConfiguration
+        self,
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         # pylint: disable=too-many-branches
@@ -388,7 +401,8 @@ class NavigatorPostProcessor:
     @staticmethod
     @_post_processor
     def container_options(
-        entry: SettingsEntry, config: ApplicationConfiguration
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         """Post process container_options"""
@@ -402,7 +416,9 @@ class NavigatorPostProcessor:
 
     @_post_processor
     def exec_shell(
-        self, entry: SettingsEntry, config: ApplicationConfiguration
+        self,
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         """Post process ``exec_shell``.
@@ -415,7 +431,9 @@ class NavigatorPostProcessor:
 
     @_post_processor
     def help_config(
-        self, entry: SettingsEntry, config: ApplicationConfiguration
+        self,
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         """Post process help_config"""
@@ -439,7 +457,9 @@ class NavigatorPostProcessor:
 
     @_post_processor
     def help_doc(
-        self, entry: SettingsEntry, config: ApplicationConfiguration
+        self,
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         """Post process help_doc"""
@@ -463,13 +483,15 @@ class NavigatorPostProcessor:
 
     @_post_processor
     def help_inventory(
-        self, entry: SettingsEntry, config: ApplicationConfiguration
+        self,
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         """Post process help_inventory"""
         messages, exit_messages = self._true_or_false(entry, config)
         if all(
-            (entry.value.current is True, config.app == "inventory", config.mode == "interactive")
+            (entry.value.current is True, config.app == "inventory", config.mode == "interactive"),
         ):
             if entry.cli_parameters:
                 long_hd = entry.cli_parameters.long_override or entry.name_dashed
@@ -489,7 +511,9 @@ class NavigatorPostProcessor:
 
     @_post_processor
     def help_playbook(
-        self, entry: SettingsEntry, config: ApplicationConfiguration
+        self,
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         """Post process help_playbook"""
@@ -543,7 +567,8 @@ class NavigatorPostProcessor:
     @staticmethod
     @_post_processor
     def inventory_column(
-        entry: SettingsEntry, config: ApplicationConfiguration
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         """Post process inventory_columns"""
@@ -555,7 +580,9 @@ class NavigatorPostProcessor:
 
     @_post_processor
     def log_append(
-        self, entry: SettingsEntry, config: ApplicationConfiguration
+        self,
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         """Post process log_append"""
         return self._true_or_false(entry, config)
@@ -581,7 +608,7 @@ class NavigatorPostProcessor:
                 (
                     f"Failed to create log file {entry.value.current}"
                     f" specified in '{entry.value.source.value}'"
-                )
+                ),
             ]
             exit_msgs.append(f"The error was: {str(exc)}")
             exit_messages.extend(ExitMessage(message=exit_msg) for exit_msg in exit_msgs)
@@ -687,7 +714,7 @@ class NavigatorPostProcessor:
                 entry.value.current is C.NOT_SET,
                 config.help_doc is False,
                 config.mode != "stdout",
-            )
+            ),
         ):
             exit_msg = "A plugin name is required when using the doc subcommand"
             exit_messages.append(ExitMessage(message=exit_msg))
@@ -699,7 +726,8 @@ class NavigatorPostProcessor:
     @staticmethod
     @_post_processor
     def pass_environment_variable(
-        entry: SettingsEntry, config: ApplicationConfiguration
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         """Post process pass_environment_variable"""
@@ -732,7 +760,9 @@ class NavigatorPostProcessor:
 
     @_post_processor
     def playbook_artifact_enable(
-        self, entry: SettingsEntry, config: ApplicationConfiguration
+        self,
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         """Post process playbook_artifact_enable"""
         return self._true_or_false(entry, config)
@@ -740,7 +770,8 @@ class NavigatorPostProcessor:
     @staticmethod
     @_post_processor
     def playbook_artifact_replay(
-        entry: SettingsEntry, config: ApplicationConfiguration
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         """Post process playbook_artifact_replay"""
         messages: List[LogMessage] = []
@@ -769,7 +800,8 @@ class NavigatorPostProcessor:
     @staticmethod
     @_post_processor
     def set_environment_variable(
-        entry: SettingsEntry, config: ApplicationConfiguration
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
         """Post process set_environment_variable"""

--- a/src/ansible_navigator/configuration_subsystem/parser.py
+++ b/src/ansible_navigator/configuration_subsystem/parser.py
@@ -86,7 +86,9 @@ class Parser:
 
     def _configure_base(self) -> None:
         self._base_parser.add_argument(
-            "--version", action="version", version="%(prog)s " + __version__
+            "--version",
+            action="version",
+            version="%(prog)s " + __version__,
         )
 
         for entry in self._config.entries:

--- a/src/ansible_navigator/image_manager/inspector.py
+++ b/src/ansible_navigator/image_manager/inspector.py
@@ -48,8 +48,10 @@ class ImagesList:
         """generate command"""
         return [
             Command(
-                id="images", command=f"{self._container_engine} images", post_process=self.parse
-            )
+                id="images",
+                command=f"{self._container_engine} images",
+                post_process=self.parse,
+            ),
         ]
 
     @staticmethod
@@ -79,8 +81,8 @@ def inspect_all(container_engine: str) -> Tuple[List, str]:
             ImagesInspect(
                 container_engine=container_engine,
                 ids=[image["image_id"] for image in images.values()],
-            )
-        ]
+            ),
+        ],
     )
     for inspect in inspects:
         images[inspect.id]["inspect"] = {"details": inspect.details, "errors": inspect.errors}

--- a/src/ansible_navigator/initialization.py
+++ b/src/ansible_navigator/initialization.py
@@ -44,7 +44,8 @@ def find_config() -> Tuple[List[LogMessage], List[ExitMessage], Union[None, str]
     # Check if the configuration file path is set via an environment var
     cfg_env_var = "ANSIBLE_NAVIGATOR_CONFIG"
     new_messages, new_exit_messages, env_config_path = environment_variable_is_file_path(
-        env_var=cfg_env_var, kind="config"
+        env_var=cfg_env_var,
+        kind="config",
     )
     messages.extend(new_messages)
     exit_messages.extend(new_exit_messages)
@@ -75,7 +76,8 @@ def find_config() -> Tuple[List[LogMessage], List[ExitMessage], Union[None, str]
 
 
 def get_and_check_collection_doc_cache(
-    share_directory: str, collection_doc_cache_path: str
+    share_directory: str,
+    collection_doc_cache_path: str,
 ) -> Tuple[List[LogMessage], List[ExitMessage], Dict]:
     """ensure the collection doc cache
     has the current version of the application
@@ -191,7 +193,8 @@ def parse_and_update(
 
     if mount_collection_cache:
         new_messages, new_exit_messages, cache = get_and_check_collection_doc_cache(
-            args.internals.share_directory, args.collection_doc_cache_path
+            args.internals.share_directory,
+            args.collection_doc_cache_path,
         )
         messages.extend(new_messages)
         exit_messages.extend(new_exit_messages)

--- a/src/ansible_navigator/runner/ansible_config.py
+++ b/src/ansible_navigator/runner/ansible_config.py
@@ -15,7 +15,10 @@ class AnsibleConfig(Base):
     """abstraction for ansible-config command-line"""
 
     def fetch_ansible_config(
-        self, action: str, config_file: Optional[str] = None, only_changed: Optional[bool] = None
+        self,
+        action: str,
+        config_file: Optional[str] = None,
+        only_changed: Optional[bool] = None,
     ) -> Tuple[str, str]:
         """Run ansible-config command and get the configuration related details.
 
@@ -36,5 +39,8 @@ class AnsibleConfig(Base):
             Tuple[str, str]: Returns a tuple of response and error string (if any).
         """
         return get_ansible_config(
-            action, config_file=config_file, only_changed=only_changed, **self._runner_args
+            action,
+            config_file=config_file,
+            only_changed=only_changed,
+            **self._runner_args,
         )

--- a/src/ansible_navigator/runner/ansible_doc.py
+++ b/src/ansible_navigator/runner/ansible_doc.py
@@ -51,5 +51,5 @@ class AnsibleDoc(Base):
             snippet=snippet,
             playbook_dir=playbook_dir,
             module_path=module_path,
-            **self._runner_args
+            **self._runner_args,
         )

--- a/src/ansible_navigator/runner/ansible_inventory.py
+++ b/src/ansible_navigator/runner/ansible_inventory.py
@@ -56,5 +56,5 @@ class AnsibleInventory(Base):
             playbook_dir=playbook_dir,
             vault_ids=vault_ids,
             vault_password_file=vault_password_file,
-            **self._runner_args
+            **self._runner_args,
         )

--- a/src/ansible_navigator/runner/base.py
+++ b/src/ansible_navigator/runner/base.py
@@ -113,7 +113,7 @@ class Base:
                     "container_volume_mounts": container_volume_mounts,
                     "container_options": container_options,
                     "container_workdir": container_workdir,
-                }
+                },
             )
         self._runner_args.update(
             {
@@ -124,7 +124,7 @@ class Base:
                 "finished_callback": self.runner_finished_callback,
                 "artifacts_handler": self.runner_artifacts_handler,
                 "timeout": self._timeout,
-            }
+            },
         )
         if self._rotate_artifacts is not None:
             self._runner_args["rotate_artifacts"] = self._rotate_artifacts
@@ -138,7 +138,7 @@ class Base:
 
         if self._navigator_mode == "stdout":
             self._runner_args.update(
-                {"input_fd": sys.stdin, "output_fd": sys.stdout, "error_fd": sys.stderr}
+                {"input_fd": sys.stdin, "output_fd": sys.stdout, "error_fd": sys.stderr},
             )
 
     def __del__(self):
@@ -150,7 +150,8 @@ class Base:
         ):
 
             self._logger.debug(
-                "delete ansible-runner artifact directory at path %s", self._runner_artifact_dir
+                "delete ansible-runner artifact directory at path %s",
+                self._runner_artifact_dir,
             )
             shutil.rmtree(self._runner_artifact_dir, ignore_errors=True)
 

--- a/src/ansible_navigator/runner/command_base.py
+++ b/src/ansible_navigator/runner/command_base.py
@@ -67,7 +67,7 @@ class CommandBase(Base):
 
         if self._navigator_mode == "stdout":
             self._runner_args.update(
-                {"input_fd": sys.stdin, "output_fd": sys.stdout, "error_fd": sys.stderr}
+                {"input_fd": sys.stdin, "output_fd": sys.stdout, "error_fd": sys.stderr},
             )
 
         for key, value in self._runner_args.items():

--- a/src/ansible_navigator/tm_tokenize/compiler.py
+++ b/src/ansible_navigator/tm_tokenize/compiler.py
@@ -38,7 +38,10 @@ class Compiler:
 
     @functools.lru_cache(maxsize=None)
     def _include(
-        self, grammar: "Grammar", repository: FChainMap[str, "_Rule"], s: str
+        self,
+        grammar: "Grammar",
+        repository: FChainMap[str, "_Rule"],
+        s: str,
     ) -> Tuple[List[str], Tuple["_Rule", ...]]:
         if s == "$self":
             return self._patterns(grammar, grammar.patterns)
@@ -57,7 +60,9 @@ class Compiler:
 
     @functools.lru_cache(maxsize=None)
     def _patterns(
-        self, grammar: "Grammar", rules: Tuple["_Rule", ...]
+        self,
+        grammar: "Grammar",
+        rules: Tuple["_Rule", ...],
     ) -> Tuple[List[str], Tuple["_Rule", ...]]:
         ret_regs = []
         ret_rules: List["_Rule"] = []

--- a/src/ansible_navigator/tm_tokenize/reg.py
+++ b/src/ansible_navigator/tm_tokenize/reg.py
@@ -67,7 +67,11 @@ class _RegSet:
         return f"{type(self).__name__}({args})"
 
     def search(
-        self, line: str, pos: int, first_line: bool, boundary: bool
+        self,
+        line: str,
+        pos: int,
+        first_line: bool,
+        boundary: bool,
     ) -> Tuple[int, Optional[Match[str]]]:
         return self._set.search(line, pos, flags=_FLAGS[first_line, boundary])
 

--- a/src/ansible_navigator/tm_tokenize/rules.py
+++ b/src/ansible_navigator/tm_tokenize/rules.py
@@ -42,7 +42,10 @@ class CompiledRule(Protocol):
         ...
 
     def start(
-        self, compiler: "Compiler", match: Match[str], state: "State"
+        self,
+        compiler: "Compiler",
+        match: Match[str],
+        state: "State",
     ) -> Tuple["State", bool, Regions]:
         ...
 
@@ -143,7 +146,10 @@ class EndRule(NamedTuple):
     u_rules: Tuple["_Rule", ...]
 
     def start(
-        self, compiler: "Compiler", match: Match[str], state: "State"
+        self,
+        compiler: "Compiler",
+        match: Match[str],
+        state: "State",
     ) -> Tuple["State", bool, "Regions"]:
         scope = state.cur.scope + self.name
         next_scope = scope + self.content_name
@@ -156,7 +162,11 @@ class EndRule(NamedTuple):
         return state, True, regions
 
     def _end_ret(
-        self, compiler: "Compiler", state: "State", pos: int, m: Match[str]
+        self,
+        compiler: "Compiler",
+        state: "State",
+        pos: int,
+        m: Match[str],
     ) -> Tuple["State", int, bool, "Regions"]:
         ret = []
         if m.start() > pos:
@@ -202,7 +212,10 @@ class MatchRule(NamedTuple):
     captures: "Captures"
 
     def start(
-        self, compiler: "Compiler", match: Match[str], state: "State"
+        self,
+        compiler: "Compiler",
+        match: Match[str],
+        state: "State",
     ) -> Tuple["State", bool, "Regions"]:
         scope = state.cur.scope + self.name
         return state, False, _captures(compiler, scope, match, self.captures)
@@ -226,7 +239,10 @@ class PatternRule(NamedTuple):
     u_rules: Tuple["_Rule", ...]
 
     def start(
-        self, compiler: "Compiler", match: Match[str], state: "State"
+        self,
+        compiler: "Compiler",
+        match: Match[str],
+        state: "State",
     ) -> Tuple["State", bool, "Regions"]:
         raise AssertionError(f"unreachable {self}")
 
@@ -352,7 +368,10 @@ class WhileRule(NamedTuple):
     u_rules: Tuple["_Rule", ...]
 
     def start(
-        self, compiler: "Compiler", match: Match[str], state: "State"
+        self,
+        compiler: "Compiler",
+        match: Match[str],
+        state: "State",
     ) -> Tuple["State", bool, "Regions"]:
         scope = state.cur.scope + self.name
         next_scope = scope + self.content_name
@@ -395,7 +414,10 @@ class WhileRule(NamedTuple):
 
 
 def _captures(
-    compiler: "Compiler", scope: "Scope", match: Match[str], captures: "Captures"
+    compiler: "Compiler",
+    scope: "Scope",
+    match: Match[str],
+    captures: "Captures",
 ) -> "Regions":
     ret: List[Region] = []
     pos, pos_end = match.span()
@@ -439,7 +461,11 @@ def _captures(
 
 
 def _inner_capture_parse(
-    compiler: "Compiler", start: int, s: str, scope: "Scope", rule: "CompiledRule"
+    compiler: "Compiler",
+    start: int,
+    s: str,
+    scope: "Scope",
+    rule: "CompiledRule",
 ) -> "Regions":
     state = State.root(Entry(scope + rule.name, rule, (s, 0)))
     _, regions = tokenize(compiler, state, s, first_line=False)

--- a/src/ansible_navigator/tm_tokenize/tokenize.py
+++ b/src/ansible_navigator/tm_tokenize/tokenize.py
@@ -12,7 +12,10 @@ if TYPE_CHECKING:
 
 
 def tokenize(
-    compiler: "Compiler", state: State, line: str, first_line: bool
+    compiler: "Compiler",
+    state: State,
+    line: str,
+    first_line: bool,
 ) -> Tuple[State, Regions]:
 
     """tokenize a string into it's parts"""

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -56,7 +56,8 @@ class ColorSchema:
             for parts in range(0, len(name.split("."))):
                 prop = name.split()[-1].rsplit(".", parts)[0]
                 color = next(
-                    (tc for tc in self._schema["tokenColors"] if prop in to_list(tc["scope"])), None
+                    (tc for tc in self._schema["tokenColors"] if prop in to_list(tc["scope"])),
+                    None,
                 )
                 if color:
                     foreground = color.get("settings", {}).get("foreground", None)
@@ -109,10 +110,12 @@ class Colorize:
                         (
                             "An unexpected error occurred within the tokenization"
                             " subsystem.  Please log an issue with the following:"
-                        )
+                        ),
                     )
                     self._logger.critical(
-                        "  Err: '%s', Scope: '%s', Line follows....", str(exc), scope
+                        "  Err: '%s', Scope: '%s', Line follows....",
+                        str(exc),
+                        scope,
                     )
                     self._logger.critical("  '%s'", line)
                     self._logger.critical("  The current content will be rendered without color")
@@ -272,7 +275,7 @@ def ansi_to_curses(line: str) -> CursesLine:
             (?P<one>\d+)                        # required, one number
             (;(?P<two>\d+))?                    # optional 2nd number
             m
-        """
+        """,
     )
     parts = ansi_regex.split(line)
     colno = 0
@@ -303,7 +306,10 @@ def ansi_to_curses(line: str) -> CursesLine:
                         style = CURSES_STYLES.get(int(one), None) or 0
             else:
                 curses_line = CursesLinePart(
-                    column=colno, string=part, color=color, decoration=style
+                    column=colno,
+                    string=part,
+                    color=color,
+                    decoration=style,
                 )
                 printable.append(curses_line)
                 colno += len(part)

--- a/src/ansible_navigator/ui_framework/curses_window.py
+++ b/src/ansible_navigator/ui_framework/curses_window.py
@@ -105,7 +105,11 @@ class CursesWindow:
             self._logger.error("Errors setting up terminal, check TERM value")
 
     def _add_line(
-        self, window: Window, lineno: int, line: CursesLine, prefix: Union[str, None] = None
+        self,
+        window: Window,
+        lineno: int,
+        line: CursesLine,
+        prefix: Union[str, None] = None,
     ) -> None:
         """add a line to a window
 

--- a/src/ansible_navigator/ui_framework/form.py
+++ b/src/ansible_navigator/ui_framework/form.py
@@ -32,8 +32,11 @@ class Form:
             # pylint: disable=no-member
             self.fields.append(
                 FieldButton(
-                    name="submit", text="Submit", validator=FormValidators.all_true, color=10
-                )
+                    name="submit",
+                    text="Submit",
+                    validator=FormValidators.all_true,
+                    color=10,
+                ),
             )
             self.fields.append(FieldButton(name="cancel", text="Cancel", color=9))
             # pylint: enable=no-member
@@ -41,8 +44,11 @@ class Form:
             # pylint: disable=no-member
             self.fields.append(
                 FieldButton(
-                    name="submit", text=" Ok ", validator=FormValidators.no_validation, color=10
-                )
+                    name="submit",
+                    text=" Ok ",
+                    validator=FormValidators.no_validation,
+                    color=10,
+                ),
             )
             # pylint: enable=no-member
         elif self.type is FormType.WORKING:

--- a/src/ansible_navigator/ui_framework/form_presenter.py
+++ b/src/ansible_navigator/ui_framework/form_presenter.py
@@ -179,7 +179,10 @@ class FormPresenter(CursesWindow):
     def _generate_field_options(self, form_field) -> CursesLine:
         lines = []
         window = curses.newwin(
-            len(form_field.options), self._field_win_width, self._line_number, self._field_win_start
+            len(form_field.options),
+            self._field_win_width,
+            self._line_number,
+            self._field_win_start,
         )
         window.keypad(True)
         form_field.win = window
@@ -250,7 +253,8 @@ class FormPresenter(CursesWindow):
         shared_input_line_cache: List[str] = []
         for form_field in self._form.fields:
             form_field.window_handler = form_field.window_handler(
-                screen=self._screen, ui_config=self._ui_config
+                screen=self._screen,
+                ui_config=self._ui_config,
             )
             if isinstance(form_field.window_handler, FormHandlerText):
                 form_field.window_handler.input_line_cache = shared_input_line_cache

--- a/src/ansible_navigator/ui_framework/menu_builder.py
+++ b/src/ansible_navigator/ui_framework/menu_builder.py
@@ -121,7 +121,10 @@ class MenuBuilder:
                 decoration=curses.A_UNDERLINE,
             )
         return CursesLinePart(
-            column=col_starts[colno], string=adj_entry, color=0, decoration=curses.A_UNDERLINE
+            column=col_starts[colno],
+            string=adj_entry,
+            color=0,
+            decoration=curses.A_UNDERLINE,
         )
 
     def _menu_lines(self, dicts: List[Dict], menu_layout: Tuple[List, ...], indices) -> CursesLines:
@@ -165,7 +168,11 @@ class MenuBuilder:
         )
 
     def _menu_line_part(
-        self, colno: int, coltext: Any, dyct: dict, menu_layout: Tuple[List, ...]
+        self,
+        colno: int,
+        coltext: Any,
+        dyct: dict,
+        menu_layout: Tuple[List, ...],
     ) -> CursesLinePart:
         """Generate one menu line part
 

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -115,7 +115,8 @@ class UserInterface(CursesWindow):
         super().__init__(ui_config=ui_config)
         self._color_menu_item: Callable[[int, str, Dict[str, Any]], Tuple[int, int]]
         self._colorizer = Colorize(
-            grammar_dir=self._ui_config.grammar_dir, theme_path=self._ui_config.theme_path
+            grammar_dir=self._ui_config.grammar_dir,
+            theme_path=self._ui_config.theme_path,
         )
         self._content_heading: Callable[[Any, int], Union[CursesLines, None]]
         self._default_colors = None
@@ -258,7 +259,7 @@ class UserInterface(CursesWindow):
                     string=left,
                     color=0,
                     decoration=curses.A_REVERSE,
-                )
+                ),
             )
             footer.append(
                 CursesLinePart(
@@ -266,7 +267,7 @@ class UserInterface(CursesWindow):
                     string=right,
                     color=0,
                     decoration=0,
-                )
+                ),
             )
         if self._status:
             # place the status to the far right -1 for the scrollbar
@@ -282,12 +283,17 @@ class UserInterface(CursesWindow):
                     string=status,
                     color=self._status_color,
                     decoration=curses.A_REVERSE,
-                )
+                ),
             )
         return tuple(footer)
 
     def _scroll_bar(
-        self, viewport_h: int, len_heading: int, menu_size: int, body_start: int, body_stop: int
+        self,
+        viewport_h: int,
+        len_heading: int,
+        menu_size: int,
+        body_start: int,
+        body_stop: int,
     ) -> None:
         """Add a scroll bar if the lines > viewport
 
@@ -309,7 +315,10 @@ class UserInterface(CursesWindow):
         for idx in range(int(start_scroll_bar), int(start_scroll_bar + len_scroll_bar)):
             lineno = idx + len_heading
             line_part = CursesLinePart(
-                column=self._screen_w - 1, string="\u2592", color=color, decoration=0
+                column=self._screen_w - 1,
+                string="\u2592",
+                color=color,
+                decoration=0,
             )
             self._add_line(
                 window=self._screen,
@@ -398,7 +407,10 @@ class UserInterface(CursesWindow):
                 line_index_str = str(line_index).rjust(index_width)
                 prefix = f"{line_index_str}\u2502"
                 self._add_line(
-                    window=self._screen, lineno=idx + len(heading), line=line, prefix=prefix
+                    window=self._screen,
+                    lineno=idx + len(heading),
+                    line=line,
+                    prefix=prefix,
                 )
 
             # Add the scroll bar
@@ -454,7 +466,9 @@ class UserInterface(CursesWindow):
                 return return_value
 
     def _template_match_action(
-        self, entry: str, current: Any
+        self,
+        entry: str,
+        current: Any,
     ) -> Union[Tuple[str, Action], Tuple[None, None]]:
         """attempt to template & match the user input against the regexen
         provided by each action
@@ -528,7 +542,7 @@ class UserInterface(CursesWindow):
         """
         if curses.COLORS > 16 and self._term_osc4_supprt:
             unique_colors = list(
-                set(chars["color"] for line in lines for chars in line if chars["color"])
+                set(chars["color"] for line in lines for chars in line if chars["color"]),
             )
             # start custom colors at 16
             for color in unique_colors:
@@ -542,7 +556,10 @@ class UserInterface(CursesWindow):
 
                     self._rgb_to_curses_color_idx[color] = curses_colors_idx
                     curses.init_color(
-                        curses_colors_idx, int(red * scale), int(green * scale), int(blue * scale)
+                        curses_colors_idx,
+                        int(red * scale),
+                        int(green * scale),
+                        int(blue * scale),
                     )
                     self._logger.debug(
                         "Added color: %s:%s",
@@ -739,7 +756,10 @@ class UserInterface(CursesWindow):
         return regex.search(str(value))
 
     def _get_heading_menu_items(
-        self, current: List, columns: List, indices
+        self,
+        current: List,
+        columns: List,
+        indices,
     ) -> Tuple[CursesLines, CursesLines]:
         """build the menu
 

--- a/src/ansible_navigator/ui_framework/validators.py
+++ b/src/ansible_navigator/ui_framework/validators.py
@@ -219,7 +219,8 @@ class FormValidators:
 
     @staticmethod
     def no_validation(
-        response: Union[List, None] = None, hint: bool = False
+        response: Union[List, None] = None,
+        hint: bool = False,
     ) -> Union[Validation, str]:
         """no validation"""
         msg = ""

--- a/src/ansible_navigator/utils.py
+++ b/src/ansible_navigator/utils.py
@@ -178,7 +178,8 @@ def escape_moustaches(obj):
 
 
 def environment_variable_is_file_path(
-    env_var: str, kind: str
+    env_var: str,
+    kind: str,
 ) -> Tuple[List[LogMessage], List[ExitMessage], Optional[str]]:
     """check if a given environment var is a viable file path, if so return that path"""
     messages: List[LogMessage] = []
@@ -281,7 +282,7 @@ def get_share_directory(app_name) -> Tuple[List[LogMessage], List[ExitMessage], 
     # We want the share directory to resolve adjacent to the directory the code lives in
     # as that's the layout in the source.
     share_directory = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "..", "..", "share", app_name)
+        os.path.join(os.path.dirname(__file__), "..", "..", "share", app_name),
     )
     description = "development path"
     if os.path.exists(share_directory):

--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -5,7 +5,7 @@ import os
 
 FIXTURES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "fixtures"))
 FIXTURES_COLLECTION_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "fixtures", "common", "collections")
+    os.path.join(os.path.dirname(__file__), "fixtures", "common", "collections"),
 )
 
 # every attempt should be made for these images to share as many layers as possible

--- a/tests/integration/_action_run_test.py
+++ b/tests/integration/_action_run_test.py
@@ -62,7 +62,9 @@ class ActionRunTest:
             "ansible_runner_timeout": self._timeout,
         }
         self._app_action = __import__(
-            f"ansible_navigator.actions.{self._action_name}", globals(), fromlist=["Action"]
+            f"ansible_navigator.actions.{self._action_name}",
+            globals(),
+            fromlist=["Action"],
         )
 
     def callable_pass_one_arg(self, value=0):

--- a/tests/integration/_cli2runner.py
+++ b/tests/integration/_cli2runner.py
@@ -34,7 +34,14 @@ class Cli2Runner:
 
     @mock.patch("ansible_navigator.runner.ansible_config.get_ansible_config")
     def test_config_interactive(
-        self, mocked_runner, tmpdir, comment, cli_entry, config_fixture, expected, patch_curses
+        self,
+        mocked_runner,
+        tmpdir,
+        comment,
+        cli_entry,
+        config_fixture,
+        expected,
+        patch_curses,
     ):
         """test use of set_environment_variable"""
         cli_entry = self.cli_entry.format(self.INTERACTIVE["config"], cli_entry, "interactive")
@@ -42,7 +49,13 @@ class Cli2Runner:
 
     @mock.patch("ansible_navigator.runner.command.run_command")
     def test_config_stdout(
-        self, mocked_runner, tmpdir, comment, cli_entry, config_fixture, expected
+        self,
+        mocked_runner,
+        tmpdir,
+        comment,
+        cli_entry,
+        config_fixture,
+        expected,
     ):
         # pylint: disable=unused-argument
         """test use of set_environment_variable"""
@@ -51,7 +64,14 @@ class Cli2Runner:
 
     @mock.patch("ansible_navigator.runner.ansible_inventory.get_inventory")
     def test_inventory_interactive(
-        self, mocked_runner, tmpdir, comment, cli_entry, config_fixture, expected, patch_curses
+        self,
+        mocked_runner,
+        tmpdir,
+        comment,
+        cli_entry,
+        config_fixture,
+        expected,
+        patch_curses,
     ):
         """test use of set_environment_variable"""
         cli_entry = self.cli_entry.format(self.INTERACTIVE["inventory"], cli_entry, "interactive")
@@ -59,7 +79,13 @@ class Cli2Runner:
 
     @mock.patch("ansible_navigator.runner.command.run_command")
     def test_inventory_stdout(
-        self, mocked_runner, tmpdir, comment, cli_entry, config_fixture, expected
+        self,
+        mocked_runner,
+        tmpdir,
+        comment,
+        cli_entry,
+        config_fixture,
+        expected,
     ):
         # pylint: disable=unused-argument
         """test use of set_environment_variable"""
@@ -68,7 +94,14 @@ class Cli2Runner:
 
     @mock.patch("ansible_navigator.runner.command_async.run_command_async")
     def test_run_interactive(
-        self, mocked_runner, tmpdir, comment, cli_entry, config_fixture, expected, patch_curses
+        self,
+        mocked_runner,
+        tmpdir,
+        comment,
+        cli_entry,
+        config_fixture,
+        expected,
+        patch_curses,
     ):
         # pylint: disable=unused-argument
         """test use of set_environment_variable"""

--- a/tests/integration/_common.py
+++ b/tests/integration/_common.py
@@ -21,7 +21,12 @@ def get_executable_path(name):
 
 
 def update_fixtures(
-    request, index, received_output, comment, testname=None, additional_information=None
+    request,
+    index,
+    received_output,
+    comment,
+    testname=None,
+    additional_information=None,
 ):
     # pylint: disable=too-many-arguments
     """Used by action plugins to generate the fixtures"""
@@ -61,7 +66,13 @@ def generate_test_log_dir(unique_test_id):
     user = os.environ.get("USER")
     if user == "zuul":
         directory = os.path.join(
-            "/", "home", "zuul", "zuul-output", "logs", "anible-navigator", unique_test_id
+            "/",
+            "home",
+            "zuul",
+            "zuul-output",
+            "logs",
+            "anible-navigator",
+            unique_test_id,
         )
     else:
         directory = os.path.join("./", ".test_logs", unique_test_id)
@@ -76,7 +87,8 @@ class Error(EnvironmentError):
 def sanitize_output(output):
     """Sanitize test output that may be environment specific or unique per run."""
     re_uuid = re.compile(
-        "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE
+        "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        re.IGNORECASE,
     )
     re_home = re.compile("(/Users|/home)/(?!runner)[a-z,0-9]*/")
     for idx, line in enumerate(output):

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -53,7 +53,9 @@ class TmuxSession:
         # pylint: disable=too-many-statements
         self._server = libtmux.Server()
         self._session = self._server.new_session(
-            session_name=self._session_name, start_directory=self._cwd, kill_session=True
+            session_name=self._session_name,
+            start_directory=self._cwd,
+            kill_session=True,
         )
         self._window = self._session.new_window(self._session_name)
         self._pane = self._window.panes[0]
@@ -71,7 +73,7 @@ class TmuxSession:
         venv_path = os.environ.get("VIRTUAL_ENV")
         if venv_path is None:
             raise AssertionError(
-                "VIRTUAL_ENV environment variable was not set but tox should have set it."
+                "VIRTUAL_ENV environment variable was not set but tox should have set it.",
             )
         venv = os.path.join(shlex.quote(venv_path), "bin", "activate")
 
@@ -95,11 +97,11 @@ class TmuxSession:
         tmux_common.append(f"export ANSIBLE_NAVIGATOR_LOG_FILE='{log_file}'")
         playbook_artifact = os.path.join(self._test_log_dir, "playbook-artifact.log")
         tmux_common.append(
-            f"export ANSIBLE_NAVIGATOR_PLAYBOOK_ARTIFACT_SAVE_AS='{playbook_artifact}'"
+            f"export ANSIBLE_NAVIGATOR_PLAYBOOK_ARTIFACT_SAVE_AS='{playbook_artifact}'",
         )
         collection_doc_cache = os.path.join(self._test_log_dir, "collection_doc_cache.db")
         tmux_common.append(
-            f"export ANSIBLE_NAVIGATOR_COLLECTION_DOC_CACHE_PATH='{collection_doc_cache}'"
+            f"export ANSIBLE_NAVIGATOR_COLLECTION_DOC_CACHE_PATH='{collection_doc_cache}'",
         )
         tmux_common.append(f"export ANSIBLE_NAVIGATOR_PULL_POLICY='{self._pull_policy}'")
         tmux_common.append("env")
@@ -118,7 +120,8 @@ class TmuxSession:
             # because the environment variables were dumped
             if showing:
                 prompt_showing = self.cli_prompt in showing[-1] and len(showing) > min(
-                    len(tmux_common), int(self._pane_height) - 1
+                    len(tmux_common),
+                    int(self._pane_height) - 1,
                 )
             if prompt_showing:
                 break
@@ -274,7 +277,8 @@ class TmuxSession:
                 tstamp = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
                 # taint the screen output w/ timestamp so it's never a valid fixture
                 alerts = [
-                    f"******** ERROR: TMUX '{err_message}' TIMEOUT @ {elapsed}s @ {tstamp} ********"
+                    f"******** ERROR: TMUX '{err_message}'"
+                    " TIMEOUT @ {elapsed}s @ {tstamp} ********",
                 ]
                 alerts.append(f"******** Captured to: {timeout_capture_path}")
                 showing = alerts + showing

--- a/tests/integration/actions/collections/base.py
+++ b/tests/integration/actions/collections/base.py
@@ -31,7 +31,9 @@ class BaseClass:
         tmp_coll_dir = os.path.join(os_indendent_tmp, request.node.name, "")
         os.makedirs(tmp_coll_dir, exist_ok=True)
         copytree(
-            FIXTURES_COLLECTION_DIR, os.path.join(tmp_coll_dir, "collections"), dirs_exist_ok=True
+            FIXTURES_COLLECTION_DIR,
+            os.path.join(tmp_coll_dir, "collections"),
+            dirs_exist_ok=True,
         )
         params = {
             "setup_commands": [
@@ -70,11 +72,13 @@ class BaseClass:
         else:
             raise ValueError(
                 "Value of 'TEST_FOR_MODE' is not set."
-                " Valid value is either 'interactive' or 'stdout'"
+                " Valid value is either 'interactive' or 'stdout'",
             )
 
         received_output = tmux_collections_session.interaction(
-            user_input, search_within_response, ignore_within_response=ignore_within_response
+            user_input,
+            search_within_response,
+            ignore_within_response=ignore_within_response,
         )
 
         received_output = [
@@ -92,5 +96,5 @@ class BaseClass:
         with open(file=f"{dir_path}/{file_name}", encoding="utf-8") as infile:
             expected_output = json.load(infile)["output"]
         assert expected_output == received_output, "\n" + "\n".join(
-            difflib.unified_diff(expected_output, received_output, "expected", "received")
+            difflib.unified_diff(expected_output, received_output, "expected", "received"),
         )

--- a/tests/integration/actions/config/base.py
+++ b/tests/integration/actions/config/base.py
@@ -111,5 +111,5 @@ class BaseClass:
                 expected_output = json.load(infile)["output"]
 
             assert expected_output == received_output, "\n" + "\n".join(
-                difflib.unified_diff(expected_output, received_output, "expected", "received")
+                difflib.unified_diff(expected_output, received_output, "expected", "received"),
             )

--- a/tests/integration/actions/doc/base.py
+++ b/tests/integration/actions/doc/base.py
@@ -39,7 +39,14 @@ class BaseClass:
             yield tmux_session
 
     def test(
-        self, request, tmux_doc_session, index, user_input, comment, testname, expected_in_output
+        self,
+        request,
+        tmux_doc_session,
+        index,
+        user_input,
+        comment,
+        testname,
+        expected_in_output,
     ):
         # pylint: disable=too-many-arguments
         # pylint: disable=too-many-locals
@@ -54,7 +61,7 @@ class BaseClass:
         else:
             raise ValueError(
                 "Value of 'TEST_FOR_MODE' is not set."
-                " Valid value is either 'interactive' or 'stdout'"
+                " Valid value is either 'interactive' or 'stdout'",
             )
 
         received_output = tmux_doc_session.interaction(user_input, search_within_response)
@@ -88,6 +95,9 @@ class BaseClass:
                 expected_output = json.load(infile)["output"]
             assert expected_output == updated_received_output, "\n" + "\n".join(
                 difflib.unified_diff(
-                    expected_output, updated_received_output, "expected", "received"
-                )
+                    expected_output,
+                    updated_received_output,
+                    "expected",
+                    "received",
+                ),
             )

--- a/tests/integration/actions/doc/test_direct_interactive_ee.py
+++ b/tests/integration/actions/doc/test_direct_interactive_ee.py
@@ -41,7 +41,8 @@ testdata_module_doc_not_exist = [
 
 
 @pytest.mark.parametrize(
-    "index, user_input, comment, testname, expected_in_output", testdata_module_doc
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_module_doc,
 )
 class TestModuleDoc(BaseClass):
     """Run the tests for doc from CLI, interactive, with an EE."""
@@ -51,7 +52,8 @@ class TestModuleDoc(BaseClass):
 
 
 @pytest.mark.parametrize(
-    "index, user_input, comment, testname, expected_in_output", testdata_lookup_doc
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_lookup_doc,
 )
 class TestLookUpDoc(BaseClass):
     """run the tests"""
@@ -61,7 +63,8 @@ class TestLookUpDoc(BaseClass):
 
 
 @pytest.mark.parametrize(
-    "index, user_input, comment, testname, expected_in_output", testdata_module_doc_not_exist
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_module_doc_not_exist,
 )
 class TestModuleDocNotExist(BaseClass):
     """run the tests"""

--- a/tests/integration/actions/doc/test_direct_interactive_noee.py
+++ b/tests/integration/actions/doc/test_direct_interactive_noee.py
@@ -39,7 +39,8 @@ testdata_module_doc_not_exist = [
 
 
 @pytest.mark.parametrize(
-    "index, user_input, comment, testname, expected_in_output", testdata_module_doc
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_module_doc,
 )
 class TestModuleDoc(BaseClass):
     """Run the tests for doc from CLI, interactive, without an EE."""
@@ -49,7 +50,8 @@ class TestModuleDoc(BaseClass):
 
 
 @pytest.mark.parametrize(
-    "index, user_input, comment, testname, expected_in_output", testdata_lookup_doc
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_lookup_doc,
 )
 class TestLookUpDoc(BaseClass):
     """run the tests"""
@@ -59,7 +61,8 @@ class TestLookUpDoc(BaseClass):
 
 
 @pytest.mark.parametrize(
-    "index, user_input, comment, testname, expected_in_output", testdata_module_doc_not_exist
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_module_doc_not_exist,
 )
 class TestModuleDocNotExist(BaseClass):
     """run the tests"""

--- a/tests/integration/actions/doc/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/doc/test_welcome_interactive_ee.py
@@ -40,7 +40,8 @@ testdata_module_doc_not_exist = [
 
 
 @pytest.mark.parametrize(
-    "index, user_input, comment, testname, expected_in_output", testdata_module_doc
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_module_doc,
 )
 class TestModuleDoc(BaseClass):
     """Run the tests for doc from welcome, interactive, with an EE, module doc."""
@@ -50,7 +51,8 @@ class TestModuleDoc(BaseClass):
 
 
 @pytest.mark.parametrize(
-    "index, user_input, comment, testname, expected_in_output", testdata_lookup_doc
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_lookup_doc,
 )
 class TestLookUpDoc(BaseClass):
     """Run the tests for doc from welcome, interactive, with an EE, lookup doc."""
@@ -60,7 +62,8 @@ class TestLookUpDoc(BaseClass):
 
 
 @pytest.mark.parametrize(
-    "index, user_input, comment, testname, expected_in_output", testdata_module_doc_not_exist
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_module_doc_not_exist,
 )
 class TestModuleDocNotExist(BaseClass):
     """Run the tests for doc from welcome, interactive, with an EE, doc not found."""

--- a/tests/integration/actions/doc/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/doc/test_welcome_interactive_noee.py
@@ -40,7 +40,8 @@ testdata_module_doc_not_exist = [
 
 
 @pytest.mark.parametrize(
-    "index, user_input, comment, testname, expected_in_output", testdata_module_doc
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_module_doc,
 )
 class TestModuleDoc(BaseClass):
     """Run the tests for doc from welcome, interactive, without an EE, module doc."""
@@ -50,7 +51,8 @@ class TestModuleDoc(BaseClass):
 
 
 @pytest.mark.parametrize(
-    "index, user_input, comment, testname, expected_in_output", testdata_lookup_doc
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_lookup_doc,
 )
 class TestLookUpDoc(BaseClass):
     """Run the tests for doc from welcome, interactive, without an EE, lookup doc."""
@@ -60,7 +62,8 @@ class TestLookUpDoc(BaseClass):
 
 
 @pytest.mark.parametrize(
-    "index, user_input, comment, testname, expected_in_output", testdata_module_doc_not_exist
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_module_doc_not_exist,
 )
 class TestModuleDocNotExist(BaseClass):
     """Run the tests for doc from welcome, interactive, without an EE, doc not found."""

--- a/tests/integration/actions/images/base.py
+++ b/tests/integration/actions/images/base.py
@@ -21,7 +21,9 @@ step_back = Step(user_input=":back", comment="goto info menu", look_fors=["Every
 
 base_steps = (
     Step(
-        user_input=f":f {IMAGE_SHORT}", comment=f"filter for {IMAGE_SHORT}", look_fors=[IMAGE_SHORT]
+        user_input=f":f {IMAGE_SHORT}",
+        comment=f"filter for {IMAGE_SHORT}",
+        look_fors=[IMAGE_SHORT],
     ),
     Step(user_input=":0", comment="goto info menu", look_fors=["Everything"]),
     Step(user_input=":0", comment="goto Image information", look_fors=["architecture:"]),
@@ -100,5 +102,5 @@ class BaseClass:
                 expected_output = json.load(infile)["output"]
 
             assert expected_output == received_output, "\n" + "\n".join(
-                difflib.unified_diff(expected_output, received_output, "expected", "received")
+                difflib.unified_diff(expected_output, received_output, "expected", "received"),
             )

--- a/tests/integration/actions/images/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/images/test_welcome_interactive_ee.py
@@ -16,7 +16,9 @@ CLI = Command(execution_environment=True).join()
 initial_steps = (
     Step(user_input=CLI, comment="welcome screen"),
     Step(
-        user_input=":images", comment="ansible-navigator images top window", look_fors=[IMAGE_SHORT]
+        user_input=":images",
+        comment="ansible-navigator images top window",
+        look_fors=[IMAGE_SHORT],
     ),
 )
 

--- a/tests/integration/actions/images/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/images/test_welcome_interactive_noee.py
@@ -17,7 +17,9 @@ CLI = Command(execution_environment=False).join()
 initial_steps = (
     Step(user_input=CLI, comment="welcome screen"),
     Step(
-        user_input=":images", comment="ansible-navigator images top window", look_fors=[IMAGE_SHORT]
+        user_input=":images",
+        comment="ansible-navigator images top window",
+        look_fors=[IMAGE_SHORT],
     ),
 )
 

--- a/tests/integration/actions/inventory/base.py
+++ b/tests/integration/actions/inventory/base.py
@@ -122,5 +122,5 @@ class BaseClass:
                 expected_output = json.load(infile)["output"]
 
             assert expected_output == received_output, "\n" + "\n".join(
-                difflib.unified_diff(expected_output, received_output, "expected", "received")
+                difflib.unified_diff(expected_output, received_output, "expected", "received"),
             )

--- a/tests/integration/actions/inventory/test_stdout_tmux.py
+++ b/tests/integration/actions/inventory/test_stdout_tmux.py
@@ -67,7 +67,7 @@ stdout_tests = (
             execution_environment=True,
         ).join(),
         look_fors=[
-            "--hi or --help-inventory is valid only when 'mode' argument is set to 'stdout'"
+            "--hi or --help-inventory is valid only when 'mode' argument is set to 'stdout'",
         ],
     ),
     ShellCommand(
@@ -78,7 +78,7 @@ stdout_tests = (
             execution_environment=False,
         ).join(),
         look_fors=[
-            "--hi or --help-inventory is valid only when 'mode' argument is set to 'stdout'"
+            "--hi or --help-inventory is valid only when 'mode' argument is set to 'stdout'",
         ],
     ),
 )

--- a/tests/integration/actions/replay/base.py
+++ b/tests/integration/actions/replay/base.py
@@ -58,5 +58,5 @@ class BaseClass:
         with open(file=f"{dir_path}/{file_name}", encoding="utf-8") as infile:
             expected_output = json.load(infile)["output"]
         assert expected_output == received_output, "\n" + "\n".join(
-            difflib.unified_diff(expected_output, received_output, "expected", "received")
+            difflib.unified_diff(expected_output, received_output, "expected", "received"),
         )

--- a/tests/integration/actions/run/base.py
+++ b/tests/integration/actions/run/base.py
@@ -119,5 +119,5 @@ class BaseClass:
                 expected_output = json.load(infile)["output"]
 
             assert expected_output == received_output, "\n" + "\n".join(
-                difflib.unified_diff(expected_output, received_output, "expected", "received")
+                difflib.unified_diff(expected_output, received_output, "expected", "received"),
             )

--- a/tests/integration/actions/stdout/base.py
+++ b/tests/integration/actions/stdout/base.py
@@ -58,5 +58,5 @@ class BaseClass:
         with open(file=f"{dir_path}/{file_name}", encoding="utf-8") as infile:
             expected_output = json.load(infile)["output"]
         assert expected_output == received_output, "\n" + "\n".join(
-            difflib.unified_diff(expected_output, received_output, "expected", "received")
+            difflib.unified_diff(expected_output, received_output, "expected", "received"),
         )

--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -28,7 +28,9 @@ base_steps = (
     Step(user_input=":0", comment="task-1 details"),
     Step(user_input=":doc", comment="doc for task", look_fors=["module: debug"]),
     Step(
-        user_input=":{{ examples }}", comment="dig examples", look_fors=["ansible.builtin.debug:"]
+        user_input=":{{ examples }}",
+        comment="dig examples",
+        look_fors=["ansible.builtin.debug:"],
     ),
     Step(user_input=":back", comment="show doc", look_fors=["module: debug"]),
     Step(user_input=":back", comment="show task"),
@@ -125,5 +127,5 @@ class BaseClass:
                 expected_output = json.load(infile)["output"]
 
             assert expected_output == received_output, "\n" + "\n".join(
-                difflib.unified_diff(expected_output, received_output, "expected", "received")
+                difflib.unified_diff(expected_output, received_output, "expected", "received"),
             )

--- a/tests/integration/test_execution_environment.py
+++ b/tests/integration/test_execution_environment.py
@@ -66,7 +66,8 @@ class Test(Cli2Runner):
         with mock.patch("sys.argv", params):
             with mock.patch.dict(os.environ, {"ANSIBLE_NAVIGATOR_CONFIG": cfg_path}):
                 with mock.patch.dict(
-                    os.environ, {"ANSIBLE_NAVIGATOR_COLLECTION_DOC_CACHE_PATH": coll_cache_path}
+                    os.environ,
+                    {"ANSIBLE_NAVIGATOR_COLLECTION_DOC_CACHE_PATH": coll_cache_path},
                 ):
                     with pytest.raises(Exception, match="called"):
                         cli.main()

--- a/tests/integration/test_execution_environment_image.py
+++ b/tests/integration/test_execution_environment_image.py
@@ -78,7 +78,8 @@ class Test(Cli2Runner):
         with mock.patch("sys.argv", params):
             with mock.patch.dict(os.environ, {"ANSIBLE_NAVIGATOR_CONFIG": cfg_path}):
                 with mock.patch.dict(
-                    os.environ, {"ANSIBLE_NAVIGATOR_COLLECTION_DOC_CACHE_PATH": coll_cache_path}
+                    os.environ,
+                    {"ANSIBLE_NAVIGATOR_COLLECTION_DOC_CACHE_PATH": coll_cache_path},
                 ):
                     with pytest.raises(Exception, match="called"):
                         cli.main()

--- a/tests/integration/test_pass_environment_variable.py
+++ b/tests/integration/test_pass_environment_variable.py
@@ -83,7 +83,8 @@ class Test(Cli2Runner):
         with mock.patch("sys.argv", params):
             with mock.patch.dict(os.environ, {"ANSIBLE_NAVIGATOR_CONFIG": cfg_path}):
                 with mock.patch.dict(
-                    os.environ, {"ANSIBLE_NAVIGATOR_COLLECTION_DOC_CACHE_PATH": coll_cache_path}
+                    os.environ,
+                    {"ANSIBLE_NAVIGATOR_COLLECTION_DOC_CACHE_PATH": coll_cache_path},
                 ):
                     with mock.patch.dict(os.environ, expected):
                         with pytest.raises(Exception, match="called"):

--- a/tests/integration/test_set_environment_variable.py
+++ b/tests/integration/test_set_environment_variable.py
@@ -83,7 +83,8 @@ class Test(Cli2Runner):
         with mock.patch("sys.argv", params):
             with mock.patch.dict(os.environ, {"ANSIBLE_NAVIGATOR_CONFIG": cfg_path}):
                 with mock.patch.dict(
-                    os.environ, {"ANSIBLE_NAVIGATOR_COLLECTION_DOC_CACHE_PATH": coll_cache_path}
+                    os.environ,
+                    {"ANSIBLE_NAVIGATOR_COLLECTION_DOC_CACHE_PATH": coll_cache_path},
                 ):
                     with pytest.raises(Exception, match="called"):
                         cli.main()

--- a/tests/unit/actions/test_run.py
+++ b/tests/unit/actions/test_run.py
@@ -40,24 +40,43 @@ def id_from_data(value):
 artifact_test_data = [
     ArtifactTstData("Filename absolute", "/tmp/artifact.json", "site.yml", "/tmp/artifact.json"),
     ArtifactTstData(
-        "Filename with .", "./artifact.json", "site.yml", f"{os.path.abspath('.')}/artifact.json"
+        "Filename with .",
+        "./artifact.json",
+        "site.yml",
+        f"{os.path.abspath('.')}/artifact.json",
     ),
     ArtifactTstData(
-        "Filename with ..", "../artifact.json", "site.yml", f"{os.path.abspath('..')}/artifact.json"
+        "Filename with ..",
+        "../artifact.json",
+        "site.yml",
+        f"{os.path.abspath('..')}/artifact.json",
     ),
     ArtifactTstData(
-        "Filename with ~", "~/artifact.json", "/tmp/site.yaml", "/home/test_user/artifact.json"
+        "Filename with ~",
+        "~/artifact.json",
+        "/tmp/site.yaml",
+        "/home/test_user/artifact.json",
     ),
     ArtifactTstData("Playbook absolute", None, "/tmp/site.yaml", "/tmp/site-artifact"),
     ArtifactTstData(
-        "Playbook with .", None, "./site.yaml", f"{os.path.abspath('.')}/site-artifact"
+        "Playbook with .",
+        None,
+        "./site.yaml",
+        f"{os.path.abspath('.')}/site-artifact",
     ),
     ArtifactTstData(
-        "Playbook with ..", None, "../site.yaml", f"{os.path.abspath('..')}/site-artifact"
+        "Playbook with ..",
+        None,
+        "../site.yaml",
+        f"{os.path.abspath('..')}/site-artifact",
     ),
     ArtifactTstData("Playbook with ~", None, "~/site.yaml", "/home/test_user/site-artifact"),
     ArtifactTstData(
-        "help_plabook enabled", None, "~/site.yaml", "/home/test_user/site-artifact", True
+        "help_plabook enabled",
+        None,
+        "~/site.yaml",
+        "/home/test_user/site-artifact",
+        True,
     ),
 ]
 
@@ -80,7 +99,7 @@ def test_artifact_path(_mocked_get_status, mocked_open, _mocked_makedirs, caplog
         args.entry("playbook_artifact_save_as").value.current = data.filename
     else:
         args.entry(
-            "playbook_artifact_save_as"
+            "playbook_artifact_save_as",
         ).value.current = playbook_artifact_save_as.value.default
     args.entry("playbook_artifact_enable").value.current = True
 

--- a/tests/unit/configuration_subsystem/data.py
+++ b/tests/unit/configuration_subsystem/data.py
@@ -75,7 +75,7 @@ BASE_EXPECTED = d2t(
         "pass_environment_variable": ["FOO", "BAR"],
         "pull_policy": "never",
         "set_environment_variable": {"E1": "V1", "E2": "V2"},
-    }
+    },
 )
 
 
@@ -149,7 +149,7 @@ CLI_DATA_REPLAY = [
     (
         "replay /tmp/part.json -m interactive",
         {"app": "replay", "mode": "interactive", "playbook_artifact_replay": "/tmp/part.json"},
-    )
+    ),
 ]
 CLI_DATA_RUN = [
     ("run /tmp/site.yml", {"app": "run", "playbook": "/tmp/site.yml"}),

--- a/tests/unit/configuration_subsystem/test_entries_sanity.py
+++ b/tests/unit/configuration_subsystem/test_entries_sanity.py
@@ -24,7 +24,7 @@ def test_entries_no_duplicate_shorts():
             entry.cli_parameters.short
             for entry in NavigatorConfiguration.entries
             if entry.cli_parameters is not None
-        ]
+        ],
     )
     assert not any(k for (k, v) in values.items() if v > 1)
 

--- a/tests/unit/configuration_subsystem/test_precedence.py
+++ b/tests/unit/configuration_subsystem/test_precedence.py
@@ -42,7 +42,12 @@ from .utils import id_for_settings
 @pytest.mark.parametrize("base", (None, BASE_SHORT_CLI, BASE_LONG_CLI), ids=id_for_base)
 @pytest.mark.parametrize("cli_entry, expected", CLI_DATA, ids=id_for_cli)
 def test_all_entries_reflect_cli_given_envvars(
-    _mf1, _mf2, generate_config, base, cli_entry, expected
+    _mf1,
+    _mf2,
+    generate_config,
+    base,
+    cli_entry,
+    expected,
 ):
     """Ensure all entries are set by the CLI, even with environment variables set."""
     if base is None:
@@ -77,7 +82,14 @@ def test_all_entries_reflect_cli_given_envvars(
 @pytest.mark.parametrize("base", (None, BASE_SHORT_CLI, BASE_LONG_CLI), ids=id_for_base)
 @pytest.mark.parametrize("cli_entry, expected", CLI_DATA, ids=id_for_cli)
 def test_all_entries_reflect_cli_given_settings(
-    _mf1, _mf2, generate_config, settings, settings_file_type, base, cli_entry, expected
+    _mf1,
+    _mf2,
+    generate_config,
+    settings,
+    settings_file_type,
+    base,
+    cli_entry,
+    expected,
 ):
     """Ensure all entries are set by the CLI
     based on the settings file, the non CLI parameters will be
@@ -113,7 +125,14 @@ def test_all_entries_reflect_cli_given_settings(
 @pytest.mark.parametrize("base", (None, BASE_SHORT_CLI, BASE_LONG_CLI), ids=id_for_base)
 @pytest.mark.parametrize("cli_entry, expected", CLI_DATA, ids=id_for_cli)
 def test_all_entries_reflect_cli_given_settings_and_envars(
-    _mf1, _mf2, generate_config, settings, source_other, base, cli_entry, expected
+    _mf1,
+    _mf2,
+    generate_config,
+    settings,
+    source_other,
+    base,
+    cli_entry,
+    expected,
 ):
     # pylint: disable=unused-argument
     """Ensure all entries are set by the CLI
@@ -170,7 +189,14 @@ def test_all_entries_reflect_default(_mocked_func, generate_config, entry):
 @pytest.mark.parametrize("settings, settings_file_type", SETTINGS, ids=id_for_settings)
 @pytest.mark.parametrize("entry, value, expected", ENVVAR_DATA)
 def test_all_entries_reflect_envvar_given_settings(
-    _mf1, _mf2, generate_config, settings, settings_file_type, entry, value, expected
+    _mf1,
+    _mf2,
+    generate_config,
+    settings,
+    settings_file_type,
+    entry,
+    value,
+    expected,
 ):
     # pylint: disable=unused-argument
     """Ensure each entry is are set by an environment variables
@@ -178,7 +204,7 @@ def test_all_entries_reflect_envvar_given_settings(
     should by default or settings file
     """
     environment_variable = NavigatorConfiguration.entry(entry).environment_variable(
-        "ansible_navigator"
+        "ansible_navigator",
     )
     with mock.patch.dict(os.environ, {environment_variable: str(value)}):
         response = generate_config(setting_file_name=settings)

--- a/tests/unit/configuration_subsystem/test_previous_cli.py
+++ b/tests/unit/configuration_subsystem/test_previous_cli.py
@@ -288,7 +288,9 @@ def test_apply_cli_subset_none():
         ],
     )
     configurator = Configurator(
-        params=["list", "-z", "zebra"], application_configuration=test_config, initial=True
+        params=["list", "-z", "zebra"],
+        application_configuration=test_config,
+        initial=True,
     )
     _messages, exit_messages = configurator.configure()
     assert not exit_messages
@@ -304,7 +306,9 @@ def test_apply_cli_subset_none():
         assert test_config.entry(expect[0]).value.source is C.USER_CLI
 
     configurator = Configurator(
-        params=["run"], application_configuration=test_config, apply_previous_cli_entries=C.ALL
+        params=["run"],
+        application_configuration=test_config,
+        apply_previous_cli_entries=C.ALL,
     )
     _messages, exit_messages = configurator.configure()
     assert not exit_messages

--- a/tests/unit/image_manager/test_image_puller.py
+++ b/tests/unit/image_manager/test_image_puller.py
@@ -78,7 +78,9 @@ def test_dont_have(valid_container_engine, data):
     """test using an image not local"""
     uuid_str = str(uuid.uuid4())
     image_puller = ImagePuller(
-        container_engine=valid_container_engine, image=uuid_str, pull_policy=data.pull_policy
+        container_engine=valid_container_engine,
+        image=uuid_str,
+        pull_policy=data.pull_policy,
     )
     image_puller.assess()
     assert image_puller.assessment.pull_required == data.pull_required

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -105,7 +105,8 @@ def test_update_args_general(_mf1, monkeypatch, given, argname, expected):
 def test_editor_command_default(_mf1, monkeypatch):
     """test editor with default"""
     monkeypatch.setenv(
-        "ANSIBLE_NAVIGATOR_CONFIG", f"{FIXTURES_DIR}/unit/cli/ansible-navigator_empty.yml"
+        "ANSIBLE_NAVIGATOR_CONFIG",
+        f"{FIXTURES_DIR}/unit/cli/ansible-navigator_empty.yml",
     )
     args = deepcopy(NavigatorConfiguration)
     _messages, exit_msgs = parse_and_update(params=[], args=args, initial=True)
@@ -139,7 +140,8 @@ tst_hint_data = [
     TstHint(command="inventory", expected="with '-i <path to inventory>'"),
     TstHint(command="--la fallss", expected="with '--la true'"),
     TstHint(
-        command="--lf {locked_directory}/test.log", expected="with '--lf ~/ansible-navigator.log'"
+        command="--lf {locked_directory}/test.log",
+        expected="with '--lf ~/ansible-navigator.log'",
     ),
     TstHint(command="-m stderr", expected="with '-m stdout'"),
     TstHint(command="--osc4 troo", expected="with '--osc4 true'"),
@@ -155,7 +157,8 @@ tst_hint_data = [
 def test_hints(monkeypatch, locked_directory, valid_container_engine, data):
     """test the hints don't generate a traceback"""
     monkeypatch.setenv(
-        "ANSIBLE_NAVIGATOR_CONFIG", f"{FIXTURES_DIR}/unit/cli/ansible-navigator_empty.yml"
+        "ANSIBLE_NAVIGATOR_CONFIG",
+        f"{FIXTURES_DIR}/unit/cli/ansible-navigator_empty.yml",
     )
     args = deepcopy(NavigatorConfiguration)
     command = data.command.format(locked_directory=locked_directory)

--- a/tests/unit/test_image_introspection.py
+++ b/tests/unit/test_image_introspection.py
@@ -49,7 +49,7 @@ which contains NET-SNMP utilities.
 def image_introspection():
     """import the image introspection script using the share directory"""
     _log_messages, _exit_messages, share_dir = utils.get_share_directory(
-        app_name="ansible_navigator"
+        app_name="ansible_navigator",
     )
     full_path = f"{share_dir}/utils/image_introspect.py"
     spec = importlib.util.spec_from_file_location("module", full_path)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -73,7 +73,10 @@ def test_find_many_settings_precedence(monkeypatch) -> None:
     ],
 )
 def test_env_var_is_file_path(
-    monkeypatch, set_env: bool, file_path: str, anticpated_result: Optional[str]
+    monkeypatch,
+    set_env: bool,
+    file_path: str,
+    anticpated_result: Optional[str],
 ) -> None:
     """test environment variable is a file path"""
     envvar = "ANSIBLE_NAVIGATOR_CONFIG"
@@ -115,7 +118,9 @@ human_time_test_data = [
     HumanTimeTestData(id="minutes seconds", value=60 + 1, expected="1m1s"),
     HumanTimeTestData(id="hours minutes seconds", value=3600 + 60 + 1, expected="1h1m1s"),
     HumanTimeTestData(
-        id="days hours minutes seconds", value=86400 + 3600 + 60 + 1, expected="1d1h1m1s"
+        id="days hours minutes seconds",
+        value=86400 + 3600 + 60 + 1,
+        expected="1d1h1m1s",
     ),
 ]
 

--- a/tests/unit/ui_framework/test_colorize.py
+++ b/tests/unit/ui_framework/test_colorize.py
@@ -10,7 +10,7 @@ from ansible_navigator.ui_framework.colorize import Colorize
 
 
 SHARE_DIR = os.path.abspath(
-    os.path.join(os.path.basename(__file__), "..", "share", "ansible_navigator")
+    os.path.join(os.path.basename(__file__), "..", "share", "ansible_navigator"),
 )
 THEME_PATH = os.path.join(SHARE_DIR, "themes", "dark_vs.json")
 GRAMMAR_DIR = os.path.join(SHARE_DIR, "grammar")
@@ -21,7 +21,8 @@ def test_basic_success_json():
     to the json string"""
     sample = json.dumps({"test": "data"})
     result = Colorize(grammar_dir=GRAMMAR_DIR, theme_path=THEME_PATH).render(
-        doc=sample, scope="source.json"
+        doc=sample,
+        scope="source.json",
     )
     assert len(result) == 1
     assert len(result[0]) == 5
@@ -35,7 +36,8 @@ def test_basic_success_yaml():
     """
     sample = human_dump({"test": "data"})
     result = Colorize(grammar_dir=GRAMMAR_DIR, theme_path=THEME_PATH).render(
-        doc=sample, scope="source.yaml"
+        doc=sample,
+        scope="source.yaml",
     )
     assert len(result) == 2
     assert len(result[0]) == 1
@@ -48,7 +50,8 @@ def test_basic_success_no_color():
     """Ensure scope nocolor return just lines"""
     sample = json.dumps({"test": "data"})
     result = Colorize(grammar_dir=GRAMMAR_DIR, theme_path=THEME_PATH).render(
-        doc=sample, scope="no_color"
+        doc=sample,
+        scope="no_color",
     )
     assert len(result) == 1
     assert len(result[0]) == 1
@@ -65,7 +68,8 @@ def test_graceful_failure(mocked_func, caplog):
     mocked_func.side_effect = ValueError()
     sample = json.dumps({"test": "data"})
     result = Colorize(grammar_dir=GRAMMAR_DIR, theme_path=THEME_PATH).render(
-        doc=sample, scope="source.json"
+        doc=sample,
+        scope="source.json",
     )
     assert len(result) == 1
     assert len(result[0]) == 1


### PR DESCRIPTION
This modifies the changed files such that the use of trailing commas is consistent through out the project.

Which in turn allows all `C812` exceptions to be removed from the `flake8` configuration file which are a result of a linter being vetted called `flake8-commas` which is part of the wemake style guide.

Although this does not enforce the use of trailing commas, it will allow users of `tox -e lint-vetting` to use it to both add trailing commas where they are missing and see errors that indicate a missing trailing comma which would be inconsistent with the repository.  

The changes were made by the precommit formatter called `add-trailing-comma` followed by `black`.  Only one file needed to be manually editted to break a long string.

```
tests/integration/_tmux_session.py:277:101: E501 line too long (101 > 100 characters)
                    f"******** ERROR: TMUX '{err_message}' TIMEOUT @ {elapsed}s @ {tstamp} ********",
``` 
(the string was simply broken in half)