### PR TITLE
Remove unnecessary generator inside inventory max modified times fuction

### DIFF
--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -142,10 +142,8 @@ class Action(App):
             if os.path.isdir(inventory):
                 mtimes.append(
                     max(
-                        (
-                            os.path.getmtime(e)
-                            for e in glob.glob(os.path.join(inventory, "**"), recursive=True)
-                        )
+                        os.path.getmtime(e)
+                        for e in glob.glob(os.path.join(inventory, "**"), recursive=True)
                     ),
                 )
             elif os.path.isfile(inventory):


### PR DESCRIPTION
The function that finds the maximum file modification time for file and directory based inventories had an unnecessary generator nested inside it.

This in turn eliminates a reported "missing trailing comma" error reported during the use of `tox -e lint-vetting`.

