### PR TITLE
Form button validation, pass a `List` not `Generator`

### DIFF
--- a/src/ansible_navigator/ui_framework/field_button.py
+++ b/src/ansible_navigator/ui_framework/field_button.py
@@ -2,6 +2,7 @@
 """
 from dataclasses import dataclass
 from typing import Callable
+from typing import List
 from typing import Union
 
 from .curses_window import Window
@@ -29,7 +30,7 @@ class FieldButton:
         """no default to add into the prompt for checkbox"""
         return ""
 
-    def validate(self, response: "FieldButton") -> None:
+    def validate(self, response: List) -> None:
         """validate this instance"""
         validation = self.validator(response)
         if validation.error_msg:
@@ -37,7 +38,7 @@ class FieldButton:
         else:
             self.disabled = False
 
-    def conditional_validation(self, response: "FieldButton") -> None:
+    def conditional_validation(self, response: List) -> None:
         """conditional validation used for
         tab
         """

--- a/src/ansible_navigator/ui_framework/field_button.py
+++ b/src/ansible_navigator/ui_framework/field_button.py
@@ -30,7 +30,7 @@ class FieldButton:
         """no default to add into the prompt for checkbox"""
         return ""
 
-    def validate(self, response: List) -> None:
+    def validate(self, response: List[Union[str, bool]]) -> None:
         """validate this instance"""
         validation = self.validator(response)
         if validation.error_msg:
@@ -38,7 +38,7 @@ class FieldButton:
         else:
             self.disabled = False
 
-    def conditional_validation(self, response: List) -> None:
+    def conditional_validation(self, response: List[Union[str, bool]]) -> None:
         """conditional validation used for
         tab
         """

--- a/src/ansible_navigator/ui_framework/field_button.py
+++ b/src/ansible_navigator/ui_framework/field_button.py
@@ -7,6 +7,7 @@ from typing import Union
 
 from .curses_window import Window
 from .form_handler_button import FormHandlerButton
+from .sentinels import Unknown
 from .validators import FieldValidators
 
 
@@ -30,7 +31,7 @@ class FieldButton:
         """no default to add into the prompt for checkbox"""
         return ""
 
-    def validate(self, response: List[Union[str, bool]]) -> None:
+    def validate(self, response: List[Union[Unknown, bool]]) -> None:
         """validate this instance"""
         validation = self.validator(response)
         if validation.error_msg:
@@ -38,7 +39,7 @@ class FieldButton:
         else:
             self.disabled = False
 
-    def conditional_validation(self, response: List[Union[str, bool]]) -> None:
+    def conditional_validation(self, response: List[Union[Unknown, bool]]) -> None:
         """conditional validation used for
         tab
         """

--- a/src/ansible_navigator/ui_framework/form_presenter.py
+++ b/src/ansible_navigator/ui_framework/form_presenter.py
@@ -158,9 +158,10 @@ class FormPresenter(CursesWindow):
             window = curses.newwin(1, len(string), self._line_number, far_right + self._pad_left)
             window.keypad(True)
             form_field.win = window
-            form_field.conditional_validation(
-                (f.valid for f in self._form.fields if not isinstance(f, FieldButton))
-            )
+            form_validity_state = [
+                f.valid for f in self._form.fields if not isinstance(f, FieldButton)
+            ]
+            form_field.conditional_validation(form_validity_state)
             if form_field.disabled is True:
                 color = 8
             else:

--- a/src/ansible_navigator/ui_framework/validators.py
+++ b/src/ansible_navigator/ui_framework/validators.py
@@ -52,7 +52,7 @@ class FieldValidators:
         return Validation(value=value, error_msg="")
 
     @staticmethod
-    def none(text="", hint: bool = False) -> Union[Validation, str]:
+    def none(text: Union[List, str] = "", hint: bool = False) -> Union[Validation, str]:
         """no validation"""
         if hint:
             return "Please provide a value (optional)"

--- a/src/ansible_navigator/ui_framework/validators.py
+++ b/src/ansible_navigator/ui_framework/validators.py
@@ -52,7 +52,7 @@ class FieldValidators:
         return Validation(value=value, error_msg="")
 
     @staticmethod
-    def none(text: Union[List, str] = "", hint: bool = False) -> Union[Validation, str]:
+    def none(text: Union[List[Union[Unknown, bool]], str] = "", hint: bool = False) -> Union[Validation, str]:
         """no validation"""
         if hint:
             return "Please provide a value (optional)"

--- a/src/ansible_navigator/ui_framework/validators.py
+++ b/src/ansible_navigator/ui_framework/validators.py
@@ -52,7 +52,9 @@ class FieldValidators:
         return Validation(value=value, error_msg="")
 
     @staticmethod
-    def none(text: Union[List[Union[Unknown, bool]], str] = "", hint: bool = False) -> Union[Validation, str]:
+    def none(
+        text: Union[List[Union[Unknown, bool]], str] = "", hint: bool = False
+    ) -> Union[Validation, str]:
         """no validation"""
         if hint:
             return "Please provide a value (optional)"


### PR DESCRIPTION
Form buttons should really only have one of 2 validators, either `all_true` in the case of a `Submit` button, or `none` in the case of a `Cancel` button.

This changes results in passing a `List` to the button's conditional validator rather than a `Generator`.

Several typing updates to correct what is being passed through.

This also eliminates a  trailing-comma error reported when using `tox -e lint-vetting`