### PR TITLE
Small formatting change for comment in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,7 @@ file_pairs = [
 # data_files specifies a sequence of (directory, files) pairs in the following way:
 # setup(...,
 #     data_files=[('bitmaps', ['bm/b1.gif', 'bm/b2.gif']),
-#                 ('config', ['cfg/data.cfg'])],
-#     )
+#                 ('config', ['cfg/data.cfg'])], ...)
 # Each (directory, files) pair in the sequence specifies the installation directory
 # and the files to install there.
 data_file_list = [(k, list(list(zip(*g))[1])) for k, g in groupby(file_pairs, itemgetter(0))]


### PR DESCRIPTION
Make a small formatting change to the comment in setup.py.

This was necessary to eliminate an error thrown (E800) by `flake8-eradicate` which is one linter being vetted.

By reducing the errors thrown by `tox -e lint-vetting` it should allow future contributors to use it with needing to look through long lists of errors unrelated to their code, and see feedback related only to the changes being made in a PR.