### PR TITLE
Disable warnings related to the use of assert in the tests directory as reported with `lint-vetting`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -70,7 +70,8 @@ per-file-ignores =
   # S101: Allow the use of assert within the tests directory
   # tests/*: S101
 
-  # The following were present during the initial implemetation
+  # The following were present during the initial implementation.
+  # They are expected to be fixed and unignored over time.
   # Please try to keep it in alphbetical order to make finding files easier for the next person
 
   docs/_ext/single_sourced_data.py: D400, D403, DAR101, DAR201, N817, P103, WPS110, WPS111, WPS201, WPS202, WPS210, WPS213, WPS221, WPS229, WPS231, WPS237, WPS305, WPS318, WPS323, WPS331, WPS336, WPS347, WPS407, WPS432, WPS440, WPS441, WPS453, WPS504

--- a/.flake8
+++ b/.flake8
@@ -63,8 +63,9 @@ max-line-length = 100
 per-file-ignores =
   # The following ignores have been researched and should be considered permanent
   # each should be preceeded with an explanation of each of the error codes
-  # When ignores are added for a specific file, these will need to be added to that line as well.
-  
+  # If other ignores are added for a specific file in the section following this,
+  # these will need to be added to that line as well.
+
   # S101: Allow the use of assert within the tests directory
   tests/**.py: S101
 
@@ -267,7 +268,6 @@ per-file-ignores =
   tests/unit/__init__.py: D104
   tests/unit/actions/__init__.py: D104
   tests/unit/actions/test_config.py: D200, D400, D403, S101, WPS110, WPS204, WPS218, WPS221, WPS226, WPS305
-  tests/unit/actions/test_exec.py: S101
   tests/unit/actions/test_inventory.py: D200, D400, D403, S101, WPS110, WPS204, WPS218, WPS221, WPS226, WPS305
   tests/unit/actions/test_run.py: D200, D400, DAR101, DAR201, N813, PT019, S101, S108, WPS110, WPS121, WPS122, WPS201, WPS226, WPS237, WPS305, WPS425, WPS432, WPS437
   tests/unit/configuration_subsystem/__init__.py: D104
@@ -279,10 +279,8 @@ per-file-ignores =
   tests/unit/configuration_subsystem/test_container_engine_auto.py: D200, DAR101, S101, WPS430, WPS520
   tests/unit/configuration_subsystem/test_entries_sanity.py: D200, D400, DAR101, N817, S101, WPS110, WPS111, WPS202, WPS221, WPS226, WPS300, WPS347
   tests/unit/configuration_subsystem/test_fixture_sanity.py: D205, D400, S101, WPS110, WPS210, WPS300, WPS436
-  tests/unit/configuration_subsystem/test_internals.py: S101
   tests/unit/configuration_subsystem/test_invalid_params.py: D200, D202, D400, DAR101, PT006, PT019, S101, WPS110, WPS202, WPS204, WPS226, WPS300, WPS305, WPS420, WPS430, WPS510
   tests/unit/configuration_subsystem/test_mode_subcommand_action.py: D205, D400, S101, WPS226, WPS336, WPS437, WPS510
-  tests/unit/configuration_subsystem/test_navigator_post_processor.py: S101
   tests/unit/configuration_subsystem/test_precedence.py: D205, D400, DAR101, N817, PT006, PT019, S101, WPS110, WPS111, WPS118, WPS201, WPS210, WPS211, WPS218, WPS226, WPS231, WPS232, WPS300, WPS347, WPS440, WPS458, WPS520, WPS529
   tests/unit/configuration_subsystem/test_previous_cli.py: D202, D205, D400, N817, PT019, S101, S108, WPS110, WPS111, WPS121, WPS204, WPS210, WPS218, WPS226, WPS347, WPS440, WPS458, WPS520
   tests/unit/configuration_subsystem/test_sample_configurations.py: D205, D400, S101, WPS219, WPS221, WPS226, WPS428, WPS437

--- a/.flake8
+++ b/.flake8
@@ -59,7 +59,7 @@ inline-quotes = "
 max-line-length = 100
 
 # Allow certain violations in certain files:
-# Please keep this list sorted, as it will be easier for others to find and add entries in the future
+# Please keep both sections sorted, as it will be easier for others to find and add entries in the future
 per-file-ignores =
   # The following ignores have been researched and should be considered permanent
   # each should be preceeded with an explanation of each of the error codes
@@ -72,8 +72,6 @@ per-file-ignores =
 
   # The following were present during the initial implementation.
   # They are expected to be fixed and unignored over time.
-  # Please try to keep it in alphabetical order to make finding files easier for the next person
-
   docs/_ext/single_sourced_data.py: D400, D403, DAR101, DAR201, N817, P103, WPS110, WPS111, WPS201, WPS202, WPS210, WPS213, WPS221, WPS229, WPS231, WPS237, WPS305, WPS318, WPS323, WPS331, WPS336, WPS347, WPS407, WPS432, WPS440, WPS441, WPS453, WPS504
   docs/_ext/spelling_stub_ext.py: DAR101, DAR201
   docs/conf.py: WPS221, WPS226, WPS301, WPS305, WPS323, WPS420, WPS429, WPS433
@@ -214,10 +212,15 @@ per-file-ignores =
   tests/integration/actions/doc/test_welcome_interactive_ee.py: D200, D400, PT006, WPS115, WPS300, WPS326
   tests/integration/actions/doc/test_welcome_interactive_noee.py: D200, D400, PT006, WPS115, WPS300
 <<<<<<< HEAD
+<<<<<<< HEAD
   tests/integration/actions/images/__init__.py: D104
 ||||||| parent of f8edcee (assert)
 =======
   tests/integration/actions/exec/base.py: S101
+||||||| parent of c24ed9f (Sort the entries in the flake8 `per_file_ignore` list (#794))
+  tests/integration/actions/exec/base.py: S101
+=======
+>>>>>>> c24ed9f (Sort the entries in the flake8 `per_file_ignore` list (#794))
   tests/integration/actions/images/__init__.py: D104
 >>>>>>> f8edcee (assert)
   tests/integration/actions/images/base.py: D200, D202, D400, D403, DAR101, DAR301, DAR401, S101, WPS110, WPS115, WPS210, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436

--- a/.flake8
+++ b/.flake8
@@ -59,16 +59,14 @@ inline-quotes = "
 max-line-length = 100
 
 # Allow certain violations in certain files:
-# Please keep both sections sorted, as it will be easier for others to find and add entries in the future
+# Please keep both sections of this list sorted, as it will be easier for others to find and add entries in the future
 per-file-ignores =
   # The following ignores have been researched and should be considered permanent
   # each should be preceeded with an explanation of each of the error codes
-  # These might be commented out as they overlap with the perfile ignores
-  # once the per file ignores are removed or added within the file itself
-  # they should be able to be uncommented
-
+  # When ignores are added for a specific file, these will need to be added to that line as well.
+  
   # S101: Allow the use of assert within the tests directory
-  # tests/*: S101
+  tests/**.py: S101
 
   # The following were present during the initial implementation.
   # They are expected to be fixed and unignored over time.

--- a/.flake8
+++ b/.flake8
@@ -66,7 +66,7 @@ per-file-ignores =
   # If other ignores are added for a specific file in the section following this,
   # these will need to be added to that line as well.
 
-  # S101: Allow the use of assert within the tests directory
+  # S101: Allow the use of assert within the tests directory, since tests require it.
   tests/**.py: S101
 
   # The following were present during the initial implementation.

--- a/.flake8
+++ b/.flake8
@@ -72,7 +72,7 @@ per-file-ignores =
 
   # The following were present during the initial implementation.
   # They are expected to be fixed and unignored over time.
-  # Please try to keep it in alphbetical order to make finding files easier for the next person
+  # Please try to keep it in alphabetical order to make finding files easier for the next person
 
   docs/_ext/single_sourced_data.py: D400, D403, DAR101, DAR201, N817, P103, WPS110, WPS111, WPS201, WPS202, WPS210, WPS213, WPS221, WPS229, WPS231, WPS237, WPS305, WPS318, WPS323, WPS331, WPS336, WPS347, WPS407, WPS432, WPS440, WPS441, WPS453, WPS504
   docs/_ext/spelling_stub_ext.py: DAR101, DAR201

--- a/.flake8
+++ b/.flake8
@@ -210,18 +210,7 @@ per-file-ignores =
   tests/integration/actions/doc/test_stdout.py: D200, D400, PT006, WPS114, WPS115, WPS202, WPS226, WPS300, WPS326
   tests/integration/actions/doc/test_welcome_interactive_ee.py: D200, D400, PT006, WPS115, WPS300, WPS326
   tests/integration/actions/doc/test_welcome_interactive_noee.py: D200, D400, PT006, WPS115, WPS300
-<<<<<<< HEAD
-<<<<<<< HEAD
   tests/integration/actions/images/__init__.py: D104
-||||||| parent of f8edcee (assert)
-=======
-  tests/integration/actions/exec/base.py: S101
-||||||| parent of c24ed9f (Sort the entries in the flake8 `per_file_ignore` list (#794))
-  tests/integration/actions/exec/base.py: S101
-=======
->>>>>>> c24ed9f (Sort the entries in the flake8 `per_file_ignore` list (#794))
-  tests/integration/actions/images/__init__.py: D104
->>>>>>> f8edcee (assert)
   tests/integration/actions/images/base.py: D200, D202, D400, D403, DAR101, DAR301, DAR401, S101, WPS110, WPS115, WPS210, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436
   tests/integration/actions/images/test_direct_interactive_ee.py: D200, D400, WPS115, WPS300, WPS436
   tests/integration/actions/images/test_direct_interactive_noee.py: D200, D400, WPS115, WPS300, WPS436

--- a/.flake8
+++ b/.flake8
@@ -61,6 +61,18 @@ max-line-length = 100
 # Allow certain violations in certain files:
 # Please keep this list sorted, as it will be easier for others to find and add entries in the future
 per-file-ignores =
+  # The following ignores have been researched and should be considered permanent
+  # each should be preceeded with an explanation of each of the error codes
+  # These might be commented out as they overlap with the perfile ignores
+  # once the per file ignores are removed or added within the file itself
+  # they should be able to be uncommented
+
+  # S101: Allow the use of assert within the tests directory
+  # tests/*: S101
+
+  # The following were present during the initial implemetation
+  # Please try to keep it in alphbetical order to make finding files easier for the next person
+
   docs/_ext/single_sourced_data.py: D400, D403, DAR101, DAR201, N817, P103, WPS110, WPS111, WPS201, WPS202, WPS210, WPS213, WPS221, WPS229, WPS231, WPS237, WPS305, WPS318, WPS323, WPS331, WPS336, WPS347, WPS407, WPS432, WPS440, WPS441, WPS453, WPS504
   docs/_ext/spelling_stub_ext.py: DAR101, DAR201
   docs/conf.py: WPS221, WPS226, WPS301, WPS305, WPS323, WPS420, WPS429, WPS433
@@ -200,7 +212,13 @@ per-file-ignores =
   tests/integration/actions/doc/test_stdout.py: D200, D400, PT006, WPS114, WPS115, WPS202, WPS226, WPS300, WPS326
   tests/integration/actions/doc/test_welcome_interactive_ee.py: D200, D400, PT006, WPS115, WPS300, WPS326
   tests/integration/actions/doc/test_welcome_interactive_noee.py: D200, D400, PT006, WPS115, WPS300
+<<<<<<< HEAD
   tests/integration/actions/images/__init__.py: D104
+||||||| parent of f8edcee (assert)
+=======
+  tests/integration/actions/exec/base.py: S101
+  tests/integration/actions/images/__init__.py: D104
+>>>>>>> f8edcee (assert)
   tests/integration/actions/images/base.py: D200, D202, D400, D403, DAR101, DAR301, DAR401, S101, WPS110, WPS115, WPS210, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436
   tests/integration/actions/images/test_direct_interactive_ee.py: D200, D400, WPS115, WPS300, WPS436
   tests/integration/actions/images/test_direct_interactive_noee.py: D200, D400, WPS115, WPS300, WPS436
@@ -247,6 +265,7 @@ per-file-ignores =
   tests/unit/__init__.py: D104
   tests/unit/actions/__init__.py: D104
   tests/unit/actions/test_config.py: D200, D400, D403, S101, WPS110, WPS204, WPS218, WPS221, WPS226, WPS305
+  tests/unit/actions/test_exec.py: S101
   tests/unit/actions/test_inventory.py: D200, D400, D403, S101, WPS110, WPS204, WPS218, WPS221, WPS226, WPS305
   tests/unit/actions/test_run.py: D200, D400, DAR101, DAR201, N813, PT019, S101, S108, WPS110, WPS121, WPS122, WPS201, WPS226, WPS237, WPS305, WPS425, WPS432, WPS437
   tests/unit/configuration_subsystem/__init__.py: D104
@@ -258,8 +277,10 @@ per-file-ignores =
   tests/unit/configuration_subsystem/test_container_engine_auto.py: D200, DAR101, S101, WPS430, WPS520
   tests/unit/configuration_subsystem/test_entries_sanity.py: D200, D400, DAR101, N817, S101, WPS110, WPS111, WPS202, WPS221, WPS226, WPS300, WPS347
   tests/unit/configuration_subsystem/test_fixture_sanity.py: D205, D400, S101, WPS110, WPS210, WPS300, WPS436
+  tests/unit/configuration_subsystem/test_internals.py: S101
   tests/unit/configuration_subsystem/test_invalid_params.py: D200, D202, D400, DAR101, PT006, PT019, S101, WPS110, WPS202, WPS204, WPS226, WPS300, WPS305, WPS420, WPS430, WPS510
   tests/unit/configuration_subsystem/test_mode_subcommand_action.py: D205, D400, S101, WPS226, WPS336, WPS437, WPS510
+  tests/unit/configuration_subsystem/test_navigator_post_processor.py: S101
   tests/unit/configuration_subsystem/test_precedence.py: D205, D400, DAR101, N817, PT006, PT019, S101, WPS110, WPS111, WPS118, WPS201, WPS210, WPS211, WPS218, WPS226, WPS231, WPS232, WPS300, WPS347, WPS440, WPS458, WPS520, WPS529
   tests/unit/configuration_subsystem/test_previous_cli.py: D202, D205, D400, N817, PT019, S101, S108, WPS110, WPS111, WPS121, WPS204, WPS210, WPS218, WPS226, WPS347, WPS440, WPS458, WPS520
   tests/unit/configuration_subsystem/test_sample_configurations.py: D205, D400, S101, WPS219, WPS221, WPS226, WPS428, WPS437


### PR DESCRIPTION
This adds a few additional files to the `per-file-ignore` list within the flake8 configuration with an exemption for `S101` which is reported by `flake8-bandit` as part of the wemake style guide which is being vetted.

The list was also alphabetized to ensure new entries were placed in a sane location.

A note was added to the top of the flake8 per-file-ignores indicating that the glob for the tests folder ignoring s101 can be added later. Currently there is a conflict between globs and per-file entries.  See https://github.com/PyCQA/flake8/issues/670

This eliminates the `S101` entry from the output of `tox -e lint-vetting` so users of it can see messages only related to the changes they are making and not for files that were previously added to the repository:

```diff
1     C812 missing trailing comma
1     RST304 Unknown interpreted text role "mod".
- 13    S101 Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
1     S404 Consider possible security implications associated with the subprocess module.
1     S603 subprocess call - check for execution of untrusted input.
2     S604 Function call with shell=True parameter identified, possible security issue.
2     WPS111 Found too short name: p < 2
2     WPS115 Found upper-case constant in a class: KEGEX
3     WPS201 Found module with too many imports: 13 > 12
6     WPS210 Found too many local variables: 6 > 5
3     WPS220 Found too deep nesting: 24 > 20
2     WPS221 Found line with high Jones Complexity: 16 > 14
3     WPS226 Found string literal over-use: test_option > 3
9     WPS305 Found `f` string
1     WPS316 Found context manager with too many assignments
6     WPS317 Found incorrect multi-line parameters
2     WPS323 Found `%` string formatting
4     WPS324 Found inconsistent `return` statement
2     WPS414 Found incorrect unpacking target
1     WPS430 Found nested function: getcwd
14    WPS436 Found protected module import: _curses
3     WPS450 Found protected object import: _CursesWindow
1     WPS602 Found using `@staticmethod`
```

Related #713