### PR TITLE
Switch from short var names to longer in one test file

### DIFF
--- a/tests/unit/test_circular_imports.py
+++ b/tests/unit/test_circular_imports.py
@@ -34,8 +34,8 @@ def _find_all_importables(pkg: ModuleType) -> List[str]:
     return sorted(
         set(
             chain.from_iterable(
-                _discover_path_importables(Path(p), pkg.__name__)
-                for p in pkg.__path__  # type: ignore[attr-defined]
+                _discover_path_importables(Path(path), pkg.__name__)
+                for path in pkg.__path__  # type: ignore[attr-defined]
             ),
         ),
     )
@@ -51,7 +51,7 @@ def _discover_path_importables(
     :param pkg_name: The name of the package
     :yields: Package directory paths
     """
-    for dir_path, _d, file_names in os.walk(pkg_pth):
+    for dir_path, _dir_names, file_names in os.walk(pkg_pth):
         pkg_dir_path = Path(dir_path)
 
         if pkg_dir_path.parts[-1] == "__pycache__":


### PR DESCRIPTION
This changes 2 variable names in one test file such that they do not violate the `WPS111` rule as reported by the wemake style guide being vetted.

This should help users of `tox -e lint-vetting` identity errors related to the changes they may be proposing instead of needing to sift through errors unrelated to their changes.  

Before:
```
1     C812 missing trailing comma
1     RST304 Unknown interpreted text role "mod".
13    S101 Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
1     S404 Consider possible security implications associated with the subprocess module.
1     S603 subprocess call - check for execution of untrusted input.
2     S604 Function call with shell=True parameter identified, possible security issue.
2     WPS111 Found too short name: p < 2
2     WPS115 Found upper-case constant in a class: KEGEX
3     WPS201 Found module with too many imports: 13 > 12
6     WPS210 Found too many local variables: 6 > 5
3     WPS220 Found too deep nesting: 24 > 20
2     WPS221 Found line with high Jones Complexity: 16 > 14
3     WPS226 Found string literal over-use: test_option > 3
9     WPS305 Found `f` string
1     WPS316 Found context manager with too many assignments
6     WPS317 Found incorrect multi-line parameters
2     WPS323 Found `%` string formatting
4     WPS324 Found inconsistent `return` statement
2     WPS414 Found incorrect unpacking target
1     WPS430 Found nested function: getcwd
14    WPS436 Found protected module import: _curses
3     WPS450 Found protected object import: _CursesWindow
1     WPS602 Found using `@staticmethod`
```



After:
```
1     C812 missing trailing comma
1     RST304 Unknown interpreted text role "mod".
13    S101 Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
1     S404 Consider possible security implications associated with the subprocess module.
1     S603 subprocess call - check for execution of untrusted input.
2     S604 Function call with shell=True parameter identified, possible security issue.
2     WPS115 Found upper-case constant in a class: KEGEX
3     WPS201 Found module with too many imports: 13 > 12
6     WPS210 Found too many local variables: 6 > 5
3     WPS220 Found too deep nesting: 24 > 20
2     WPS221 Found line with high Jones Complexity: 16 > 14
3     WPS226 Found string literal over-use: test_option > 3
9     WPS305 Found `f` string
1     WPS316 Found context manager with too many assignments
6     WPS317 Found incorrect multi-line parameters
2     WPS323 Found `%` string formatting
4     WPS324 Found inconsistent `return` statement
2     WPS414 Found incorrect unpacking target
1     WPS430 Found nested function: getcwd
14    WPS436 Found protected module import: _curses
3     WPS450 Found protected object import: _CursesWindow
1     WPS602 Found using `@staticmethod`
```