### PR TITLE
Sort the entries in the flake8 `per_file_ignore` list

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -59,6 +59,7 @@ inline-quotes = "
 max-line-length = 100
 
 # Allow certain violations in certain files:
+# Please keep this list sorted, as it will be easier for others to find and add entries in the future
 per-file-ignores =
   docs/_ext/single_sourced_data.py: D400, D403, DAR101, DAR201, N817, P103, WPS110, WPS111, WPS201, WPS202, WPS210, WPS213, WPS221, WPS229, WPS231, WPS237, WPS305, WPS318, WPS323, WPS331, WPS336, WPS347, WPS407, WPS432, WPS440, WPS441, WPS453, WPS504
   docs/_ext/spelling_stub_ext.py: DAR101, DAR201

--- a/.flake8
+++ b/.flake8
@@ -60,14 +60,20 @@ max-line-length = 100
 
 # Allow certain violations in certain files:
 per-file-ignores =
-  docs/conf.py: WPS221, WPS226, WPS301, WPS305, WPS323, WPS420, WPS429, WPS433
   docs/_ext/single_sourced_data.py: D400, D403, DAR101, DAR201, N817, P103, WPS110, WPS111, WPS201, WPS202, WPS210, WPS213, WPS221, WPS229, WPS231, WPS237, WPS305, WPS318, WPS323, WPS331, WPS336, WPS347, WPS407, WPS432, WPS440, WPS441, WPS453, WPS504
   docs/_ext/spelling_stub_ext.py: DAR101, DAR201
+  docs/conf.py: WPS221, WPS226, WPS301, WPS305, WPS323, WPS420, WPS429, WPS433
   setup.py: D210, D400, WPS111, WPS221
+  share/ansible_navigator/utils/__init__.py: D104
   share/ansible_navigator/utils/catalog_collections.py: D107, D200, D400, D401, D403, DAR101, DAR201, S404, S602, WPS110, WPS111, WPS121, WPS122, WPS201, WPS202, WPS210, WPS211, WPS220, WPS221, WPS226, WPS229, WPS231, WPS232, WPS237, WPS305, WPS306, WPS331, WPS336, WPS338, WPS349, WPS420, WPS426, WPS432, WPS433, WPS437, WPS440, WPS458, WPS529, WPS602
   share/ansible_navigator/utils/image_introspect.py: D101, D102, D107, D205, D209, D400, D401, D403, DAR101, DAR201, S404, S602, WPS110, WPS111, WPS121, WPS122, WPS202, WPS210, WPS220, WPS221, WPS226, WPS229, WPS231, WPS305, WPS306, WPS335, WPS338, WPS440, WPS441, WPS510, WPS602
   share/ansible_navigator/utils/key_value_store.py: D105, D107, D200, D400, D403, DAR101, DAR201, DAR301, DAR401, WPS110, WPS214, WPS526, WPS600, WPS603
+  src/ansible_navigator/__init__.py: D200, D400, WPS300, WPS412, WPS436
+  src/ansible_navigator/__main__.py: RST304, WPS300
+  src/ansible_navigator/_version.py: D210, D400, D412, WPS410
+  src/ansible_navigator/_yaml.py: D210, D400, D401, DAR101, DAR201, WPS110, WPS229, WPS433, WPS437, WPS440, WPS458
   src/ansible_navigator/action_runner.py: D107, D200, D400, D403, DAR101, WPS231, WPS300, WPS437
+  src/ansible_navigator/actions/__init__.py: D400, WPS300, WPS410, WPS412, WPS450
   src/ansible_navigator/actions/_actions.py: D210, D400, D401, DAR101, DAR201, WPS111, WPS202, WPS221, WPS305, WPS407, WPS433, WPS440, WPS458
   src/ansible_navigator/actions/back.py: D107, D400, DAR101, WPS115, WPS300, WPS306, WPS323, WPS450
   src/ansible_navigator/actions/collections.py: C409, C414, D102, D107, D201, D202, D205, D400, D403, DAR101, DAR201, WPS110, WPS111, WPS115, WPS121, WPS122, WPS201, WPS204, WPS210, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS323, WPS336, WPS338, WPS440, WPS441, WPS450, WPS504, WPS505, WPS529
@@ -76,7 +82,6 @@ per-file-ignores =
   src/ansible_navigator/actions/filter.py: D107, D400, DAR101, WPS115, WPS300, WPS306, WPS323, WPS450
   src/ansible_navigator/actions/help_doc.py: D107, D400, DAR101, DAR201, WPS115, WPS300, WPS360, WPS450
   src/ansible_navigator/actions/images.py: D107, D201, D400, D403, DAR101, DAR201, WPS110, WPS111, WPS115, WPS121, WPS122, WPS201, WPS210, WPS212, WPS213, WPS214, WPS221, WPS223, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS323, WPS331, WPS336, WPS338, WPS349, WPS450, WPS504, WPS510, WPS529
-  src/ansible_navigator/actions/__init__.py: D400, WPS300, WPS410, WPS412, WPS450
   src/ansible_navigator/actions/inventory.py: C409, D102, D107, D202, D205, D400, D403, DAR101, DAR201, N806, WPS110, WPS111, WPS112, WPS115, WPS201, WPS210, WPS212, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS300, WPS305, WPS323, WPS324, WPS331, WPS336, WPS338, WPS450, WPS510, WPS600
   src/ansible_navigator/actions/log.py: D107, D400, DAR101, DAR201, WPS115, WPS231, WPS232, WPS300, WPS360, WPS450
   src/ansible_navigator/actions/open_file.py: D105, D107, D400, DAR101, DAR201, S605, WPS110, WPS111, WPS115, WPS201, WPS210, WPS221, WPS231, WPS300, WPS306, WPS323, WPS338, WPS436, WPS440, WPS450
@@ -99,11 +104,11 @@ per-file-ignores =
   src/ansible_navigator/app_public.py: D204, D205, D211, D400, WPS300
   src/ansible_navigator/app.py: D107, D200, D205, D209, D400, D401, D403, DAR101, DAR201, DAR401, N817, WPS110, WPS111, WPS201, WPS214, WPS221, WPS300, WPS306, WPS338, WPS347, WPS602
   src/ansible_navigator/cli.py: B010, D200, D400, D403, DAR101, DAR201, WPS201, WPS210, WPS213, WPS221, WPS229, WPS237, WPS300, WPS305, WPS323, WPS331, WPS336, WPS440
-  src/ansible_navigator/command_runner/command_runner.py: D107, D400, D403, DAR101, DAR201, S404, S602, WPS110, WPS121, WPS122, WPS229, WPS306, WPS440, WPS602
   src/ansible_navigator/command_runner/__init__.py: D210, D400, WPS300, WPS412
+  src/ansible_navigator/command_runner/command_runner.py: D107, D400, D403, DAR101, DAR201, S404, S602, WPS110, WPS121, WPS122, WPS229, WPS306, WPS440, WPS602
+  src/ansible_navigator/configuration_subsystem/__init__.py: D200, D400, WPS300, WPS412
   src/ansible_navigator/configuration_subsystem/configurator.py: B010, D200, D202, D205, D400, D401, D403, DAR101, DAR201, N817, WPS110, WPS111, WPS201, WPS210, WPS211, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS232, WPS237, WPS300, WPS305, WPS306, WPS336, WPS337, WPS338, WPS347, WPS436, WPS440, WPS510
   src/ansible_navigator/configuration_subsystem/definitions.py: D200, D204, D400, D401, DAR101, DAR201, DAR401, WPS110, WPS115, WPS221, WPS226, WPS237, WPS300, WPS305, WPS331, WPS338, WPS613
-  src/ansible_navigator/configuration_subsystem/__init__.py: D200, D400, WPS300, WPS412
   src/ansible_navigator/configuration_subsystem/navigator_configuration.py: D200, D205, D400, DAR201, N812, N817, WPS111, WPS201, WPS204, WPS221, WPS226, WPS237, WPS300, WPS305, WPS347, WPS436
   src/ansible_navigator/configuration_subsystem/navigator_post_processor.py: B009, B014, D200, D400, DAR101, DAR201, N817, WPS111, WPS201, WPS204, WPS210, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS306, WPS336, WPS337, WPS338, WPS347, WPS420, WPS440, WPS441, WPS448, WPS510, WPS602
   src/ansible_navigator/configuration_subsystem/parser.py: D107, D200, D400, DAR101, DAR201, N817, WPS111, WPS221, WPS237, WPS300, WPS305, WPS306, WPS323, WPS336, WPS347, WPS436, WPS450, WPS504, WPS507, WPS602
@@ -111,8 +116,7 @@ per-file-ignores =
   src/ansible_navigator/image_manager/inspector.py: D107, D400, D403, DAR101, DAR201, WPS110, WPS114, WPS210, WPS221, WPS300, WPS305, WPS306, WPS602
   src/ansible_navigator/image_manager/puller.py: D107, D400, D403, DAR201, DAR401, S404, S603, WPS110, WPS111, WPS213, WPS214, WPS221, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS306, WPS338
   src/ansible_navigator/initialization.py: D202, D205, D400, D403, DAR101, DAR201, N812, N817, WPS110, WPS111, WPS201, WPS204, WPS210, WPS213, WPS221, WPS226, WPS237, WPS300, WPS301, WPS305, WPS336, WPS347, WPS436, WPS504, WPS529, WPS609
-  src/ansible_navigator/__init__.py: D200, D400, WPS300, WPS412, WPS436
-  src/ansible_navigator/__main__.py: RST304, WPS300
+  src/ansible_navigator/runner/__init__.py: D200, D400, WPS300, WPS412
   src/ansible_navigator/runner/ansible_config.py: C815, D205, D400, WPS300
   src/ansible_navigator/runner/ansible_doc.py: C815, D205, D400, DAR101, DAR201, WPS211, WPS221, WPS234, WPS300
   src/ansible_navigator/runner/ansible_inventory.py: C815, D205, D400, WPS211, WPS300
@@ -120,19 +124,21 @@ per-file-ignores =
   src/ansible_navigator/runner/command_async.py: D400, DAR101, DAR201, WPS300, WPS323, WPS338, WPS414
   src/ansible_navigator/runner/command_base.py: D205, D211, D400, D401, DAR101, RST201, RST301, WPS110, WPS111, WPS211, WPS300, WPS305, WPS323
   src/ansible_navigator/runner/command.py: D202, D205, D400, D403, DAR201, WPS300, WPS331
-  src/ansible_navigator/runner/__init__.py: D200, D400, WPS300, WPS412
   src/ansible_navigator/steps.py: D107, D200, D211, D400, D401, D403, DAR101, DAR201, DAR401, WPS110, WPS211, WPS214, WPS230, WPS237, WPS305, WPS306, WPS602
+  src/ansible_navigator/tm_tokenize/__init__.py: D104
+  src/ansible_navigator/tm_tokenize/_types.py: WPS440
   src/ansible_navigator/tm_tokenize/compiler.py: D100, D101, D102, D107, S101, WPS111, WPS201, WPS214, WPS221, WPS226, WPS231, WPS300, WPS305, WPS306, WPS331, WPS338, WPS420, WPS429, WPS450, WPS503
   src/ansible_navigator/tm_tokenize/fchainmap.py: D100, D101, D105, D107, WPS300, WPS420, WPS428, WPS436, WPS500, WPS503
   src/ansible_navigator/tm_tokenize/grammars.py: D100, D101, D102, D107, WPS110, WPS111, WPS201, WPS210, WPS226, WPS234, WPS300, WPS306, WPS331, WPS338, WPS361, WPS420, WPS429, WPS440, WPS450, WPS529
-  src/ansible_navigator/tm_tokenize/region.py: D100, D101
   src/ansible_navigator/tm_tokenize/reg.py: D100, D103, WPS111, WPS201, WPS211, WPS221, WPS234, WPS237, WPS300, WPS305, WPS306, WPS407, WPS436, WPS450
+  src/ansible_navigator/tm_tokenize/region.py: D100, D101
   src/ansible_navigator/tm_tokenize/rules.py: D100, D101, D102, D400, WPS111, WPS201, WPS202, WPS210, WPS211, WPS214, WPS221, WPS231, WPS300, WPS305, WPS338, WPS362, WPS428, WPS429, WPS436, WPS437, WPS441, WPS450, WPS503, WPS529
   src/ansible_navigator/tm_tokenize/state.py: D100, D101, D102, WPS221, WPS300
   src/ansible_navigator/tm_tokenize/tokenize.py: D100, D201, D400, D403, DAR101, DAR201, WPS210, WPS300
-  src/ansible_navigator/tm_tokenize/_types.py: WPS440
   src/ansible_navigator/tm_tokenize/utils.py: D100, D400, D403, DAR101, DAR201, WPS100, WPS111, WPS609
+  src/ansible_navigator/ui_framework/__init__.py: D200, D400, WPS201, WPS300, WPS412
   src/ansible_navigator/ui_framework/colorize.py: D107, D200, D205, D400, D403, DAR101, DAR201, WPS110, WPS111, WPS114, WPS202, WPS204, WPS210, WPS220, WPS221, WPS226, WPS231, WPS232, WPS300, WPS306, WPS323, WPS331, WPS338, WPS355, WPS407, WPS420, WPS432, WPS440, WPS518
+  src/ansible_navigator/ui_framework/curses_defs.py: D200, D400
   src/ansible_navigator/ui_framework/curses_window.py: D107, D200, D202, D205, D209, D400, D401, D403, DAR101, DAR201, WPS110, WPS111, WPS210, WPS213, WPS220, WPS221, WPS229, WPS231, WPS300, WPS306, WPS323, WPS349, WPS407, WPS420, WPS436, WPS450
   src/ansible_navigator/ui_framework/field_button.py: D200, D205, D400, D403, DAR101, DAR201, WPS300, WPS306, WPS502, WPS601
   src/ansible_navigator/ui_framework/field_checks.py: D200, D204, D205, D400, D403, DAR101, DAR201, WPS201, WPS300, WPS306, WPS338, WPS502, WPS601
@@ -148,29 +154,36 @@ per-file-ignores =
   src/ansible_navigator/ui_framework/form_handler_text.py: C409, D107, D200, D205, D300, D400, D403, DAR101, DAR201, Q002, WPS110, WPS223, WPS231, WPS232, WPS300, WPS338, WPS504, WPS510
   src/ansible_navigator/ui_framework/form_handler_working.py: D107, D205, D400, D403, DAR101, DAR201, WPS110, WPS300, WPS602
   src/ansible_navigator/ui_framework/form_presenter.py: C409, D107, D200, D400, D403, DAR201, WPS110, WPS111, WPS201, WPS210, WPS213, WPS214, WPS221, WPS231, WPS237, WPS300, WPS305, WPS331, WPS338, WPS432, WPS440, WPS441, WPS510, WPS602
-  src/ansible_navigator/ui_framework/form.py: D200, D205, D400, D403, DAR101, DAR201, WPS221, WPS300, WPS306, WPS420, WPS601
   src/ansible_navigator/ui_framework/form_utils.py: D200, D205, D400, D403, DAR101, DAR201, WPS110, WPS201, WPS204, WPS210, WPS219, WPS226, WPS231, WPS232, WPS300, WPS432, WPS437, WPS440, WPS441, WPS510, WPS529
-  src/ansible_navigator/ui_framework/__init__.py: D200, D400, WPS201, WPS300, WPS412
+  src/ansible_navigator/ui_framework/form.py: D200, D205, D400, D403, DAR101, DAR201, WPS221, WPS300, WPS306, WPS420, WPS601
   src/ansible_navigator/ui_framework/menu_builder.py: C409, D107, D200, D400, D401, D403, DAR101, DAR201, WPS111, WPS201, WPS210, WPS211, WPS214, WPS221, WPS300, WPS306, WPS337, WPS349, WPS440, WPS441, WPS602
   src/ansible_navigator/ui_framework/sentinels.py: D102, D105, D205, D400, WPS221, WPS306, WPS608
+  src/ansible_navigator/ui_framework/ui_config.py: D205, D400
   src/ansible_navigator/ui_framework/ui.py: C401, C408, C409, D200, D202, D205, D211, D400, D403, DAR101, DAR201, DAR401, WPS110, WPS111, WPS201, WPS210, WPS211, WPS213, WPS214, WPS220, WPS221, WPS223, WPS226, WPS231, WPS232, WPS237, WPS300, WPS305, WPS323, WPS331, WPS338, WPS349, WPS404, WPS407, WPS432, WPS436, WPS437, WPS440, WPS504, WPS510, WPS602
   src/ansible_navigator/ui_framework/utils.py: D200, D205, D400, D403, DAR101, DAR201, WPS100, WPS110, WPS111, WPS210, WPS221, WPS336, WPS349
   src/ansible_navigator/ui_framework/validators.py: B006, D200, D400, D401, D403, DAR101, DAR201, DAR401, S311, WPS110, WPS111, WPS214, WPS221, WPS229, WPS237, WPS300, WPS305, WPS306, WPS334, WPS336, WPS337, WPS404, WPS420, WPS432, WPS504, WPS510, WPS602
   src/ansible_navigator/utils.py: C408, D105, D200, D202, D205, D400, D401, D403, DAR101, DAR201, DAR401, E302, RST304, WPS100, WPS110, WPS111, WPS115, WPS122, WPS201, WPS202, WPS204, WPS210, WPS212, WPS213, WPS221, WPS226, WPS229, WPS231, WPS237, WPS305, WPS323, WPS331, WPS336, WPS338, WPS425, WPS430, WPS432, WPS440, WPS507, WPS510
-  src/ansible_navigator/_version.py: D210, D400, D412, WPS410
-  src/ansible_navigator/_yaml.py: D210, D400, D401, DAR101, DAR201, WPS110, WPS229, WPS433, WPS437, WPS440, WPS458
+  tests/__init__.py: D104
   tests/conftest.py: D210, D400, D401, D403, DAR101, DAR201, DAR301, DAR401, PT003, S103, S404, S603, WPS300, WPS339, WPS432, WPS454
   tests/defaults.py: D200, WPS221
   tests/fixtures/common/collections/ansible_collections/testorg/coll_1/plugins/lookup/lookup_1.py: WPS114, WPS422
   tests/fixtures/common/collections/ansible_collections/testorg/coll_1/plugins/modules/mod_1.py: WPS114, WPS422
   tests/fixtures/common/collections/ansible_collections/testorg/coll_2/plugins/lookup/lookup_2.py: WPS114, WPS422
   tests/fixtures/common/collections/ansible_collections/testorg/coll_2/plugins/modules/mod_2.py: WPS114, WPS422
+  tests/integration/__init__.py: D104
   tests/integration/_action_run_test.py: D107, D205, D400, D401, D403, DAR101, DAR201, DAR401, N817, WPS110, WPS111, WPS201, WPS210, WPS211, WPS305, WPS306, WPS347
+  tests/integration/_cli2runner.py: D200, D400, D401, D403, DAR101, DAR401, WPS115, WPS211, WPS214, WPS226, WPS306, WPS338, WPS454
+  tests/integration/_common.py: B005, D103, D200, D400, D401, D403, DAR101, DAR201, DAR401, WPS210, WPS211, WPS231, WPS300, WPS305, WPS440
+  tests/integration/_interactions.py: D200, D204, D400, D403, DAR101, DAR201, WPS110, WPS115, WPS305, WPS336, WPS437, WPS503
+  tests/integration/_tmux_session.py: D105, D107, D205, D400, D403, DAR101, DAR201, DAR401, WPS110, WPS210, WPS211, WPS213, WPS220, WPS221, WPS226, WPS231, WPS232, WPS300, WPS305, WPS306, WPS436, WPS440
+  tests/integration/actions/__init__.py: D104
+  tests/integration/actions/collections/__init__.py: D104
   tests/integration/actions/collections/base.py: D200, D202, D400, D403, DAR101, DAR301, DAR401, PT005, S101, WPS110, WPS115, WPS210, WPS211, WPS300, WPS305, WPS306, WPS336, WPS337, WPS338, WPS436, WPS602
   tests/integration/actions/collections/test_direct_interactive_ee.py: D200, D400, PT006, WPS115, WPS226, WPS300
   tests/integration/actions/collections/test_direct_interactive_noee.py: D200, D400, PT006, WPS115, WPS226, WPS300
   tests/integration/actions/collections/test_welcome_interactive_ee.py: D200, D400, PT006, WPS115, WPS226, WPS300
   tests/integration/actions/collections/test_welcome_interactive_noee.py: D200, D400, PT006, WPS115, WPS226, WPS300
+  tests/integration/actions/config/__init__.py: D104
   tests/integration/actions/config/base.py: D200, D202, D400, D403, DAR101, DAR301, DAR401, S101, WPS110, WPS111, WPS115, WPS210, WPS231, WPS300, WPS305, WPS306, WPS336, WPS337, WPS432, WPS436
   tests/integration/actions/config/test_direct_interactive_ee.py: D200, D400, WPS115, WPS300, WPS436
   tests/integration/actions/config/test_direct_interactive_noee.py: D200, D400, WPS115, WPS300, WPS436
@@ -179,57 +192,63 @@ per-file-ignores =
   tests/integration/actions/config/test_welcome_interactive_noee.py: D200, D400, WPS115, WPS300, WPS436
   tests/integration/actions/config/test_welcome_interactive_param_use.py: D200, D400, WPS115, WPS300, WPS436
   tests/integration/actions/config/test_welcome_interactive_specified_config.py: D200, D400, WPS115, WPS300, WPS336, WPS436
+  tests/integration/actions/doc/__init__.py: D104
   tests/integration/actions/doc/base.py: D200, D400, D403, DAR101, DAR301, DAR401, S101, WPS110, WPS115, WPS210, WPS211, WPS220, WPS231, WPS232, WPS300, WPS305, WPS306, WPS335, WPS336, WPS337, WPS432, WPS436, WPS441, WPS602
   tests/integration/actions/doc/test_direct_interactive_ee.py: D200, D400, PT006, WPS115, WPS300, WPS326
   tests/integration/actions/doc/test_direct_interactive_noee.py: D200, D400, PT006, WPS115, WPS300
   tests/integration/actions/doc/test_stdout.py: D200, D400, PT006, WPS114, WPS115, WPS202, WPS226, WPS300, WPS326
   tests/integration/actions/doc/test_welcome_interactive_ee.py: D200, D400, PT006, WPS115, WPS300, WPS326
   tests/integration/actions/doc/test_welcome_interactive_noee.py: D200, D400, PT006, WPS115, WPS300
+  tests/integration/actions/images/__init__.py: D104
   tests/integration/actions/images/base.py: D200, D202, D400, D403, DAR101, DAR301, DAR401, S101, WPS110, WPS115, WPS210, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436
   tests/integration/actions/images/test_direct_interactive_ee.py: D200, D400, WPS115, WPS300, WPS436
   tests/integration/actions/images/test_direct_interactive_noee.py: D200, D400, WPS115, WPS300, WPS436
   tests/integration/actions/images/test_welcome_interactive_ee.py: D200, D400, WPS115, WPS300, WPS436
   tests/integration/actions/images/test_welcome_interactive_noee.py: D200, D400, WPS115, WPS300, WPS436
+  tests/integration/actions/inventory/__init__.py: D104
   tests/integration/actions/inventory/base.py: D200, D201, D400, D403, DAR101, DAR301, DAR401, S101, WPS110, WPS115, WPS210, WPS226, WPS231, WPS232, WPS300, WPS306, WPS336, WPS337, WPS432, WPS436, WPS602
   tests/integration/actions/inventory/test_direct_interactive_ee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/inventory/test_direct_interactive_noee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/inventory/test_stdout_tmux.py: D400, D403, DAR101, DAR201, WPS110, WPS115, WPS226, WPS300, WPS305, WPS436
   tests/integration/actions/inventory/test_welcome_interactive_ee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/inventory/test_welcome_interactive_noee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
+  tests/integration/actions/replay/__init__.py: D104
   tests/integration/actions/replay/base.py: D200, D201, D400, D403, DAR101, DAR301, S101, WPS110, WPS115, WPS211, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436, WPS602
   tests/integration/actions/replay/test_direct_interactive_ee.py: D200, D400, PT006, WPS115, WPS226, WPS300, WPS305, WPS326
   tests/integration/actions/replay/test_direct_interactive_noee.py: D200, D400, PT006, WPS115, WPS226, WPS300, WPS305
   tests/integration/actions/replay/test_welcome_interactive_ee.py: D200, D400, PT006, WPS115, WPS226, WPS300, WPS305
   tests/integration/actions/replay/test_welcome_interactive_noee.py: D200, D400, PT006, WPS115, WPS226, WPS300, WPS305
+  tests/integration/actions/run/__init__.py: D104
   tests/integration/actions/run/base.py: D200, D202, D400, D403, DAR101, DAR301, S101, WPS110, WPS115, WPS210, WPS220, WPS226, WPS231, WPS232, WPS300, WPS306, WPS335, WPS336, WPS337, WPS432, WPS436, WPS602
   tests/integration/actions/run/test_direct_interactive_ee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/run/test_direct_interactive_noee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/run/test_stdout_tmux.py: D210, D400, D403, DAR101, DAR201, WPS110, WPS115, WPS226, WPS300, WPS305, WPS436
   tests/integration/actions/run/test_welcome_interactive_ee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/run/test_welcome_interactive_noee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
+  tests/integration/actions/stdout/__init__.py: D104
   tests/integration/actions/stdout/base.py: D200, D201, D400, D403, DAR101, DAR301, S101, WPS110, WPS115, WPS211, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436, WPS602
   tests/integration/actions/stdout/test_direct_interactive_ee.py: D200, D400, PT006, WPS115, WPS226, WPS300, WPS305, WPS326
   tests/integration/actions/stdout/test_direct_interactive_noee.py: D200, D400, PT006, WPS115, WPS226, WPS300, WPS305, WPS326
   tests/integration/actions/stdout/test_welcome_interactive_ee.py: D200, D400, PT006, WPS115, WPS226, WPS300, WPS305, WPS326
   tests/integration/actions/stdout/test_welcome_interactive_noee.py: D200, D400, PT006, WPS115, WPS226, WPS300, WPS305
+  tests/integration/actions/templar/__init__.py: D104
   tests/integration/actions/templar/base.py: D200, D202, D400, D403, DAR101, DAR301, S101, WPS110, WPS115, WPS210, WPS220, WPS231, WPS232, WPS300, WPS306, WPS335, WPS336, WPS337, WPS432, WPS436, WPS602
   tests/integration/actions/templar/test_direct_interactive_ee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/templar/test_direct_interactive_noee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/templar/test_welcome_interactive_ee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/templar/test_welcome_interactive_noee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
-  tests/integration/_cli2runner.py: D200, D400, D401, D403, DAR101, DAR401, WPS115, WPS211, WPS214, WPS226, WPS306, WPS338, WPS454
-  tests/integration/_common.py: B005, D103, D200, D400, D401, D403, DAR101, DAR201, DAR401, WPS210, WPS211, WPS231, WPS300, WPS305, WPS440
   tests/integration/conftest.py: D205, D400, D401, D403, DAR101, DAR201, DAR301, PT001, PT003, PT004, PT022, S108, WPS300, WPS407, WPS433, WPS436
-  tests/integration/_interactions.py: D200, D204, D400, D403, DAR101, DAR201, WPS110, WPS115, WPS305, WPS336, WPS437, WPS503
   tests/integration/test_execution_environment_image.py: D200, D205, D400, D403, DAR101, S101, WPS110, WPS111, WPS115, WPS210, WPS211, WPS220, WPS221, WPS226, WPS300, WPS301, WPS305, WPS436
   tests/integration/test_execution_environment.py: D200, D205, D400, D403, DAR101, S101, WPS110, WPS111, WPS115, WPS210, WPS211, WPS220, WPS221, WPS300, WPS301, WPS305, WPS436
   tests/integration/test_pass_environment_variable.py: D200, D205, D400, D403, DAR101, S101, WPS110, WPS111, WPS115, WPS210, WPS211, WPS220, WPS221, WPS226, WPS300, WPS301, WPS305, WPS436
   tests/integration/test_set_environment_variable.py: D200, D205, D400, D403, DAR101, S101, WPS110, WPS111, WPS115, WPS210, WPS211, WPS220, WPS221, WPS300, WPS301, WPS305, WPS436
   tests/integration/test_stdout_exit_codes.py: D200, D400, D403, DAR101, DAR201, S101, WPS110, WPS226, WPS300, WPS305
-  tests/integration/_tmux_session.py: D105, D107, D205, D400, D403, DAR101, DAR201, DAR401, WPS110, WPS210, WPS211, WPS213, WPS220, WPS221, WPS226, WPS231, WPS232, WPS300, WPS305, WPS306, WPS436, WPS440
+  tests/unit/__init__.py: D104
+  tests/unit/actions/__init__.py: D104
   tests/unit/actions/test_config.py: D200, D400, D403, S101, WPS110, WPS204, WPS218, WPS221, WPS226, WPS305
   tests/unit/actions/test_inventory.py: D200, D400, D403, S101, WPS110, WPS204, WPS218, WPS221, WPS226, WPS305
   tests/unit/actions/test_run.py: D200, D400, DAR101, DAR201, N813, PT019, S101, S108, WPS110, WPS121, WPS122, WPS201, WPS226, WPS237, WPS305, WPS425, WPS432, WPS437
+  tests/unit/configuration_subsystem/__init__.py: D104
   tests/unit/configuration_subsystem/conftest.py: D200, D400, D403, DAR101, DAR201, WPS110, WPS201, WPS210, WPS300, WPS436
   tests/unit/configuration_subsystem/data.py: D205, D400, D403, DAR101, DAR201, S108, WPS226, WPS331, WPS407
   tests/unit/configuration_subsystem/defaults.py: D200, D400, WPS300
@@ -244,6 +263,7 @@ per-file-ignores =
   tests/unit/configuration_subsystem/test_previous_cli.py: D202, D205, D400, N817, PT019, S101, S108, WPS110, WPS111, WPS121, WPS204, WPS210, WPS218, WPS226, WPS347, WPS440, WPS458, WPS520
   tests/unit/configuration_subsystem/test_sample_configurations.py: D205, D400, S101, WPS219, WPS221, WPS226, WPS428, WPS437
   tests/unit/configuration_subsystem/utils.py: D200, D400, DAR101, DAR201, WPS100, WPS110, WPS305, WPS336, WPS510
+  tests/unit/image_manager/__init__.py: D104
   tests/unit/image_manager/test_image_puller.py: D400, D403, DAR101, DAR201, S101, WPS110, WPS226, WPS300, WPS305
   tests/unit/runner/test_api.py: D200, D202, D400, D403, DAR101, PT006, S101, S108, WPS226, WPS437
   tests/unit/test_cli.py: D200, D202, D205, D400, D403, DAR101, DAR201, PT006, PT019, S101, S108, WPS110, WPS210, WPS226, WPS300, WPS305, WPS360
@@ -252,26 +272,6 @@ per-file-ignores =
   tests/unit/test_utils.py: D200, D202, D400, D403, DAR101, PT006, S101, WPS110, WPS202, WPS221, WPS226, WPS237, WPS305, WPS336, WPS407, WPS430, WPS432
   tests/unit/test_yaml.py: D200, S101, WPS301, WPS436
   tests/unit/ui_framework/test_colorize.py: D200, D205, D209, D400, DAR101, S101, WPS110, WPS204, WPS218, WPS221, WPS226, WPS436
-  src/ansible_navigator/tm_tokenize/__init__.py: D104
-  src/ansible_navigator/ui_framework/curses_defs.py: D200, D400
-  src/ansible_navigator/ui_framework/ui_config.py: D205, D400
-  tests/__init__.py: D104
-  tests/integration/actions/collections/__init__.py: D104
-  tests/integration/actions/config/__init__.py: D104
-  tests/integration/actions/doc/__init__.py: D104
-  tests/integration/actions/images/__init__.py: D104
-  tests/integration/actions/__init__.py: D104
-  tests/integration/actions/inventory/__init__.py: D104
-  tests/integration/actions/replay/__init__.py: D104
-  tests/integration/actions/run/__init__.py: D104
-  tests/integration/actions/stdout/__init__.py: D104
-  tests/integration/actions/templar/__init__.py: D104
-  tests/integration/__init__.py: D104
-  tests/unit/actions/__init__.py: D104
-  tests/unit/configuration_subsystem/__init__.py: D104
-  tests/unit/image_manager/__init__.py: D104
-  tests/unit/__init__.py: D104
-  share/ansible_navigator/utils/__init__.py: D104
 
 # Count the number of occurrences of each error/warning code and print a report:
 statistics = true


### PR DESCRIPTION
Sort the entries in the `flake8` `per_file_ingore` list and add a note asking they are sorted in the future.

This should make it easier to find and add entries in the future in a predictable spot.

No changes were made to any line, just re-odered.
