### PR TITLE
Enable automatic import statement sorting

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,6 +12,8 @@ maintain it and you contribute.
 
 3. code-spell (prevents typos in code)
 
+4. isort (sorts import statements)
+
 ```{note}
 In early development cycles, a decision was made to use black as a formatter
 which is why current pull-requests are required to pass a

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   rev: 5.10.1
   hooks:
   - id: isort
-    stages: ["manual"]
+    name: Sort import statements using isort
 
 - repo: https://github.com/Lucas-C/pre-commit-hooks.git
   rev: v1.1.10
@@ -167,6 +167,7 @@ repos:
     language_version: python3
     additional_dependencies:
     - flake8-2020 >= 1.6.0
+    - flake8-isort >= 4.1.1
   - id: flake8
     alias: flake8-extended
     name: >-


### PR DESCRIPTION
This enables a pre-commit hook to sort all import statements across the project so future contributors do not need to order them in a manner that is consistent with the repository. This should save all of us time and brain cycles during submissions and review.

Because `pre-commit` and `isort` will run automatically for every pull-request, it doesn't even need to be run locally as part of a developer workflow. (but can be with `tox -e lint`, so the changes can be seen locally)

- Remove the `stages: ['manual']` from the precommit entry, which will allow it to run when using `tox -e lint`
- Add `flake8-isort` as a required check after `isort` runs.
- Update contributors guide to reflect the use of isort

(this is a trust and verify approach, trust `isort` will do it's job, verify it did with the `flake8` extention)

This PR is not intended to revisit the current configuration, please log and submit issues and PRs in the future for this.
