### PR TITLE
Move `WPSXXX` errors reported by `lint-vetting` into `per-file-ignores`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -73,19 +73,20 @@ per-file-ignores =
   src/ansible_navigator/__main__.py: RST304, WPS300
   src/ansible_navigator/_version.py: D210, D400, D412, WPS410
   src/ansible_navigator/_yaml.py: D210, D400, D401, DAR101, DAR201, WPS110, WPS229, WPS433, WPS437, WPS440, WPS458
-  src/ansible_navigator/action_runner.py: D107, D200, D400, D403, DAR101, WPS231, WPS300, WPS437
+  src/ansible_navigator/action_runner.py: D107, D200, D400, D403, DAR101, WPS231, WPS300, WPS436, WPS437, WPS450
   src/ansible_navigator/actions/__init__.py: D400, WPS300, WPS410, WPS412, WPS450
-  src/ansible_navigator/actions/_actions.py: D210, D400, D401, DAR101, DAR201, WPS111, WPS202, WPS221, WPS305, WPS407, WPS433, WPS440, WPS458
+  src/ansible_navigator/actions/_actions.py: D210, D400, D401, DAR101, DAR201, WPS111, WPS201, WPS202, WPS210, WPS221, WPS305, WPS323, WPS407, WPS433, WPS440, WPS458
   src/ansible_navigator/actions/back.py: D107, D400, DAR101, WPS115, WPS300, WPS306, WPS323, WPS450
-  src/ansible_navigator/actions/collections.py: C409, C414, D102, D107, D201, D202, D205, D400, D403, DAR101, DAR201, WPS110, WPS111, WPS115, WPS121, WPS122, WPS201, WPS204, WPS210, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS323, WPS336, WPS338, WPS440, WPS441, WPS450, WPS504, WPS505, WPS529
-  src/ansible_navigator/actions/config.py: C405, C409, D107, D201, D202, D205, D400, D403, DAR101, DAR201, DAR401, WPS110, WPS111, WPS115, WPS201, WPS204, WPS210, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS232, WPS300, WPS305, WPS323, WPS331, WPS336, WPS436, WPS440, WPS450, WPS502
+  src/ansible_navigator/actions/collections.py: C409, C414, D102, D107, D201, D202, D205, D400, D403, DAR101, DAR201, WPS110, WPS111, WPS115, WPS121, WPS122, WPS201, WPS204, WPS210, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS323, WPS324, WPS336, WPS338, WPS440, WPS441, WPS450, WPS504, WPS505, WPS529
+  src/ansible_navigator/actions/config.py: C405, C409, D107, D201, D202, D205, D400, D403, DAR101, DAR201, DAR401, WPS110, WPS111, WPS115, WPS201, WPS204, WPS210, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS232, WPS300, WPS305, WPS323, WPS324, WPS331, WPS336, WPS436, WPS440, WPS450, WPS502
   src/ansible_navigator/actions/doc.py: D107, D202, D400, D403, DAR101, DAR201, DAR401, N817, WPS110, WPS111, WPS115, WPS201, WPS210, WPS213, WPS220, WPS221, WPS229, WPS231, WPS232, WPS300, WPS305, WPS323, WPS331, WPS347, WPS450, WPS503
+  src/ansible_navigator/actions/exec.py: WPS115, WPS210, WPS323, WPS450
   src/ansible_navigator/actions/filter.py: D107, D400, DAR101, WPS115, WPS300, WPS306, WPS323, WPS450
   src/ansible_navigator/actions/help_doc.py: D107, D400, DAR101, DAR201, WPS115, WPS300, WPS360, WPS450
   src/ansible_navigator/actions/images.py: D107, D201, D400, D403, DAR101, DAR201, WPS110, WPS111, WPS115, WPS121, WPS122, WPS201, WPS210, WPS212, WPS213, WPS214, WPS221, WPS223, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS323, WPS331, WPS336, WPS338, WPS349, WPS450, WPS504, WPS510, WPS529
   src/ansible_navigator/actions/inventory.py: C409, D102, D107, D202, D205, D400, D403, DAR101, DAR201, N806, WPS110, WPS111, WPS112, WPS115, WPS201, WPS210, WPS212, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS300, WPS305, WPS323, WPS324, WPS331, WPS336, WPS338, WPS450, WPS510, WPS600
   src/ansible_navigator/actions/log.py: D107, D400, DAR101, DAR201, WPS115, WPS231, WPS232, WPS300, WPS360, WPS450
-  src/ansible_navigator/actions/open_file.py: D105, D107, D400, DAR101, DAR201, S605, WPS110, WPS111, WPS115, WPS201, WPS210, WPS221, WPS231, WPS300, WPS306, WPS323, WPS338, WPS436, WPS440, WPS450
+  src/ansible_navigator/actions/open_file.py: D105, D107, D400, DAR101, DAR201, S605, WPS110, WPS111, WPS115, WPS201, WPS210, WPS220, WPS221, WPS231, WPS300, WPS306, WPS323, WPS324, WPS338, WPS436, WPS440, WPS450
   src/ansible_navigator/actions/quit.py: D107, D200, D400, DAR101, DAR201, WPS115, WPS300, WPS306, WPS323, WPS360, WPS450
   src/ansible_navigator/actions/refresh.py: D107, D400, DAR101, WPS115, WPS300, WPS306, WPS450
   src/ansible_navigator/actions/replay.py: D200, D400, WPS115, WPS300, WPS450
@@ -101,9 +102,9 @@ per-file-ignores =
   src/ansible_navigator/actions/stdout.py: D107, D400, DAR101, DAR201, WPS110, WPS115, WPS231, WPS232, WPS300, WPS360, WPS450
   src/ansible_navigator/actions/template.py: D107, D400, DAR101, DAR201, WPS110, WPS111, WPS115, WPS210, WPS213, WPS221, WPS231, WPS232, WPS300, WPS323, WPS360, WPS450
   src/ansible_navigator/actions/welcome.py: D107, D400, DAR101, DAR201, WPS115, WPS300, WPS360, WPS450
-  src/ansible_navigator/actions/write_file.py: D107, D400, DAR101, DAR201, WPS110, WPS111, WPS115, WPS210, WPS221, WPS231, WPS232, WPS300, WPS306, WPS323, WPS436, WPS440, WPS450
+  src/ansible_navigator/actions/write_file.py: D107, D400, DAR101, DAR201, WPS110, WPS111, WPS115, WPS210, WPS221, WPS231, WPS232, WPS300, WPS306, WPS323, WPS324, WPS436, WPS440, WPS450
   src/ansible_navigator/app_public.py: D204, D205, D211, D400, WPS300
-  src/ansible_navigator/app.py: D107, D200, D205, D209, D400, D401, D403, DAR101, DAR201, DAR401, N817, WPS110, WPS111, WPS201, WPS214, WPS221, WPS300, WPS306, WPS338, WPS347, WPS602
+  src/ansible_navigator/app.py: D107, D200, D205, D209, D400, D401, D403, DAR101, DAR201, DAR401, N817, WPS110, WPS111, WPS201, WPS214, WPS221, WPS300, WPS305, WPS306, WPS338, WPS347, WPS602
   src/ansible_navigator/cli.py: B010, D200, D400, D403, DAR101, DAR201, WPS201, WPS210, WPS213, WPS221, WPS229, WPS237, WPS300, WPS305, WPS323, WPS331, WPS336, WPS440
   src/ansible_navigator/command_runner/__init__.py: D210, D400, WPS300, WPS412
   src/ansible_navigator/command_runner/command_runner.py: D107, D400, D403, DAR101, DAR201, S404, S602, WPS110, WPS121, WPS122, WPS229, WPS306, WPS440, WPS602
@@ -111,12 +112,12 @@ per-file-ignores =
   src/ansible_navigator/configuration_subsystem/configurator.py: B010, D200, D202, D205, D400, D401, D403, DAR101, DAR201, N817, WPS110, WPS111, WPS201, WPS210, WPS211, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS232, WPS237, WPS300, WPS305, WPS306, WPS336, WPS337, WPS338, WPS347, WPS436, WPS440, WPS510
   src/ansible_navigator/configuration_subsystem/definitions.py: D200, D204, D400, D401, DAR101, DAR201, DAR401, WPS110, WPS115, WPS221, WPS226, WPS237, WPS300, WPS305, WPS331, WPS338, WPS613
   src/ansible_navigator/configuration_subsystem/navigator_configuration.py: D200, D205, D400, DAR201, N812, N817, WPS111, WPS201, WPS204, WPS221, WPS226, WPS237, WPS300, WPS305, WPS347, WPS436
-  src/ansible_navigator/configuration_subsystem/navigator_post_processor.py: B009, B014, D200, D400, DAR101, DAR201, N817, WPS111, WPS201, WPS204, WPS210, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS306, WPS336, WPS337, WPS338, WPS347, WPS420, WPS440, WPS441, WPS448, WPS510, WPS602
+  src/ansible_navigator/configuration_subsystem/navigator_post_processor.py: B009, B014, D200, D400, DAR101, DAR201, N817, WPS111, WPS115, WPS201, WPS204, WPS210, WPS213, WPS214, WPS220, WPS221, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS306, WPS336, WPS337, WPS338, WPS347, WPS420, WPS440, WPS441, WPS448, WPS510, WPS602
   src/ansible_navigator/configuration_subsystem/parser.py: D107, D200, D400, DAR101, DAR201, N817, WPS111, WPS221, WPS237, WPS300, WPS305, WPS306, WPS323, WPS336, WPS347, WPS436, WPS450, WPS504, WPS507, WPS602
   src/ansible_navigator/image_manager/__init__.py: D210, D400, WPS300, WPS412
   src/ansible_navigator/image_manager/inspector.py: D107, D400, D403, DAR101, DAR201, WPS110, WPS114, WPS210, WPS221, WPS300, WPS305, WPS306, WPS602
   src/ansible_navigator/image_manager/puller.py: D107, D400, D403, DAR201, DAR401, S404, S603, WPS110, WPS111, WPS213, WPS214, WPS221, WPS226, WPS229, WPS231, WPS237, WPS300, WPS305, WPS306, WPS338
-  src/ansible_navigator/initialization.py: D202, D205, D400, D403, DAR101, DAR201, N812, N817, WPS110, WPS111, WPS201, WPS204, WPS210, WPS213, WPS221, WPS226, WPS237, WPS300, WPS301, WPS305, WPS336, WPS347, WPS436, WPS504, WPS529, WPS609
+  src/ansible_navigator/initialization.py: D202, D205, D400, D403, DAR101, DAR201, N812, N817, WPS110, WPS111, WPS201, WPS204, WPS210, WPS213, WPS221, WPS226, WPS237, WPS300, WPS301, WPS305, WPS336, WPS347, WPS414, WPS436, WPS504, WPS529, WPS609
   src/ansible_navigator/runner/__init__.py: D200, D400, WPS300, WPS412
   src/ansible_navigator/runner/ansible_config.py: C815, D205, D400, WPS300
   src/ansible_navigator/runner/ansible_doc.py: C815, D205, D400, DAR101, DAR201, WPS211, WPS221, WPS234, WPS300
@@ -172,7 +173,7 @@ per-file-ignores =
   tests/fixtures/common/collections/ansible_collections/testorg/coll_2/plugins/lookup/lookup_2.py: WPS114, WPS422
   tests/fixtures/common/collections/ansible_collections/testorg/coll_2/plugins/modules/mod_2.py: WPS114, WPS422
   tests/integration/__init__.py: D104
-  tests/integration/_action_run_test.py: D107, D205, D400, D401, D403, DAR101, DAR201, DAR401, N817, WPS110, WPS111, WPS201, WPS210, WPS211, WPS305, WPS306, WPS347
+  tests/integration/_action_run_test.py: D107, D205, D400, D401, D403, DAR101, DAR201, DAR401, N817, WPS110, WPS111, WPS201, WPS210, WPS211, WPS305, WPS306, WPS316, WPS347
   tests/integration/_cli2runner.py: D200, D400, D401, D403, DAR101, DAR401, WPS115, WPS211, WPS214, WPS226, WPS306, WPS338, WPS454
   tests/integration/_common.py: B005, D103, D200, D400, D401, D403, DAR101, DAR201, DAR401, WPS210, WPS211, WPS231, WPS300, WPS305, WPS440
   tests/integration/_interactions.py: D200, D204, D400, D403, DAR101, DAR201, WPS110, WPS115, WPS305, WPS336, WPS437, WPS503
@@ -200,8 +201,11 @@ per-file-ignores =
   tests/integration/actions/doc/test_stdout.py: D200, D400, PT006, WPS114, WPS115, WPS202, WPS226, WPS300, WPS326
   tests/integration/actions/doc/test_welcome_interactive_ee.py: D200, D400, PT006, WPS115, WPS300, WPS326
   tests/integration/actions/doc/test_welcome_interactive_noee.py: D200, D400, PT006, WPS115, WPS300
+  tests/integration/actions/exec/base.py: S101, WPS201, WPS210, WPS305, WPS436
+  tests/integration/actions/exec/test_stdout_config_cli.py: WPS305, WPS436
+  tests/integration/actions/exec/test_stdout_config_file.py: WPS305, WPS436
   tests/integration/actions/images/__init__.py: D104
-  tests/integration/actions/images/base.py: D200, D202, D400, D403, DAR101, DAR301, DAR401, S101, WPS110, WPS115, WPS210, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436
+  tests/integration/actions/images/base.py: D200, D202, D400, D403, DAR101, DAR301, DAR401, S101, WPS110, WPS115, WPS210, WPS221, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436, WPS602
   tests/integration/actions/images/test_direct_interactive_ee.py: D200, D400, WPS115, WPS300, WPS436
   tests/integration/actions/images/test_direct_interactive_noee.py: D200, D400, WPS115, WPS300, WPS436
   tests/integration/actions/images/test_welcome_interactive_ee.py: D200, D400, WPS115, WPS300, WPS436
@@ -214,7 +218,7 @@ per-file-ignores =
   tests/integration/actions/inventory/test_welcome_interactive_ee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/inventory/test_welcome_interactive_noee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/replay/__init__.py: D104
-  tests/integration/actions/replay/base.py: D200, D201, D400, D403, DAR101, DAR301, S101, WPS110, WPS115, WPS211, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436, WPS602
+  tests/integration/actions/replay/base.py: D200, D201, D400, D403, DAR101, DAR301, S101, WPS110, WPS115, WPS210, WPS211, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436, WPS602
   tests/integration/actions/replay/test_direct_interactive_ee.py: D200, D400, PT006, WPS115, WPS226, WPS300, WPS305, WPS326
   tests/integration/actions/replay/test_direct_interactive_noee.py: D200, D400, PT006, WPS115, WPS226, WPS300, WPS305
   tests/integration/actions/replay/test_welcome_interactive_ee.py: D200, D400, PT006, WPS115, WPS226, WPS300, WPS305
@@ -227,7 +231,7 @@ per-file-ignores =
   tests/integration/actions/run/test_welcome_interactive_ee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/run/test_welcome_interactive_noee.py: D200, D400, WPS115, WPS300, WPS305, WPS436
   tests/integration/actions/stdout/__init__.py: D104
-  tests/integration/actions/stdout/base.py: D200, D201, D400, D403, DAR101, DAR301, S101, WPS110, WPS115, WPS211, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436, WPS602
+  tests/integration/actions/stdout/base.py: D200, D201, D400, D403, DAR101, DAR301, S101, WPS110, WPS115, WPS210, WPS211, WPS300, WPS305, WPS306, WPS336, WPS337, WPS436, WPS602
   tests/integration/actions/stdout/test_direct_interactive_ee.py: D200, D400, PT006, WPS115, WPS226, WPS300, WPS305, WPS326
   tests/integration/actions/stdout/test_direct_interactive_noee.py: D200, D400, PT006, WPS115, WPS226, WPS300, WPS305, WPS326
   tests/integration/actions/stdout/test_welcome_interactive_ee.py: D200, D400, PT006, WPS115, WPS226, WPS300, WPS305, WPS326
@@ -247,6 +251,7 @@ per-file-ignores =
   tests/unit/__init__.py: D104
   tests/unit/actions/__init__.py: D104
   tests/unit/actions/test_config.py: D200, D400, D403, S101, WPS110, WPS204, WPS218, WPS221, WPS226, WPS305
+  tests/unit/actions/test_exec.py: S101, WPS305, WPS450
   tests/unit/actions/test_inventory.py: D200, D400, D403, S101, WPS110, WPS204, WPS218, WPS221, WPS226, WPS305
   tests/unit/actions/test_run.py: D200, D400, DAR101, DAR201, N813, PT019, S101, S108, WPS110, WPS121, WPS122, WPS201, WPS226, WPS237, WPS305, WPS425, WPS432, WPS437
   tests/unit/configuration_subsystem/__init__.py: D104
@@ -258,19 +263,22 @@ per-file-ignores =
   tests/unit/configuration_subsystem/test_container_engine_auto.py: D200, DAR101, S101, WPS430, WPS520
   tests/unit/configuration_subsystem/test_entries_sanity.py: D200, D400, DAR101, N817, S101, WPS110, WPS111, WPS202, WPS221, WPS226, WPS300, WPS347
   tests/unit/configuration_subsystem/test_fixture_sanity.py: D205, D400, S101, WPS110, WPS210, WPS300, WPS436
+  tests/unit/configuration_subsystem/test_internals.py: S101, WPS430
   tests/unit/configuration_subsystem/test_invalid_params.py: D200, D202, D400, DAR101, PT006, PT019, S101, WPS110, WPS202, WPS204, WPS226, WPS300, WPS305, WPS420, WPS430, WPS510
   tests/unit/configuration_subsystem/test_mode_subcommand_action.py: D205, D400, S101, WPS226, WPS336, WPS437, WPS510
-  tests/unit/configuration_subsystem/test_precedence.py: D205, D400, DAR101, N817, PT006, PT019, S101, WPS110, WPS111, WPS118, WPS201, WPS210, WPS211, WPS218, WPS226, WPS231, WPS232, WPS300, WPS347, WPS440, WPS458, WPS520, WPS529
-  tests/unit/configuration_subsystem/test_previous_cli.py: D202, D205, D400, N817, PT019, S101, S108, WPS110, WPS111, WPS121, WPS204, WPS210, WPS218, WPS226, WPS347, WPS440, WPS458, WPS520
+  tests/unit/configuration_subsystem/test_navigator_post_processor.py: S101, WPS226, WPS317
+  tests/unit/configuration_subsystem/test_precedence.py: D205, D400, DAR101, N817, PT006, PT019, S101, WPS110, WPS111, WPS118, WPS201, WPS210, WPS211, WPS218, WPS221, WPS226, WPS231, WPS232, WPS300, WPS347, WPS440, WPS458, WPS520, WPS529
+  tests/unit/configuration_subsystem/test_previous_cli.py: D202, D205, D400, N817, PT019, S101, S108, WPS110, WPS111, WPS121, WPS201, WPS204, WPS210, WPS218, WPS226, WPS347, WPS440, WPS458, WPS520
   tests/unit/configuration_subsystem/test_sample_configurations.py: D205, D400, S101, WPS219, WPS221, WPS226, WPS428, WPS437
   tests/unit/configuration_subsystem/utils.py: D200, D400, DAR101, DAR201, WPS100, WPS110, WPS305, WPS336, WPS510
   tests/unit/image_manager/__init__.py: D104
   tests/unit/image_manager/test_image_puller.py: D400, D403, DAR101, DAR201, S101, WPS110, WPS226, WPS300, WPS305
-  tests/unit/runner/test_api.py: D200, D202, D400, D403, DAR101, PT006, S101, S108, WPS226, WPS437
-  tests/unit/test_cli.py: D200, D202, D205, D400, D403, DAR101, DAR201, PT006, PT019, S101, S108, WPS110, WPS210, WPS226, WPS300, WPS305, WPS360
+  tests/unit/runner/test_api.py: D200, D202, D400, D403, DAR101, PT006, S101, S108, WPS226, WPS317, WPS437
+  tests/unit/test_circular_imports.py: WPS210, WPS305, WPS317
+  tests/unit/test_cli.py: D200, D202, D205, D400, D403, DAR101, DAR201, PT006, PT019, S101, S108, WPS110, WPS210, WPS226, WPS300, WPS305, WPS317, WPS360
   tests/unit/test_image_introspection.py: D200, D400, D403, DAR101, DAR201, S101, WPS111, WPS204, WPS210, WPS218, WPS221, WPS226, WPS305
   tests/unit/test_log_append.py: D200, D400, D403, DAR101, S101, WPS324, WPS430
-  tests/unit/test_utils.py: D200, D202, D400, D403, DAR101, PT006, S101, WPS110, WPS202, WPS221, WPS226, WPS237, WPS305, WPS336, WPS407, WPS430, WPS432
+  tests/unit/test_utils.py: D200, D202, D400, D403, DAR101, PT006, S101, WPS110, WPS202, WPS221, WPS226, WPS237, WPS305, WPS317, WPS336, WPS407, WPS430, WPS432
   tests/unit/test_yaml.py: D200, S101, WPS301, WPS436
   tests/unit/ui_framework/test_colorize.py: D200, D205, D209, D400, DAR101, S101, WPS110, WPS204, WPS218, WPS221, WPS226, WPS436
 


### PR DESCRIPTION
When running `tox -e lint-vetting` a number of errors are reported by the wemake python style guide.

This moves those errors into the `per-file-ignore` list within the `flake8` configuration file.

No attempt was made to review or remediate the errors as WPS is just being vetted.

(`S101` was also added to account for #792 where needed when a per-file addition was newly added)

This should make it easier for users of `tox -e lint-vetting` to identify errors from linters being vetted for the changes they are making without needing to parse all errors that previously existed in the code.

Follow up PRs should be expected to migrate some per file ignores into the extended ignore list)

The list of errors was
```
src/ansible_navigator/action_runner.py:17:5: WPS436 Found protected module import: _curses
src/ansible_navigator/action_runner.py:17:5: WPS450 Found protected object import: _CursesWindow
src/ansible_navigator/actions/_actions.py:0:1: WPS201 Found module with too many imports: 13 > 12
src/ansible_navigator/actions/_actions.py:105:22: WPS323 Found `%` string formatting
src/ansible_navigator/actions/_actions.py:98:1: WPS210 Found too many local variables: 6 > 5
src/ansible_navigator/actions/collections.py:335:5: WPS324 Found inconsistent `return` statement
src/ansible_navigator/actions/config.py:286:5: WPS324 Found inconsistent `return` statement
src/ansible_navigator/actions/exec.py:14:1: WPS450 Found protected object import: _actions
src/ansible_navigator/actions/exec.py:45:5: WPS115 Found upper-case constant in a class: KEGEX
src/ansible_navigator/actions/exec.py:66:5: WPS210 Found too many local variables: 6 > 5
src/ansible_navigator/actions/exec.py:83:17: WPS323 Found `%` string formatting
src/ansible_navigator/actions/open_file.py:104:25: WPS220 Found too deep nesting: 24 > 20
src/ansible_navigator/actions/open_file.py:56:5: WPS324 Found inconsistent `return` statement
src/ansible_navigator/actions/open_file.py:90:25: WPS220 Found too deep nesting: 24 > 20
src/ansible_navigator/actions/open_file.py:99:25: WPS220 Found too deep nesting: 24 > 20
src/ansible_navigator/actions/write_file.py:28:5: WPS324 Found inconsistent `return` statement
src/ansible_navigator/app.py:86:17: WPS305 Found `f` string
src/ansible_navigator/app.py:89:17: WPS305 Found `f` string
src/ansible_navigator/configuration_subsystem/navigator_post_processor.py:62:5: WPS115 Found upper-case constant in a class: Z
src/ansible_navigator/initialization.py:166:5: WPS414 Found incorrect unpacking target
src/ansible_navigator/initialization.py:166:5: WPS414 Found incorrect unpacking target
tests/integration/_action_run_test.py:144:9: WPS316 Found context manager with too many assignments
tests/integration/actions/exec/base.py:0:1: WPS201 Found module with too many imports: 13 > 12
tests/integration/actions/exec/base.py:100:23: WPS305 Found `f` string
tests/integration/actions/exec/base.py:111:56: WPS305 Found `f` string
tests/integration/actions/exec/base.py:14:1: WPS436 Found protected module import: _common
tests/integration/actions/exec/base.py:15:1: WPS436 Found protected module import: _common
tests/integration/actions/exec/base.py:16:1: WPS436 Found protected module import: _interactions
tests/integration/actions/exec/base.py:17:1: WPS436 Found protected module import: _interactions
tests/integration/actions/exec/base.py:18:1: WPS436 Found protected module import: _tmux_session
tests/integration/actions/exec/base.py:55:5: WPS210 Found too many local variables: 9 > 5
tests/integration/actions/exec/test_stdout_config_cli.py:5:1: WPS436 Found protected module import: _interactions
tests/integration/actions/exec/test_stdout_config_cli.py:6:1: WPS436 Found protected module import: _interactions
tests/integration/actions/exec/test_stdout_config_cli.py:71:12: WPS305 Found `f` string
tests/integration/actions/exec/test_stdout_config_cli.py:7:1: WPS436 Found protected module import: _interactions
tests/integration/actions/exec/test_stdout_config_cli.py:8:1: WPS436 Found protected module import: _interactions
tests/integration/actions/exec/test_stdout_config_file.py:5:1: WPS436 Found protected module import: _interactions
tests/integration/actions/exec/test_stdout_config_file.py:55:12: WPS305 Found `f` string
tests/integration/actions/exec/test_stdout_config_file.py:6:1: WPS436 Found protected module import: _interactions
tests/integration/actions/exec/test_stdout_config_file.py:7:1: WPS436 Found protected module import: _interactions
tests/integration/actions/exec/test_stdout_config_file.py:8:1: WPS436 Found protected module import: _interactions
tests/integration/actions/images/base.py:17:1: WPS221 Found line with high Jones Complexity: 16 > 14
tests/integration/actions/images/base.py:50:5: WPS602 Found using `@staticmethod`
tests/integration/actions/replay/base.py:41:5: WPS210 Found too many local variables: 6 > 5
tests/integration/actions/stdout/base.py:41:5: WPS210 Found too many local variables: 6 > 5
tests/unit/actions/test_exec.py:27:12: WPS305 Found `f` string
tests/unit/actions/test_exec.py:8:1: WPS450 Found protected object import: _generate_command
tests/unit/configuration_subsystem/test_internals.py:31:5: WPS430 Found nested function: getcwd
tests/unit/configuration_subsystem/test_navigator_post_processor.py:0:1: WPS226 Found string literal over-use: /bar > 3
tests/unit/configuration_subsystem/test_navigator_post_processor.py:0:1: WPS226 Found string literal over-use: /foo > 3
tests/unit/configuration_subsystem/test_navigator_post_processor.py:0:1: WPS226 Found string literal over-use: test_option > 3
tests/unit/configuration_subsystem/test_navigator_post_processor.py:13:2: WPS317 Found incorrect multi-line parameters
tests/unit/configuration_subsystem/test_precedence.py:146:9: WPS221 Found line with high Jones Complexity: 15 > 14
tests/unit/configuration_subsystem/test_previous_cli.py:0:1: WPS201 Found module with too many imports: 13 > 12
tests/unit/runner/test_api.py:9:2: WPS317 Found incorrect multi-line parameters
tests/unit/test_circular_imports.py:101:9: WPS305 Found `f` string
tests/unit/test_circular_imports.py:44:1: WPS210 Found too many local variables: 7 > 5
tests/unit/test_circular_imports.py:67:35: WPS317 Found incorrect multi-line parameters
tests/unit/test_circular_imports.py:69:24: WPS305 Found `f` string
tests/unit/test_cli.py:16:2: WPS317 Found incorrect multi-line parameters
tests/unit/test_utils.py:61:2: WPS317 Found incorrect multi-line parameters
tests/unit/test_utils.py:88:2: WPS317 Found incorrect multi-line parameters
```

and the output of `tox -e lint-vetting` after:
```diff
1     C812 missing trailing comma
1     RST304 Unknown interpreted text role "mod".
13    S101 Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
1     S404 Consider possible security implications associated with the subprocess module.
1     S603 subprocess call - check for execution of untrusted input.
2     S604 Function call with shell=True parameter identified, possible security issue.
- 2     WPS115 Found upper-case constant in a class: KEGEX
- 3     WPS201 Found module with too many imports: 13 > 12
- 6     WPS210 Found too many local variables: 6 > 5
- 3     WPS220 Found too deep nesting: 24 > 20
- 2     WPS221 Found line with high Jones Complexity: 16 > 14
- 3     WPS226 Found string literal over-use: test_option > 3
- 9     WPS305 Found `f` string
- 1     WPS316 Found context manager with too many assignments
- 6     WPS317 Found incorrect multi-line parameters
- 2     WPS323 Found `%` string formatting
- 4     WPS324 Found inconsistent `return` statement
- 2     WPS414 Found incorrect unpacking target
- 1     WPS430 Found nested function: getcwd
- 14    WPS436 Found protected module import: _curses
- 3     WPS450 Found protected object import: _CursesWindow
- 1     WPS602 Found using `@staticmethod`
```
