### PR TITLE
Enable `useless-suppression` and remove errors that had been uselessly suppressed for `pylint` 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -226,4 +226,30 @@ repos:
     stages:
     - manual
 
+- repo: local
+  hooks:
+  - id: pylint-useless-supression
+    language: python
+    language_version: python3.10
+    additional_dependencies:
+      - "pylint"
+      - "pytest"
+      - astroid==2.9.0
+      - ansible_runner
+      - ansible-core
+      - libtmux
+      - sphinx
+    name: PyLint (useless-suppression)
+    files: \.py$
+    entry: python -m pylint
+    args:
+    - --disable=all
+    - --enable=useless-supression
+    - docs/
+    - share/
+    - src/
+    - tests/
+    pass_filenames: false
+    stages:
+    - manual
 ...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -225,4 +225,5 @@ repos:
     pass_filenames: false
     stages:
     - manual
+
 ...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -225,31 +225,4 @@ repos:
     pass_filenames: false
     stages:
     - manual
-
-- repo: local
-  hooks:
-  - id: pylint-useless-supression
-    language: python
-    language_version: python3.10
-    additional_dependencies:
-      - "pylint"
-      - "pytest"
-      - astroid==2.9.0
-      - ansible_runner
-      - ansible-core
-      - libtmux
-      - sphinx
-    name: PyLint (useless-suppression)
-    files: \.py$
-    entry: python -m pylint
-    args:
-    - --disable=all
-    - --enable=useless-supression
-    - docs/
-    - share/
-    - src/
-    - tests/
-    pass_filenames: false
-    stages:
-    - manual
 ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ skip_glob = ["tests/fixtures/common/collections*"] # Skip ansible content due to
       "fixme",
       "unsubscriptable-object",
     ]
+    enable = "useless-suppression"
 
     [tool.pylint.format]
     max-line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,9 @@ skip_glob = ["tests/fixtures/common/collections*"] # Skip ansible content due to
       "fixme",
       "unsubscriptable-object",
     ]
-    enable = "useless-suppression"
+    enable = [
+      "useless-suppression",  # Identify unneeded pylint disable statements
+    ]
 
     [tool.pylint.format]
     max-line-length = 100

--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -200,7 +200,6 @@ class CollectionCatalog:
 
 def worker(pending_queue: multiprocessing.Queue, completed_queue: multiprocessing.Queue) -> None:
     """extract a doc from a plugin, place in completed q"""
-    # pylint: disable=ungrouped-imports
     # pylint: disable=import-outside-toplevel
 
     # load the fragment_loader _after_ the path is set

--- a/src/ansible_navigator/action_runner.py
+++ b/src/ansible_navigator/action_runner.py
@@ -28,7 +28,6 @@ THEME = "dark_vs.json"
 
 
 class ActionRunner(App):
-
     """A single action runner."""
 
     def __init__(self, args: ApplicationConfiguration) -> None:

--- a/src/ansible_navigator/action_runner.py
+++ b/src/ansible_navigator/action_runner.py
@@ -14,7 +14,7 @@ from .ui_framework import UserInterface
 
 
 if TYPE_CHECKING:
-    from _curses import _CursesWindow  # pylint: disable=no-name-in-module
+    from _curses import _CursesWindow
 
     Window = _CursesWindow
 else:
@@ -29,8 +29,6 @@ THEME = "dark_vs.json"
 
 class ActionRunner(App):
 
-    # pylint: disable=too-few-public-methods
-    # pylint: disable=too-many-instance-attributes
     """A single action runner."""
 
     def __init__(self, args: ApplicationConfiguration) -> None:

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -77,9 +77,6 @@ def filter_content_keys(obj: Dict[Any, Any]) -> Dict[Any, Any]:
 class Action(App):
     """:doc"""
 
-    # pylint:disable=too-few-public-methods
-    # pylint:disable=too-many-instance-attributes
-
     KEGEX = r"^collections(\s(?P<params>.*))?$"
 
     def __init__(self, args: ApplicationConfiguration):
@@ -95,7 +92,6 @@ class Action(App):
         self._calling_app.update()
 
     def run(self, interaction: Interaction, app: AppPublic) -> Union[Interaction, None]:
-        # pylint: disable=too-many-branches
         """Handle :doc
 
         :param interaction: The interaction from the user

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -84,8 +84,6 @@ def filter_content_keys(obj: Dict[Any, Any]) -> Dict[Any, Any]:
 class Action(App):
     """:doc"""
 
-    # pylint:disable=too-few-public-methods
-
     KEGEX = r"^config(\s(?P<params>.*))?$"
 
     def __init__(self, args: ApplicationConfiguration):
@@ -95,7 +93,6 @@ class Action(App):
         self._runner: Union[AnsibleConfig, Command]
 
     def run(self, interaction: Interaction, app: AppPublic) -> Union[Interaction, None]:
-        # pylint: disable=too-many-branches
         """Handle :doc
 
         :param interaction: The interaction from the user
@@ -287,7 +284,6 @@ class Action(App):
         """yaml load the list, and parse the dump
         merge dump int list
         """
-        # pylint: disable=too-many-branches
         try:
             parsed = yaml.load(list_output, Loader=Loader)
             self._logger.debug("yaml loading list output succeeded")

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -28,8 +28,6 @@ from . import _actions as actions
 class Action(App):
     """:doc"""
 
-    # pylint:disable=too-few-public-methods
-
     KEGEX = r"^d(?:oc)?(\s(?P<params>.*))?$"
 
     def __init__(self, args: ApplicationConfiguration):
@@ -59,7 +57,6 @@ class Action(App):
         return heading
 
     def run(self, interaction: Interaction, app: AppPublic) -> Union[Interaction, None]:
-        # pylint: disable=too-many-branches
         """Handle :doc
 
         :param interaction: The interaction from the user

--- a/src/ansible_navigator/actions/exec.py
+++ b/src/ansible_navigator/actions/exec.py
@@ -40,8 +40,6 @@ def _generate_command(exec_command: str, exec_shell: bool) -> GeneratedCommand:
 class Action(App):
     """Run the :exec subcommand."""
 
-    # pylint: disable=too-few-public-methods
-
     KEGEX = "^e(?:xec)?$"
 
     def __init__(self, args: ApplicationConfiguration):
@@ -64,8 +62,6 @@ class Action(App):
         return None
 
     def _run_runner(self) -> Optional[Tuple]:
-        # pylint: disable=too-many-branches
-        # pylint: disable=too-many-statements
         """Spin up runner.
 
         :return: The stdout, stderr and return code from runner

--- a/src/ansible_navigator/actions/help_doc.py
+++ b/src/ansible_navigator/actions/help_doc.py
@@ -12,8 +12,6 @@ from . import _actions as actions
 class Action(App):
     """:help"""
 
-    # pylint: disable=too-few-public-methods
-
     KEGEX = r"^h(?:elp)?$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -43,8 +43,6 @@ def filter_content_keys(obj: Dict[Any, Any]) -> Dict[Any, Any]:
 class Action(App):
     """:images"""
 
-    # pylint: disable=too-few-public-methods
-
     KEGEX = r"^im(?:ages)?(\s(?P<params>.*))?$"
 
     def __init__(self, args: ApplicationConfiguration):
@@ -416,7 +414,6 @@ class Action(App):
 
     def _parse(self, output) -> Union[Dict, None]:
         """parse the introspection output"""
-        # pylint: disable=too-many-branches
         try:
             if not output.startswith("{"):
                 _warnings, json_str = output.split("{", 1)

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -94,7 +94,6 @@ class Menu(list):
 class Action(App):
     """:inventory"""
 
-    # pylint:disable=too-few-public-methods
     # pylint: disable=too-many-instance-attributes
 
     KEGEX = r"^i(?:nventory)?(\s(?P<params>.*))?$"
@@ -157,7 +156,6 @@ class Action(App):
         self._calling_app.update()
 
     def run(self, interaction: Interaction, app: AppPublic) -> Union[Interaction, None]:
-        # pylint: disable=too-many-branches
         """Handle :inventory
 
         :param interaction: The interaction from the user
@@ -421,7 +419,6 @@ class Action(App):
             if form.cancelled:
                 return
 
-            # pylint: disable=not-an-iterable
             inventories = [
                 field.value
                 for field in form.fields

--- a/src/ansible_navigator/actions/log.py
+++ b/src/ansible_navigator/actions/log.py
@@ -10,8 +10,6 @@ from . import _actions as actions
 class Action(App):
     """:log"""
 
-    # pylint: disable=too-few-public-methods
-
     KEGEX = r"^l(?:og)?$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/actions/open_file.py
+++ b/src/ansible_navigator/actions/open_file.py
@@ -52,7 +52,6 @@ class Action:
             obj = [e for e in obj if menu_filter().search(" ".join(str(v) for v in e.values()))]
         return obj
 
-    # pylint: disable=too-many-branches
     def run(self, interaction: Interaction, app: AppPublic) -> None:
         # pylint: disable=too-many-branches
         # pylint: disable=unused-argument

--- a/src/ansible_navigator/actions/replay.py
+++ b/src/ansible_navigator/actions/replay.py
@@ -7,8 +7,6 @@ from .run import Action as BaseAction
 
 @actions.register
 class Action(BaseAction):
-
-    # pylint: disable=too-many-instance-attributes
     """:replay"""
 
     KEGEX = r"""(?x)

--- a/src/ansible_navigator/actions/rerun.py
+++ b/src/ansible_navigator/actions/rerun.py
@@ -8,9 +8,6 @@ from ..ui_framework import Interaction
 from . import _actions as actions
 
 
-# pylint: disable=protected-access
-
-
 @actions.register
 class Action:
     """:rerun"""

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -254,7 +254,6 @@ class Action(App):
         return self.runner.ansible_runner_instance.rc
 
     def run(self, interaction: Interaction, app: AppPublic) -> Union[Interaction, None]:
-        # pylint: disable=too-many-branches
         """run :run or :replay
 
         :param interaction: The interaction from the user

--- a/src/ansible_navigator/actions/sample_form.py
+++ b/src/ansible_navigator/actions/sample_form.py
@@ -88,14 +88,11 @@ form:
 class Action(App):
     """handle :sample_form"""
 
-    # pylint: disable=too-few-public-methods
-
     KEGEX = r"^sample_form$"
 
     def __init__(self, args: ApplicationConfiguration):
         super().__init__(args=args, logger_name=__name__, name="sample_form")
 
-    # pylint: disable=unused-argument
     def run(self, interaction: Interaction, app: AppPublic) -> Interaction:
         """Handle :doc
 

--- a/src/ansible_navigator/actions/sample_notification.py
+++ b/src/ansible_navigator/actions/sample_notification.py
@@ -31,14 +31,11 @@ form:
 class Action(App):
     """handle :sample_notification"""
 
-    # pylint: disable=too-few-public-methods
-
     KEGEX = r"^sample_notification$"
 
     def __init__(self, args: ApplicationConfiguration):
         super().__init__(args=args, logger_name=__name__, name="sample_form")
 
-    # pylint: disable=unused-argument
     def run(self, interaction: Interaction, app: AppPublic) -> Interaction:
         """Handle :doc
 

--- a/src/ansible_navigator/actions/sample_working.py
+++ b/src/ansible_navigator/actions/sample_working.py
@@ -14,14 +14,11 @@ from . import _actions as actions
 class Action(App):
     """handle :sample_working"""
 
-    # pylint: disable=too-few-public-methods
-
     KEGEX = r"^sample_working$"
 
     def __init__(self, args: ApplicationConfiguration):
         super().__init__(args=args, logger_name=__name__, name="sample_working")
 
-    # pylint: disable=unused-argument
     def run(self, interaction: Interaction, app: AppPublic) -> None:
         """Handle :doc
 

--- a/src/ansible_navigator/actions/select.py
+++ b/src/ansible_navigator/actions/select.py
@@ -7,9 +7,6 @@ from ..ui_framework import Interaction
 from . import _actions as actions
 
 
-# pylint: disable=protected-access
-
-
 @actions.register
 class Action:
     r""":\d+|[0-9]"""

--- a/src/ansible_navigator/actions/stdout.py
+++ b/src/ansible_navigator/actions/stdout.py
@@ -11,8 +11,6 @@ from . import _actions as actions
 class Action(App):
     """:stdout"""
 
-    # pylint: disable=too-few-public-methods
-
     KEGEX = r"^st(?:dout)?$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/actions/template.py
+++ b/src/ansible_navigator/actions/template.py
@@ -18,8 +18,6 @@ from . import _actions as actions
 class Action(App):
     """{{ }}"""
 
-    # pylint: disable=too-few-public-methods
-
     KEGEX = r"^{{.*}}$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/actions/welcome.py
+++ b/src/ansible_navigator/actions/welcome.py
@@ -17,8 +17,6 @@ WELCOME = """
 class Action(App):
     """:welcome"""
 
-    # pylint: disable=too-few-public-methods
-
     KEGEX = r"^welcome$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/app.py
+++ b/src/ansible_navigator/app.py
@@ -21,7 +21,6 @@ from .utils import LogMessage
 
 
 class App:
-    # pylint: disable=too-few-public-methods
     # pylint: disable=too-many-instance-attributes
     """Base class for apps (actions)."""
 

--- a/src/ansible_navigator/app_public.py
+++ b/src/ansible_navigator/app_public.py
@@ -11,8 +11,6 @@ from .steps import Steps
 
 
 class AppPublic(NamedTuple):
-    # pylint: disable=inherit-non-class
-    # pylint: disable=too-few-public-methods
     """A carrier class for app internals.
 
     This will be shared with other actions and is immutable.

--- a/src/ansible_navigator/configuration_subsystem/configurator.py
+++ b/src/ansible_navigator/configuration_subsystem/configurator.py
@@ -21,9 +21,7 @@ from .parser import Parser
 
 
 class Configurator:
-    # pylint: disable=too-many-arguments
     # pylint: disable=too-few-public-methods
-    # pylint: disable=too-many-instance-attributes
     """the configuration class"""
 
     def __init__(
@@ -267,7 +265,6 @@ class Configurator:
                     )
 
     def _apply_previous_cli_to_current(self) -> None:
-        # pylint: disable=too-many-nested-blocks
         """Apply eligible previous CLI values to current not set by the CLI"""
 
         # _apply_previous_cli_entries must be ALL or a list of entries

--- a/src/ansible_navigator/configuration_subsystem/definitions.py
+++ b/src/ansible_navigator/configuration_subsystem/definitions.py
@@ -53,7 +53,6 @@ class SettingsEntryValue(SimpleNamespace):
 
 
 class SettingsEntry(SimpleNamespace):
-    # pylint: disable=too-few-public-methods
     """One entry in the configuration
 
     apply_to_subsequent_cli: Should this be applied to future CLIs parsed
@@ -68,6 +67,7 @@ class SettingsEntry(SimpleNamespace):
     subcommands: which subcommand should this be used for
     value: the SettingsEntryValue for the entry
     """
+
     name: str
     short_description: str
     value: SettingsEntryValue

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -89,7 +89,7 @@ class VolumeMount:
         """Render the volume mount in a way that (docker|podman) understands."""
         out = f"{self.src}:{self.dest}"
         if self.options:
-            joined_opts = ",".join(o.value for o in self.options)  # pylint: disable=not-an-iterable
+            joined_opts = ",".join(o.value for o in self.options)
             out += f":{joined_opts}"
         return out
 
@@ -421,7 +421,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process ``exec_shell``.
 
         :param entry: The current settings entry
@@ -436,7 +435,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process help_config"""
         messages, exit_messages = self._true_or_false(entry, config)
         if all((entry.value.current is True, config.app == "config", config.mode == "interactive")):
@@ -462,7 +460,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process help_doc"""
         messages, exit_messages = self._true_or_false(entry, config)
         if all((entry.value.current is True, config.app == "doc", config.mode == "interactive")):
@@ -488,7 +485,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process help_inventory"""
         messages, exit_messages = self._true_or_false(entry, config)
         if all(
@@ -516,7 +512,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process help_playbook"""
         messages, exit_messages = self._true_or_false(entry, config)
         if all((entry.value.current is True, config.app == "run", config.mode == "interactive")):
@@ -741,7 +736,6 @@ class NavigatorPostProcessor:
     @staticmethod
     @_post_processor
     def playbook(entry: SettingsEntry, config: ApplicationConfiguration) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process pass_environment_variable"""
         messages: List[LogMessage] = []
         exit_messages: List[ExitMessage] = []

--- a/src/ansible_navigator/runner/ansible_config.py
+++ b/src/ansible_navigator/runner/ansible_config.py
@@ -11,7 +11,6 @@ from .base import Base
 
 
 class AnsibleConfig(Base):
-    # pylint: disable=too-many-arguments
     """abstraction for ansible-config command-line"""
 
     def fetch_ansible_config(

--- a/src/ansible_navigator/runner/base.py
+++ b/src/ansible_navigator/runner/base.py
@@ -21,7 +21,6 @@ from ansible_runner import Runner  # type: ignore[import]
 class Base:
     """Base class"""
 
-    # pylint: disable=too-few-public-methods
     # pylint: disable=too-many-arguments
     # pylint: disable=too-many-instance-attributes
     def __init__(

--- a/src/ansible_navigator/runner/command.py
+++ b/src/ansible_navigator/runner/command.py
@@ -9,8 +9,6 @@ from .command_base import CommandBase
 
 
 class Command(CommandBase):
-    # pylint: disable=too-few-public-methods
-    # pylint: disable=too-many-instance-attributes
     """a runner wrapper"""
 
     def run(self) -> Tuple[str, str, int]:

--- a/src/ansible_navigator/runner/command_async.py
+++ b/src/ansible_navigator/runner/command_async.py
@@ -14,8 +14,6 @@ from .command_base import CommandBase
 
 
 class CommandAsync(CommandBase):
-    # pylint: disable=too-few-public-methods
-    # pylint: disable=too-many-instance-attributes
     """A wrapper for the asynchronous runner."""
 
     def __init__(self, executable_cmd: str, queue: Queue, **kwargs):

--- a/src/ansible_navigator/runner/command_base.py
+++ b/src/ansible_navigator/runner/command_base.py
@@ -12,9 +12,7 @@ from .base import Base
 
 
 class CommandBase(Base):
-    # pylint: disable=too-few-public-methods
     # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-instance-attributes
 
     """Base class for runner command interaction"""
 

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -255,9 +255,6 @@ def columns_and_colors(lines, schema):
 
 
 def ansi_to_curses(line: str) -> CursesLine:
-
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
     """Convert ansible color codes to curses colors
 
     :param line: A string with ansi colors

--- a/src/ansible_navigator/ui_framework/curses_defs.py
+++ b/src/ansible_navigator/ui_framework/curses_defs.py
@@ -6,8 +6,6 @@ from typing import Tuple
 
 
 class CursesLinePart(NamedTuple):
-    # pylint: disable=inherit-non-class
-    # pylint: disable=too-few-public-methods
     """One chunk of a line of text
 
     :param column: the column at which the text should start

--- a/src/ansible_navigator/ui_framework/curses_window.py
+++ b/src/ansible_navigator/ui_framework/curses_window.py
@@ -13,7 +13,6 @@ from .ui_config import UIConfig
 
 
 if TYPE_CHECKING:
-    # pylint: disable= no-name-in-module
     from _curses import _CursesWindow
 
     Window = _CursesWindow

--- a/src/ansible_navigator/ui_framework/field_button.py
+++ b/src/ansible_navigator/ui_framework/field_button.py
@@ -13,8 +13,6 @@ from .validators import FieldValidators
 
 @dataclass
 class FieldButton:
-
-    # pylint: disable=too-many-instance-attributes
     """a text input field"""
 
     name: str
@@ -24,7 +22,7 @@ class FieldButton:
     color: int = 0
     window_handler = FormHandlerButton
     validator: Callable = FieldValidators.none
-    win: Union[Window, None] = None  # pylint: disable=unsubscriptable-object
+    win: Union[Window, None] = None
 
     @property
     def full_prompt(self) -> str:

--- a/src/ansible_navigator/ui_framework/field_checks.py
+++ b/src/ansible_navigator/ui_framework/field_checks.py
@@ -19,13 +19,12 @@ from .validators import Validation
 
 @dataclass
 class FieldChecks:
-
-    # pylint: disable=too-many-instance-attributes
     """a form filed containing checks"""
+
     prompt: str
     name: str
     current_error: str = ""
-    valid: Union[Unknown, bool] = unknown  # pylint: disable=unsubscriptable-object
+    valid: Union[Unknown, bool] = unknown
     options: List = field(default_factory=list)
     max_selected: int = sys.maxsize
     min_selected: int = 1
@@ -34,7 +33,6 @@ class FieldChecks:
     @property
     def checked(self) -> Tuple[bool, ...]:
         """conveniently return just checked"""
-        # pylint: disable=not-an-iterable
         return tuple(option.name for option in self.options if option.checked)
 
     @property

--- a/src/ansible_navigator/ui_framework/field_information.py
+++ b/src/ansible_navigator/ui_framework/field_information.py
@@ -14,10 +14,8 @@ from .validators import FieldValidators
 
 @dataclass
 class FieldInformation:
-
-    # pylint: disable=too-many-instance-attributes
-    # pylint: disable=unsubscriptable-object
     """a text input field"""
+
     name: str
     information: List[str]
     current_error: str = ""
@@ -40,6 +38,5 @@ class FieldInformation:
         self.valid = True
 
     def conditional_validation(self, response: str) -> None:
-        # pylint: disable=unused-argument
         """no conditional validation"""
         self.validate(response)

--- a/src/ansible_navigator/ui_framework/field_option.py
+++ b/src/ansible_navigator/ui_framework/field_option.py
@@ -16,7 +16,6 @@ class FieldOption:
     checked: bool = False
     disabled: bool = False
 
-    # pylint: disable=unsubscriptable-object
     def ansi_code(self, form_field: Union[FieldChecks, FieldRadio]) -> str:
         """return our icon based on the
         form provided

--- a/src/ansible_navigator/ui_framework/field_radio.py
+++ b/src/ansible_navigator/ui_framework/field_radio.py
@@ -17,20 +17,18 @@ from .validators import Validation
 
 @dataclass
 class FieldRadio:
-
-    # pylint: disable=too-many-instance-attributes
     """a form filed containing radios"""
+
     prompt: str
     name: str
     current_error: str = ""
-    valid: Union[Unknown, bool] = unknown  # pylint: disable=unsubscriptable-object
+    valid: Union[Unknown, bool] = unknown
     options: List = field(default_factory=list)
     window_handler = FormHandlerOptions
 
     @property
     def checked(self):
         """conveniently return just checked"""
-        # pylint: disable=not-an-iterable
         return tuple(option.name for option in self.options if option.checked)
 
     @property

--- a/src/ansible_navigator/ui_framework/field_text.py
+++ b/src/ansible_navigator/ui_framework/field_text.py
@@ -17,7 +17,6 @@ from .validators import FieldValidators
 class FieldText:
 
     # pylint: disable=too-many-instance-attributes
-    # pylint: disable=unsubscriptable-object
     """a text input field"""
     name: str
     prompt: str

--- a/src/ansible_navigator/ui_framework/field_text.py
+++ b/src/ansible_navigator/ui_framework/field_text.py
@@ -15,7 +15,6 @@ from .validators import FieldValidators
 
 @dataclass
 class FieldText:
-
     # pylint: disable=too-many-instance-attributes
     """a text input field"""
     name: str

--- a/src/ansible_navigator/ui_framework/field_working.py
+++ b/src/ansible_navigator/ui_framework/field_working.py
@@ -14,10 +14,8 @@ from .validators import FieldValidators
 
 @dataclass
 class FieldWorking:
-
-    # pylint: disable=too-many-instance-attributes
-    # pylint: disable=unsubscriptable-object
     """a text input field"""
+
     name: str
     messages: List[str]
     current_error: str = ""
@@ -40,6 +38,5 @@ class FieldWorking:
         self.valid = True
 
     def conditional_validation(self, response: str) -> None:
-        # pylint: disable=unused-argument
         """no conditional validation"""
         self.validate(response)

--- a/src/ansible_navigator/ui_framework/form.py
+++ b/src/ansible_navigator/ui_framework/form.py
@@ -29,7 +29,6 @@ class Form:
     def present(self, screen, ui_config):
         """present the form the to user and return the results"""
         if self.type is FormType.FORM:
-            # pylint: disable=no-member
             self.fields.append(
                 FieldButton(
                     name="submit",
@@ -39,9 +38,7 @@ class Form:
                 ),
             )
             self.fields.append(FieldButton(name="cancel", text="Cancel", color=9))
-            # pylint: enable=no-member
         elif self.type is FormType.NOTIFICATION:
-            # pylint: disable=no-member
             self.fields.append(
                 FieldButton(
                     name="submit",
@@ -50,21 +47,16 @@ class Form:
                     color=10,
                 ),
             )
-            # pylint: enable=no-member
         elif self.type is FormType.WORKING:
             pass
 
         FormPresenter(form=self, screen=screen, ui_config=ui_config).present()
         try:
-            # pylint: disable=not-an-iterable
             self.submitted = next(field for field in self.fields if field.name == "submit").pressed
-            # pylint: enable=not-an-iterable
         except StopIteration:
             self.submitted = False
         try:
-            # pylint: disable=not-an-iterable
             self.cancelled = next(field for field in self.fields if field.name == "cancel").pressed
-            # pylint: enable=not-an-iterable
         except StopIteration:
             self.cancelled = False
         return self

--- a/src/ansible_navigator/ui_framework/form_handler_options.py
+++ b/src/ansible_navigator/ui_framework/form_handler_options.py
@@ -42,7 +42,6 @@ class FormHandlerOptions(CursesWindow):
             self._add_line(self.win, idx, ([clp_option_code, clp_text]))
 
     def handle(self, idx, form_fields: List) -> Tuple[Union["FieldChecks", "FieldRadio"], int]:
-        # pylint: disable=too-many-branches
         # pylint: disable=too-many-nested-blocks
 
         """handle the check box field"""

--- a/src/ansible_navigator/ui_framework/form_presenter.py
+++ b/src/ansible_navigator/ui_framework/form_presenter.py
@@ -35,7 +35,6 @@ TPAD_RATIO = 2 / 5
 BUTTON_SPACE = 10
 
 
-# pylint: disable=no-member
 class FormPresenter(CursesWindow):
     """present the form to the user"""
 

--- a/src/ansible_navigator/ui_framework/form_utils.py
+++ b/src/ansible_navigator/ui_framework/form_utils.py
@@ -53,7 +53,7 @@ def dict_to_form(form_data: Dict) -> Form:
             if pre_populate:
                 frm_field_text.pre_populate(pre_populate)
 
-            form.fields.append(frm_field_text)  # pylint: disable=no-member
+            form.fields.append(frm_field_text)
 
         elif field["type"] in ["checkbox", "radio"]:
             field_params["prompt"] = field["prompt"]
@@ -67,19 +67,19 @@ def dict_to_form(form_data: Dict) -> Form:
                 if min_selected:
                     field_params["min_selected"] = min_selected
                 frm_field_checks = FieldChecks(**field_params)
-                form.fields.append(frm_field_checks)  # pylint: disable=no-member
+                form.fields.append(frm_field_checks)
 
             elif field["type"] == "radio":
                 frm_field_radio = FieldRadio(**field_params)
-                form.fields.append(frm_field_radio)  # pylint: disable=no-member
+                form.fields.append(frm_field_radio)
 
         elif field["type"] == "information":
             frm_field_info = FieldInformation(name=field["name"], information=field["information"])
-            form.fields.append(frm_field_info)  # pylint: disable=no-member
+            form.fields.append(frm_field_info)
 
         elif field["type"] == "working":
             frm_field_working = FieldWorking(name=field["name"], messages=field["messages"])
-            form.fields.append(frm_field_working)  # pylint: disable=no-member
+            form.fields.append(frm_field_working)
 
     return form
 

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -1,7 +1,5 @@
 """the main UI renderer
 """
-
-# pylint: disable=too-many-lines
 import curses
 import json
 import logging
@@ -41,9 +39,6 @@ from .ui_config import UIConfig
 
 STND_KEYS = {"^f/PgUp": "page up", "^b/PgDn": "page down", "\u2191\u2193": "scroll", "esc": "back"}
 END_KEYS = {":help": "help"}
-
-# pylint: disable=inherit-non-class
-# pylint: disable=too-few-public-methods
 
 
 class Action(NamedTuple):
@@ -89,7 +84,6 @@ class Interaction(NamedTuple):
 
 class UserInterface(CursesWindow):
     # pylint: disable=too-many-instance-attributes
-    # pylint: disable=too-few-public-methods
     # pylint: disable=too-many-arguments
 
     """The main UI class"""
@@ -360,7 +354,6 @@ class UserInterface(CursesWindow):
         # pylint: disable=too-many-branches
         # pylint: disable=too-many-locals
         # pylint: disable=too-many-statements
-        # pylint: disable=too-many-nested-blocks
         """show something on the screen
 
         :param lines: The lines to show
@@ -623,7 +616,6 @@ class UserInterface(CursesWindow):
         return res
 
     def _show_obj_from_list(self, objs: List[Any], index: int, await_input: bool) -> Interaction:
-        # pylint: disable=too-many-arguments
         # pylint: disable=too-many-branches
         # pylint: disable=too-many-locals
         # pylint: disable=too-many-statements

--- a/src/ansible_navigator/ui_framework/validators.py
+++ b/src/ansible_navigator/ui_framework/validators.py
@@ -16,8 +16,6 @@ from .sentinels import unknown
 
 
 class Validation(NamedTuple):
-    # pylint: disable=inherit-non-class
-    # pylint: disable=too-few-public-methods
     """the response from a validation"""
 
     value: Any
@@ -41,7 +39,6 @@ class FieldValidators:
 
     @staticmethod
     def masked_or_none(text="", hint: bool = False) -> Union[Validation, str]:
-        # pylint: disable=unused-argument
         """no validation"""
         if hint:
             return "Please provide a value (optional)"

--- a/src/ansible_navigator/utils.py
+++ b/src/ansible_navigator/utils.py
@@ -52,7 +52,6 @@ class ExitPrefix(Enum):
 
 
 class ExitMessage(SimpleNamespace):
-    # pylint: disable=too-few-public-methods
     """An object to hold a message destined for the logger"""
 
     message: str

--- a/tests/integration/_interactions.py
+++ b/tests/integration/_interactions.py
@@ -47,8 +47,8 @@ class Command(NamedTuple):
 
 
 class Step(NamedTuple):
-    # pylint: disable=too-few-public-methods
     """test data object"""
+
     user_input: str
     comment: str
 

--- a/tests/integration/actions/collections/base.py
+++ b/tests/integration/actions/collections/base.py
@@ -59,7 +59,6 @@ class BaseClass:
         comment,
     ):
         # pylint: disable=too-many-arguments
-        # pylint: disable=too-many-locals
         """Run the tests for collections, mode and ``ee`` set in child class.
 
         wait on help here to ensure we get the welcome screen and subsequent screens

--- a/tests/integration/actions/doc/base.py
+++ b/tests/integration/actions/doc/base.py
@@ -23,7 +23,6 @@ class BaseClass:
     @staticmethod
     @pytest.fixture(scope="module", name="tmux_doc_session")
     def fixture_tmux_doc_session(request):
-        # pylint: disable=too-many-locals
         """Tmux fixture for this module."""
         params = {
             "pane_height": "2000",

--- a/tests/integration/actions/images/base.py
+++ b/tests/integration/actions/images/base.py
@@ -56,7 +56,6 @@ class BaseClass:
             yield tmux_session
 
     def test(self, request, tmux_session, step):
-        # pylint: disable=too-many-locals
         """Run the tests for images, mode and ``ee`` set in child class."""
 
         if step.search_within_response is SearchFor.HELP:

--- a/tests/integration/actions/replay/base.py
+++ b/tests/integration/actions/replay/base.py
@@ -40,7 +40,6 @@ class BaseClass:
 
     def test(self, request, tmux_session, index, user_input, comment, search_within_response):
         # pylint: disable=too-many-arguments
-        # pylint: disable=too-many-locals
         """Run the tests for replay, mode and ``ee`` set in child class."""
         assert os.path.exists(PLAYBOOK_ARTIFACT)
         assert os.path.exists(TEST_CONFIG_FILE)

--- a/tests/integration/actions/stdout/base.py
+++ b/tests/integration/actions/stdout/base.py
@@ -40,7 +40,6 @@ class BaseClass:
 
     def test(self, request, tmux_session, index, user_input, comment, search_within_response):
         # pylint:disable=too-many-arguments
-        # pylint: disable=too-many-locals
         """Run the tests for stdout, mode and EE set in child class."""
         assert os.path.exists(ANSIBLE_PLAYBOOK)
         assert os.path.exists(TEST_CONFIG_FILE)

--- a/tests/unit/configuration_subsystem/test_broken_settings.py
+++ b/tests/unit/configuration_subsystem/test_broken_settings.py
@@ -4,7 +4,6 @@ import os
 
 
 def test_broken_settings_file(generate_config):
-    # pylint: disable=import-outside-toplevel
     """Ensure exit_messages generated for broken settings file"""
     response = generate_config(setting_file_name="ansible-navigator_broken.yml")
     assert len(response.exit_messages) == 3, response.exit_messages
@@ -13,7 +12,6 @@ def test_broken_settings_file(generate_config):
 
 
 def test_garbage_settings_file(generate_config):
-    # pylint: disable=import-outside-toplevel
     """Ensure exit_messages generated for garbage settings file"""
     response = generate_config(setting_file_name=os.path.abspath(__file__))
     error = "but failed to load it."

--- a/tests/unit/configuration_subsystem/test_invalid_params.py
+++ b/tests/unit/configuration_subsystem/test_invalid_params.py
@@ -22,7 +22,6 @@ def test_generate_argparse_error(generate_config):
 
 @patch("shutil.which", return_value="/path/to/container_engine")
 def test_inventory_no_inventory(_mocked_func, generate_config):
-    # pylint: disable=import-outside-toplevel
     """Ensure exit_messages generated for an inventory without an inventory specified"""
     response = generate_config(params=["inventory"])
     exit_msg = "An inventory is required when using the inventory subcommand"
@@ -86,7 +85,6 @@ def test_replay_missing_artifact(_mocked_func, generate_config):
 
 @patch("shutil.which", return_value="/path/to/container_engine")
 def test_badly_formatted_envar(_mocked_func, generate_config):
-    # pylint: disable=import-outside-toplevel
     """Ensure exit_messages generated for badly formatted ``--senv``."""
     params = "run site.yml --senv TK1:TV1"
     response = generate_config(params=params.split())
@@ -96,7 +94,6 @@ def test_badly_formatted_envar(_mocked_func, generate_config):
 
 @patch("shutil.which", return_value="/path/to/container_engine")
 def test_not_a_bool(_mocked_func, generate_config):
-    # pylint: disable=import-outside-toplevel
     """Ensure exit_messages generated for wrong type of value"""
 
     response = generate_config(setting_file_name="ansible-navigator_not_bool.yml")
@@ -112,7 +109,6 @@ choices = [entry for entry in NavigatorConfiguration.entries if entry.choices]
 @patch("shutil.which", return_value="/path/to/container_engine")
 @pytest.mark.parametrize("entry", choices, ids=id_for_name)
 def test_poor_choices(_mocked_func, generate_config, entry):
-    # pylint: disable=import-outside-toplevel
     """Ensure exit_messages generated for poor choices"""
 
     def test(subcommand, param, look_for):
@@ -147,7 +143,6 @@ def test_poor_choices(_mocked_func, generate_config, entry):
 
 @pytest.mark.parametrize("subcommand, params", (("images", __file__), ("collections", "")))
 def test_interactive_only_subcommand(generate_config, subcommand, params):
-    # pylint: disable=import-outside-toplevel
     """Ensure exit_messages generated for interactive only subcommand."""
     params = [subcommand, params, "-m", "stdout"]
     response = generate_config(params=params)

--- a/tests/unit/configuration_subsystem/test_precedence.py
+++ b/tests/unit/configuration_subsystem/test_precedence.py
@@ -198,7 +198,6 @@ def test_all_entries_reflect_envvar_given_settings(
     value,
     expected,
 ):
-    # pylint: disable=unused-argument
     """Ensure each entry is are set by an environment variables
     even though settings file has been provided, the others
     should by default or settings file

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -88,7 +88,6 @@ from ..defaults import FIXTURES_DIR
         "run, check playbook",
     ],
 )
-# pylint:disable=redefined-outer-name
 @patch("shutil.which", return_value="/path/to/container_engine")
 def test_update_args_general(_mf1, monkeypatch, given, argname, expected):
     """test the parse and update function"""


### PR DESCRIPTION
Enables checking for `useless-suppression` checking as part of `pylint` as a required check.

The majority of these appear to be simple cut and paste carry overs during the initial development cycles.

Fixes: #771 

Changes made:
- Enable `useless-suppression` in the `pyproject.toml` file
- Remove unneeded ignore statements as reported with `tox -e lint`

Note: These might vary with different python versions so we might want to wait for #799 which give us some consistency with the python version.

Zuul is no longer enabled disregard the following historical information:

This can be seen if the GHA action is comapred to zuul: 

Zuul reports:
```
2022-01-26 12:40:39.881817 | centos-8-stream | ************* Module src.ansible_navigator.ui_framework.form_utils
2022-01-26 12:40:39.881832 | centos-8-stream | src/ansible_navigator/ui_framework/form_utils.py:56:12: E1101: Instance of 'Field' has no 'append' member (no-member)
2022-01-26 12:40:39.881864 | centos-8-stream | src/ansible_navigator/ui_framework/form_utils.py:70:16: E1101: Instance of 'Field' has no 'append' member (no-member)
2022-01-26 12:40:39.881881 | centos-8-stream | src/ansible_navigator/ui_framework/form_utils.py:74:16: E1101: Instance of 'Field' has no 'append' member (no-member)
2022-01-26 12:40:39.881895 | centos-8-stream | src/ansible_navigator/ui_framework/form_utils.py:78:12: E1101: Instance of 'Field' has no 'append' member (no-member)
2022-01-26 12:40:39.881909 | centos-8-stream | src/ansible_navigator/ui_framework/form_utils.py:82:12: E1101: Instance of 'Field' has no 'append' member (no-member)
2022-01-26 12:40:39.881922 | centos-8-stream | ************* Module src.ansible_navigator.ui_framework.field_checks
2022-01-26 12:40:39.881936 | centos-8-stream | src/ansible_navigator/ui_framework/field_checks.py:36:47: E1133: Non-iterable value self.options is used in an iterating context (not-an-iterable)
2022-01-26 12:40:39.881957 | centos-8-stream | ************* Module src.ansible_navigator.ui_framework.form
2022-01-26 12:40:39.881972 | centos-8-stream | src/ansible_navigator/ui_framework/form.py:32:12: E1101: Instance of 'Field' has no 'append' member (no-member)
2022-01-26 12:40:39.881987 | centos-8-stream | src/ansible_navigator/ui_framework/form.py:40:12: E1101: Instance of 'Field' has no 'append' member (no-member)
2022-01-26 12:40:39.882001 | centos-8-stream | src/ansible_navigator/ui_framework/form.py:42:12: E1101: Instance of 'Field' has no 'append' member (no-member)
2022-01-26 12:40:39.882015 | centos-8-stream | src/ansible_navigator/ui_framework/form.py:55:53: E1133: Non-iterable value self.fields is used in an iterating context (not-an-iterable)
2022-01-26 12:40:39.882054 | centos-8-stream | src/ansible_navigator/ui_framework/form.py:59:53: E1133: Non-iterable value self.fields is used in an iterating context (not-an-iterable)
2022-01-26 12:40:39.882074 | centos-8-stream | ************* Module src.ansible_navigator.ui_framework.field_text
2022-01-26 12:40:39.882089 | centos-8-stream | src/ansible_navigator/ui_framework/field_text.py:18:0: I0021: Useless suppression of 'too-many-instance-attributes' (useless-suppression)
2022-01-26 12:40:39.882103 | centos-8-stream | ************* Module src.ansible_navigator.ui_framework.field_radio
2022-01-26 12:40:39.882116 | centos-8-stream | src/ansible_navigator/ui_framework/field_radio.py:32:47: E1133: Non-iterable value self.options is used in an iterating context (not-an-iterable)
2022-01-26 12:40:39.882131 | centos-8-stream | ************* Module src.ansible_navigator.configuration_subsystem.navigator_post_processor
2022-01-26 12:40:39.882145 | centos-8-stream | src/ansible_navigator/configuration_subsystem/navigator_post_processor.py:92:52: E1133: Non-iterable value self.options is used in an iterating context (not-an-iterable)
2022-01-26 12:40:39.882159 | centos-8-stream | ************* Module src.ansible_navigator.actions.inventory
2022-01-26 12:40:39.882175 | centos-8-stream | src/ansible_navigator/actions/inventory.py:424:29: E1133: Non-iterable value form.fields is used in an iterating context (not-an-iterable)
2022-01-26 12:40:39.882190 | centos-8-stream |
```

But the GHA runs clean.

This might also have to wait for zuul to be disabled.