### PR TITLE
Configure pylint to run as native pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -251,21 +251,30 @@ repos:
     - src/
     - tests/
 
-- repo: local
+- repo: https://github.com/pycqa/pylint.git
+  rev: v2.12.2
   hooks:
   - id: pylint
-    language: system
-    name: PyLint
-    files: \.py$
-    entry: python -m pylint
     args:
     # FIXME: uncomment once it doesn't have violations
     # - docs/
     - share/
     - src/
     - tests/
+    additional_dependencies:
+    - ansible-core
+    # astroid is a transitive dep for pylint, > 2.9.0 introduces false no-name-in-module and no-member errors
+    # attempt to remove this when astroid 2.9.4 or later is released
+    # related: https://github.com/PyCQA/pylint/issues/5131
+    # related: https://github.com/ansible/ansible-navigator/issues/772
+    - astroid == 2.9.0
+    - ansible-runner
+    - jinja2
+    - libtmux
+    - onigurumacffi
+    - pylint-pytest < 1.1.0
+    - setuptools-scm
+    - sphinx
     pass_filenames: false
-    stages:
-    - manual
 
 ...

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ allowlist_externals = ansible-playbook
 description = Enforce quality standards under {basepython} ({envpython})
 install_command = pip install {opts} {packages}
 commands =
-  pre-commit run {--show-diff-on-failure \
+  pre-commit run {posargs:--show-diff-on-failure \
     --hook-stage manual \
     --all-files -v}
   black -v --diff --check {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -61,29 +61,13 @@ allowlist_externals = ansible-playbook
 description = Enforce quality standards under {basepython} ({envpython})
 install_command = pip install {opts} {packages}
 commands =
-  pre-commit run -a {posargs}
-
-  {envpython} -m \
-    pre_commit run \
-    {posargs:pylint \
-    --show-diff-on-failure \
+  pre-commit run {--show-diff-on-failure \
     --hook-stage manual \
     --all-files -v}
-
   black -v --diff --check {toxinidir}
 deps =
   {[testenv]deps}
   -r{toxinidir}/docs/requirements.in
-  # direct dependencies
-  pylint
-  pylint-pytest < 1.1.0
-
-  # indirect dependencies
-  # astroid is a transitive dep for pylint, > 2.9.0 introduces false no-name-in-module and no-member errors
-  # attempt to remove this when astroid 2.9.4 or later is released
-  # related: https://github.com/PyCQA/pylint/issues/5131
-  # related: https://github.com/ansible/ansible-navigator/issues/772
-  astroid == 2.9.0
 setenv =
   # NOTE: Running some of the MyPy checks is disabled here but they may
   # NOTE: be reconfigured in the pre-commit configuration file. So the


### PR DESCRIPTION
This changes the `pylint` entry configured for pre-commit to be run as a native pre-commit hook rather than a local hook.

local hooks are described here:  https://pre-commit.com/#repository-local-hooks

Pros:
- pylint will now run automatically as a pre-commit hook for contributors that have installed the pre-commit hooks with `pre-commit install`
-  the version of the pre-commit hook as specified in the `rev` key is a reference to the version of the hook and in this case specifies the `pylint` version to use
- In the future, if necessary, the python version can also be specified in the pre-commit configuration if differences are found between the hook being run locally and via pre-commit

Cons:
- due to the nature of pre-commit hooks and caching, the dependencies and sometime their versions for pylint to run need to be specified in the pre-commit configuration in addition to the tox.ini as well as the test-requirements.txt, This comes with operational overhead when they need to set or modified.
- there is documentation in the dev version of `pylint` that suggests the hook only works with a local installation of `pylint`. It is unknown today exactly what this might mean in the future: https://pylint.pycqa.org/en/latest/user_guide/pre-commit-integration.html

If it becomes necessary to revert to a local hook in the future, the amount of work to do so should not be major, it would basically be a fail forward PR effectively reverting this one.