### PR TITLE
Changes necessary to have the `pylint` configuration in only one location

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,9 +1,0 @@
-[MASTER]
-
-ignore =
-  tm_tokenize,  # virtually vendored and shouldn't be linted as such
-
-
-[MESSAGES CONTROL]
-
-disable=duplicate-code,unsubscriptable-object,fixme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,11 @@ skip_glob = ["tests/fixtures/common/collections*"] # Skip ansible content due to
 
 [tool.pylint]
     [tool.pylint.master]
-    ignore="tm_tokenize"
+    # tm_tokenize is virtually vendored and shouldn't be linted as such
+    ignore = "tm_tokenize"
 
     [tool.pylint.messages_control]
-    disable = "C0330, C0326"
+    disable = "duplicate-code,unsubscriptable-object,fixme"
 
     [tool.pylint.format]
     max-line-length = 100


### PR DESCRIPTION
The resulting configuration in `pyproject.toml` should reflect what is needed now.

Having it in two places was confusing.