### PR TITLE
Predefine `FieldValidatorState` and `FieldValidatorStates`

### DIFF
--- a/src/ansible_navigator/ui_framework/field_button.py
+++ b/src/ansible_navigator/ui_framework/field_button.py
@@ -2,12 +2,11 @@
 """
 from dataclasses import dataclass
 from typing import Callable
-from typing import List
 from typing import Union
 
 from .curses_window import Window
+from .form_defs import FieldValidationStates
 from .form_handler_button import FormHandlerButton
-from .sentinels import Unknown
 from .validators import FieldValidators
 
 
@@ -31,7 +30,7 @@ class FieldButton:
         """no default to add into the prompt for checkbox"""
         return ""
 
-    def validate(self, response: List[Union[Unknown, bool]]) -> None:
+    def validate(self, response: FieldValidationStates) -> None:
         """validate this instance"""
         validation = self.validator(response)
         if validation.error_msg:
@@ -39,7 +38,7 @@ class FieldButton:
         else:
             self.disabled = False
 
-    def conditional_validation(self, response: List[Union[Unknown, bool]]) -> None:
+    def conditional_validation(self, response: FieldValidationStates) -> None:
         """conditional validation used for
         tab
         """

--- a/src/ansible_navigator/ui_framework/form_defs.py
+++ b/src/ansible_navigator/ui_framework/form_defs.py
@@ -2,6 +2,14 @@
 """
 
 from enum import Enum
+from typing import List
+from typing import Union
+
+from .sentinels import Unknown
+
+
+FieldValidationState = Union[Unknown, bool]
+FieldValidationStates = List[FieldValidationState]
 
 
 class FormType(Enum):

--- a/src/ansible_navigator/ui_framework/validators.py
+++ b/src/ansible_navigator/ui_framework/validators.py
@@ -11,6 +11,7 @@ from typing import NamedTuple
 from typing import Union
 from urllib.parse import urlparse
 
+from .form_defs import FieldValidationStates
 from .sentinels import Unknown
 from .sentinels import unknown
 
@@ -53,7 +54,8 @@ class FieldValidators:
 
     @staticmethod
     def none(
-        text: Union[List[Union[Unknown, bool]], str] = "", hint: bool = False
+        text: Union[FieldValidationStates, str] = "",
+        hint: bool = False,
     ) -> Union[Validation, str]:
         """no validation"""
         if hint:


### PR DESCRIPTION
This is follow up to #790 which replaces the complex inline type with a predefined type.

As I was explaining it to @ssbarnea I realized this might be a better approach. (thanks for mentioning it sorin)