### PR TITLE
POC for running mypy with multiple python versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -44,6 +44,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # needed by setuptools-scm
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -184,11 +184,14 @@ repos:
 - repo: https://github.com/pre-commit/mirrors-mypy.git
   rev: v0.910-1
   hooks:
-  - id: mypy
+  - &mypy-config
+    id: mypy
+    name: mypy-3.6
     additional_dependencies:
     - lxml == 4.6.4  # needed for `--txt-report`
     - types-docutils
     - types-PyYAML
+    language_version: "3.6"
     args:
     # FIXME: get rid of missing imports ignore
     - --ignore-missing-imports
@@ -208,6 +211,9 @@ repos:
     - src/
     - tests/
     pass_filenames: false
+  - <<: *mypy-config
+    language_version: "3.10"
+    name: mypy-3.10
 
 - repo: local
   hooks:


### PR DESCRIPTION
That should be seen as an alternative to #726 that avoids cluttering
the mypy hook configuration.

Closes: https://github.com/ansible/ansible-navigator/pull/726/files
