### PR TITLE
Disable 2 `flake8-bandit` checks (S404 and S603) in one unit test

### DIFF
--- a/tests/unit/test_circular_imports.py
+++ b/tests/unit/test_circular_imports.py
@@ -11,7 +11,7 @@ This module is based on an idea that pytest uses for self-testing:
 """  # noqa: E501
 import os
 import pkgutil
-import subprocess
+import subprocess  # noqa: S404 Required due to the nature of this test
 import sys
 
 from itertools import chain
@@ -101,4 +101,4 @@ def test_no_warnings(import_path: str) -> None:
         f"import {import_path!s}",
     )
 
-    subprocess.check_call(imp_cmd)
+    subprocess.check_call(imp_cmd)  # noqa: S603 Input is trusted, generated above, not external


### PR DESCRIPTION
These are reported by `flake8-bandit` which is part of the wemake-python style guide being vetted

Noting how and why subprocess was used seems reasonable here for future reviews that might see it.

```
tests/unit/test_circular_imports.py:14:1: S404 Consider possible security implications associated with the subprocess module.
import subprocess
^
tests/unit/test_circular_imports.py:104:1: S603 subprocess call - check for execution of untrusted input.
    subprocess.check_call(imp_cmd)
^
```

Details can be found here: https://bandit.readthedocs.io/en/latest/blacklists/blacklist_imports.html?highlight=B404 and here: https://bandit.readthedocs.io/en/latest/plugins/index.html#complete-test-plugin-listing

Note- The `flake8-bandit` extension changes the B to an S see https://github.com/tylerwince/flake8-bandit