### PR TITLE
Add `mod` as permitted RST role

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -319,6 +319,7 @@ rst-roles =
   data,
   exc,
   meth,
+  mod,
   term,
   py:class,
   py:data,


### PR DESCRIPTION
This adds `mod` to the user list of sphinx roles in the `flake8` file.  It was being reported by `flake8-rst-docstring` whcih is being vetted as it is included in the wemake style guide.

This was the error begin reported:

```
tests/unit/test_utils.py:1:1: RST304 Unknown interpreted text role "mod".
"""Test the functions exposed in the :mod:`~ansible_navigator.utils` subpackage."""
^
```

Some good info about this is here: https://github.com/peterjc/flake8-rst-docstrings/pull/16