### PR TITLE
Add missing doc string for `__init__` for some actions

### DIFF
--- a/src/ansible_navigator/actions/back.py
+++ b/src/ansible_navigator/actions/back.py
@@ -17,6 +17,10 @@ class Action:
     KEGEX = r"^\^\[|\x1b|back$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:back`` action.
+
+        :param args: The current settings for the application
+        """
         self._args = args
         self._logger = logging.getLogger(__name__)
 

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -83,6 +83,10 @@ class Action(App):
     KEGEX = r"^collections(\s(?P<params>.*))?$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:collections`` action.
+
+        :param args: The current settings for the application
+        """
         super().__init__(args=args, logger_name=__name__, name="collections")
         self._adjacent_collection_dir: str
         self._collection_cache: Dict

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -89,6 +89,10 @@ class Action(App):
     KEGEX = r"^config(\s(?P<params>.*))?$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:config`` action.
+
+        :param args: The current settings for the application
+        """
         super().__init__(args=args, logger_name=__name__, name="config")
 
         self._config: Union[List[Any], None] = None

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -33,6 +33,10 @@ class Action(App):
     KEGEX = r"^d(?:oc)?(\s(?P<params>.*))?$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:doc`` action.
+
+        :param args: The current settings for the application
+        """
         super().__init__(args=args, logger_name=__name__, name="doc")
 
         self._plugin_name: Optional[str]

--- a/src/ansible_navigator/actions/exec.py
+++ b/src/ansible_navigator/actions/exec.py
@@ -45,9 +45,9 @@ class Action(App):
     KEGEX = "^e(?:xec)?$"
 
     def __init__(self, args: ApplicationConfiguration):
-        """Initialize the action.
+        """Initialize the ``:exec`` action.
 
-        :param args: The current application configuration.
+        :param args: The current settings for the application
         """
         super().__init__(args=args, logger_name=__name__, name="exec")
 

--- a/src/ansible_navigator/actions/filter.py
+++ b/src/ansible_navigator/actions/filter.py
@@ -16,6 +16,10 @@ class Action:
     KEGEX = r"^f(ilter)?(\s(?P<regex>.*))?$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:filter`` action.
+
+        :param args: The current settings for the application
+        """
         self._args = args
         self._logger = logging.getLogger(__name__)
 

--- a/src/ansible_navigator/actions/help_doc.py
+++ b/src/ansible_navigator/actions/help_doc.py
@@ -17,6 +17,10 @@ class Action(App):
     KEGEX = r"^h(?:elp)?$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:help`` action.
+
+        :param args: The current settings for the application
+        """
         super().__init__(args=args, logger_name=__name__, name="help")
 
     def run(self, interaction: Interaction, app: AppPublic) -> Interaction:

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -48,6 +48,10 @@ class Action(App):
     KEGEX = r"^im(?:ages)?(\s(?P<params>.*))?$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:images`` action.
+
+        :param args: The current settings for the application
+        """
         super().__init__(args=args, logger_name=__name__, name="images")
         self._image_list: List = []
         self._images = Step(

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -100,6 +100,10 @@ class Action(App):
     KEGEX = r"^i(?:nventory)?(\s(?P<params>.*))?$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:images`` action.
+
+        :param args: The current settings for the application
+        """
         super().__init__(args=args, logger_name=__name__, name="inventory")
 
         self.__inventory: Dict[Any, Any] = {}

--- a/src/ansible_navigator/actions/log.py
+++ b/src/ansible_navigator/actions/log.py
@@ -15,6 +15,10 @@ class Action(App):
     KEGEX = r"^l(?:og)?$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:exec`` action.
+
+        :param args: The current settings for the application
+        """
         super().__init__(args=args, logger_name=__name__, name="log")
 
     def run(self, interaction: Interaction, app: AppPublic) -> Interaction:

--- a/src/ansible_navigator/actions/open_file.py
+++ b/src/ansible_navigator/actions/open_file.py
@@ -40,6 +40,10 @@ class Action:
     KEGEX = r"^o(?:pen)?(\s(?P<something>.*))?$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:open`` action.
+
+        :param args: The current settings for the application
+        """
         self._args = args
         self._logger = logging.getLogger(__name__)
 

--- a/src/ansible_navigator/actions/quit.py
+++ b/src/ansible_navigator/actions/quit.py
@@ -17,6 +17,10 @@ class Action:
     KEGEX = r"q(?:uit)?(?P<exclamation>!)?$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:quit`` action.
+
+        :param args: The current settings for the application
+        """
         self._args = args
         self._logger = logging.getLogger(__name__)
 

--- a/src/ansible_navigator/actions/refresh.py
+++ b/src/ansible_navigator/actions/refresh.py
@@ -16,6 +16,10 @@ class Action:
     KEGEX = r"^KEY_F\(5\)$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the refresh action.
+
+        :param args: The current settings for the application
+        """
         self._args = args
         self._logger = logging.getLogger(__name__)
 

--- a/src/ansible_navigator/actions/rerun.py
+++ b/src/ansible_navigator/actions/rerun.py
@@ -20,6 +20,10 @@ class Action:
     KEGEX = r"^rr|rerun?$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:rerun`` action.
+
+        :param args: The current settings for the application
+        """
         self._args = args
         self._logger = logging.getLogger(__name__)
 

--- a/src/ansible_navigator/actions/sample_form.py
+++ b/src/ansible_navigator/actions/sample_form.py
@@ -93,6 +93,10 @@ class Action(App):
     KEGEX = r"^sample_form$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:sample_form`` action.
+
+        :param args: The current settings for the application
+        """
         super().__init__(args=args, logger_name=__name__, name="sample_form")
 
     # pylint: disable=unused-argument

--- a/src/ansible_navigator/actions/sample_notification.py
+++ b/src/ansible_navigator/actions/sample_notification.py
@@ -36,6 +36,10 @@ class Action(App):
     KEGEX = r"^sample_notification$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:sample_form`` action.
+
+        :param args: The current settings for the application
+        """
         super().__init__(args=args, logger_name=__name__, name="sample_form")
 
     # pylint: disable=unused-argument

--- a/src/ansible_navigator/actions/sample_notification.py
+++ b/src/ansible_navigator/actions/sample_notification.py
@@ -36,7 +36,7 @@ class Action(App):
     KEGEX = r"^sample_notification$"
 
     def __init__(self, args: ApplicationConfiguration):
-        """Initialize the ``:sample_form`` action.
+        """Initialize the ``:sample_notification`` action.
 
         :param args: The current settings for the application
         """

--- a/src/ansible_navigator/actions/sample_working.py
+++ b/src/ansible_navigator/actions/sample_working.py
@@ -19,6 +19,10 @@ class Action(App):
     KEGEX = r"^sample_working$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:sample_working`` action.
+
+        :param args: The current settings for the application
+        """
         super().__init__(args=args, logger_name=__name__, name="sample_working")
 
     # pylint: disable=unused-argument

--- a/src/ansible_navigator/actions/save.py
+++ b/src/ansible_navigator/actions/save.py
@@ -16,6 +16,10 @@ class Action:
     KEGEX = r"^s(?:ave)?\s(?P<filename>.*)$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:save`` action.
+
+        :param args: The current settings for the application
+        """
         self._args = args
         self._logger = logging.getLogger(__name__)
 

--- a/src/ansible_navigator/actions/select.py
+++ b/src/ansible_navigator/actions/select.py
@@ -19,6 +19,10 @@ class Action:
     KEGEX = r"^\d+$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the select action.
+
+        :param args: The current settings for the application
+        """
         self._args = args
         self._logger = logging.getLogger(__name__)
 

--- a/src/ansible_navigator/actions/serialize_json.py
+++ b/src/ansible_navigator/actions/serialize_json.py
@@ -16,6 +16,10 @@ class Action:
     KEGEX = r"^j(?:son)?$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:json`` action.
+
+        :param args: The current settings for the application
+        """
         self._args = args
         self._logger = logging.getLogger(__name__)
 

--- a/src/ansible_navigator/actions/serialize_yaml.py
+++ b/src/ansible_navigator/actions/serialize_yaml.py
@@ -16,6 +16,10 @@ class Action:
     KEGEX = r"^y(?:aml)?$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:yaml`` action.
+
+        :param args: The current settings for the application
+        """
         self._args = args
         self._logger = logging.getLogger(__name__)
 

--- a/src/ansible_navigator/actions/stdout.py
+++ b/src/ansible_navigator/actions/stdout.py
@@ -16,6 +16,10 @@ class Action(App):
     KEGEX = r"^st(?:dout)?$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:stdout`` action.
+
+        :param args: The current settings for the application
+        """
         super().__init__(args=args, logger_name=__name__, name="stdout")
 
     def run(self, interaction: Interaction, app: AppPublic) -> Interaction:

--- a/src/ansible_navigator/actions/template.py
+++ b/src/ansible_navigator/actions/template.py
@@ -23,6 +23,10 @@ class Action(App):
     KEGEX = r"^{{.*}}$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the template action.
+
+        :param args: The current settings for the application
+        """
         super().__init__(args=args, logger_name=__name__, name="template")
 
     def run(self, interaction: Interaction, app: AppPublic) -> Union[Interaction, None]:

--- a/src/ansible_navigator/actions/welcome.py
+++ b/src/ansible_navigator/actions/welcome.py
@@ -22,6 +22,10 @@ class Action(App):
     KEGEX = r"^welcome$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:welcome`` action.
+
+        :param args: The current settings for the application
+        """
         super().__init__(args=args, logger_name=__name__, name="welcome")
 
     def run(self, interaction: Interaction, app: AppPublic) -> Interaction:

--- a/src/ansible_navigator/actions/write_file.py
+++ b/src/ansible_navigator/actions/write_file.py
@@ -21,6 +21,10 @@ class Action:
     KEGEX = r"^w(?:rite)?(?P<force>!)?\s+(?P<append>>>)?\s*(?P<filename>.+)$"
 
     def __init__(self, args: ApplicationConfiguration):
+        """Initialize the ``:write`` action.
+
+        :param args: The current settings for the application
+        """
         self._args = args
         self._logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This add a doc string to some action that were missing it.

Some are formatting as code when there is a corresponding `:colon` command, the ones that don't really have a `:colon` were formatted without.

Updates to the `flake8` file will be in a separate PR after a few similar PRs are submitted.