### PR TITLE
Fix wrong check condition on GHA

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -68,8 +68,6 @@ jobs:
           TOXENV: ${{ matrix.tox_env }}
 
   check:
-    if: always()
-
     needs:
       - tox
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removes condition that was part of all-green implementation, which is not used in our case. We do not want check to always run, even after its dependencies failed.