### PR TITLE
Add doc strings to `__init__` in the UI subsystem

### DIFF
--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -70,6 +70,11 @@ class Colorize:
 
     # pylint: disable=too-few-public-methods
     def __init__(self, grammar_dir: str, theme_path: str):
+        """Initialize the colorizer.
+
+        :param grammar_dir: The directory in which the grammars reside
+        :param theme_path: The path to the currently configured color theme
+        """
         self._logger = logging.getLogger(__name__)
         self._schema = None
         self._grammars = Grammars(grammar_dir)

--- a/src/ansible_navigator/ui_framework/curses_window.py
+++ b/src/ansible_navigator/ui_framework/curses_window.py
@@ -48,6 +48,10 @@ class CursesWindow:
     """abstraction for a curses window"""
 
     def __init__(self, ui_config: UIConfig):
+        """Initialize a curses window.
+
+        :param ui_config: The current user interface configuration
+        """
         self._logger = logging.getLogger(__name__)
 
         self._screen: Window

--- a/src/ansible_navigator/ui_framework/form_handler_button.py
+++ b/src/ansible_navigator/ui_framework/form_handler_button.py
@@ -9,6 +9,8 @@ from typing import Tuple
 
 from .curses_defs import CursesLinePart
 from .curses_window import CursesWindow
+from .curses_window import Window
+from .ui_config import UIConfig
 
 
 if TYPE_CHECKING:
@@ -19,6 +21,11 @@ class FormHandlerButton(CursesWindow):
     """handle form button"""
 
     def __init__(self, screen, ui_config):
+        """Initialize the handler for a form button.
+
+        :param screen:  A curses window
+        :param ui_config: The current user interface configuration
+        """
         super().__init__(ui_config=ui_config)
         self._form_field = None
         self._form_fields = None

--- a/src/ansible_navigator/ui_framework/form_handler_button.py
+++ b/src/ansible_navigator/ui_framework/form_handler_button.py
@@ -9,8 +9,6 @@ from typing import Tuple
 
 from .curses_defs import CursesLinePart
 from .curses_window import CursesWindow
-from .curses_window import Window
-from .ui_config import UIConfig
 
 
 if TYPE_CHECKING:

--- a/src/ansible_navigator/ui_framework/form_handler_information.py
+++ b/src/ansible_navigator/ui_framework/form_handler_information.py
@@ -18,6 +18,11 @@ class FormHandlerInformation(CursesWindow):
     """handle form button"""
 
     def __init__(self, screen, ui_config):
+        """Initialize the handler for a informational notification.
+
+        :param screen: A curses window
+        :param ui_config: The current user interface configuration
+        """
         super().__init__(ui_config=ui_config)
         self._screen = screen
 

--- a/src/ansible_navigator/ui_framework/form_handler_options.py
+++ b/src/ansible_navigator/ui_framework/form_handler_options.py
@@ -21,6 +21,11 @@ class FormHandlerOptions(CursesWindow):
     """handle form checkbox field"""
 
     def __init__(self, screen, ui_config):
+        """Initialize the handler for either form checkboxes or radio button.
+
+        :param screen: A curses window
+        :param ui_config: The current user interface configuration
+        """
         super().__init__(ui_config=ui_config)
         self._screen = screen
 

--- a/src/ansible_navigator/ui_framework/form_handler_options.py
+++ b/src/ansible_navigator/ui_framework/form_handler_options.py
@@ -21,7 +21,7 @@ class FormHandlerOptions(CursesWindow):
     """handle form checkbox field"""
 
     def __init__(self, screen, ui_config):
-        """Initialize the handler for either form checkboxes or radio button.
+        """Initialize the handler for either form checkboxes or radio buttons.
 
         :param screen: A curses window
         :param ui_config: The current user interface configuration

--- a/src/ansible_navigator/ui_framework/form_handler_text.py
+++ b/src/ansible_navigator/ui_framework/form_handler_text.py
@@ -16,6 +16,11 @@ class FormHandlerText(CursesWindow, Textbox):
     """Get one line of text input"""
 
     def __init__(self, screen, ui_config):
+        """Initialize the handler for a form text field.
+
+        :param screen: A curses window
+        :param ui_config: The current user interface configuration
+        """
         super().__init__(ui_config=ui_config)
         self.input_line_cache = []
         self.input_line_pointer = 0

--- a/src/ansible_navigator/ui_framework/form_handler_working.py
+++ b/src/ansible_navigator/ui_framework/form_handler_working.py
@@ -18,6 +18,11 @@ class FormHandlerWorking(CursesWindow):
     """handle form button"""
 
     def __init__(self, screen, ui_config):
+        """Initialize the handler for a form working notification.
+
+        :param screen: A curses window
+        :param ui_config: The current user interface configuration
+        """
         super().__init__(ui_config=ui_config)
         self._screen = screen
 

--- a/src/ansible_navigator/ui_framework/form_presenter.py
+++ b/src/ansible_navigator/ui_framework/form_presenter.py
@@ -41,6 +41,12 @@ class FormPresenter(CursesWindow):
     # pylint: disable=too-many-instance-attributes
     # pylint: disable=too-few-public-methods
     def __init__(self, form, screen, ui_config):
+        """Initialize the form presenter.
+
+        :param form: The form to present to the user
+        :param screen: A curses window
+        :param ui_config: The current user interface configuration
+        """
         super().__init__(ui_config=ui_config)
         self._form = form
         self._screen = screen

--- a/src/ansible_navigator/ui_framework/menu_builder.py
+++ b/src/ansible_navigator/ui_framework/menu_builder.py
@@ -30,6 +30,14 @@ class MenuBuilder:
         color_menu_item: Callable,
         ui_config: UIConfig,
     ):
+        """Initialize the menu builder.
+
+        :param pbar_width:  The width of the progress bar
+        :param screen_w: The current screen width
+        :param number_colors: The number of colors the current terminal supports
+        :param color_menu_item: The callback for adding color to menu entries
+        :param ui_config: The current user interface configuration
+        """
         # pylint: disable=too-many-arguments
         self._number_colors = number_colors
         self._pbar_width = pbar_width


### PR DESCRIPTION
This adds doc sting to the `__init__` functions within the UI subsystem where missing.

This is part of a continuing effort to clean up documentation.

Note: param type was not added in anticipation of eventually being able to carry from forward form the type hints in the signature.

The `flake8` file will be updated later when all `D107` errors reported by `flake8-pydocstyle` (being vetted) are fixed.
