### PR TITLE
Add doc string to `__init__` in 7 files

### DIFF
--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -43,6 +43,10 @@ class CollectionCatalog:
     """collection cataloger"""
 
     def __init__(self, directories: List[str]):
+        """Initialize the collection cataloger.
+
+        :param directories: A list of directories that may contain collections
+        """
         self._directories = directories
         self._collections: OrderedDict[str, Dict] = OrderedDict()
         self._errors: List[Dict[str, str]] = []

--- a/share/ansible_navigator/utils/key_value_store.py
+++ b/share/ansible_navigator/utils/key_value_store.py
@@ -7,6 +7,10 @@ class KeyValueStore(dict):
     """use sqlite as a k,v store"""
 
     def __init__(self, filename):
+        """Initialize the key value store.
+
+        :param filename: The full path to the sqlite database file
+        """
         # pylint: disable=super-init-not-called
         self.conn = sqlite3.connect(filename)
         self.path = filename

--- a/src/ansible_navigator/command_runner/command_runner.py
+++ b/src/ansible_navigator/command_runner/command_runner.py
@@ -57,6 +57,7 @@ class CommandRunner:
     """I run commands"""
 
     def __init__(self):
+        """Initialize the command runner."""
         self._completed_queue: Union[Queue, None] = None
         self._pending_queue: Union[Queue, None] = None
 

--- a/src/ansible_navigator/configuration_subsystem/parser.py
+++ b/src/ansible_navigator/configuration_subsystem/parser.py
@@ -20,6 +20,10 @@ class Parser:
 
     # pylint: disable=too-few-public-methods
     def __init__(self, config: ApplicationConfiguration):
+        """Initialize the command line interface parameter parser.
+
+        :param config: The current settings for the application
+        """
         self._config = config
         self._base_parser = ArgumentParser(add_help=False)
         self._configure_base()

--- a/src/ansible_navigator/image_manager/puller.py
+++ b/src/ansible_navigator/image_manager/puller.py
@@ -24,6 +24,12 @@ class ImagePuller:
     """Image puller"""
 
     def __init__(self, container_engine: str, image: str, pull_policy: str):
+        """Initialize the container image puller.
+
+        :param container_engine: The name of the container engine
+        :param image: The name of the image to pull
+        :param pull_policy: The current pull policy from the settings
+        """
         self._assessment = ImageAssessment
         self._container_engine = container_engine
         self._exit_messages: List[ExitMessage] = []

--- a/src/ansible_navigator/tm_tokenize/grammars.py
+++ b/src/ansible_navigator/tm_tokenize/grammars.py
@@ -45,6 +45,10 @@ class Grammar(NamedTuple):
 
 class Grammars:
     def __init__(self, *directories: str) -> None:
+        """Initialize an instance of Grammars.
+
+        :param directories: A tuple of strings, each a directory in which grammar files can be found
+        """
         self._scope_to_files = {
             os.path.splitext(filename)[0]: os.path.join(directory, filename)
             for directory in directories

--- a/tests/integration/_action_run_test.py
+++ b/tests/integration/_action_run_test.py
@@ -39,6 +39,23 @@ class ActionRunTest:
         rotate_artifacts: Optional[int] = None,
         timeout: Optional[int] = None,
     ) -> None:
+        """Initialize the test runner for an action.
+
+        :param action_name: The name of the action tests will be run against
+        :param container_engine: The name of the container engine
+        :param container_options: Any options being passed directly to the container engine
+        :param execution_environment: A boolean indicating if an execution environment
+            should be used
+        :param execution_environment_image: The name of the execution environment image to be used
+        :param host_cwd: The current working directory for the host
+        :param set_environment_variable: Any environment variable to set in the
+            execution environment
+        :param pass_environment_variable: Any environment variables to pass into the
+            execution environment
+        :param private_data_dir: The artifact directory for ansible runner
+        :param rotate_artifacts: The number of artifacts ansible runner should maintain
+        :param timeout: The ansible runner timeout value
+        """
         self._action_name = action_name
         self._container_engine = container_engine
         self._container_options = container_options


### PR DESCRIPTION
This adds doc sting to the __init__ functions in 7 different files. the list is getting smaller so these are spread across multiple directories and subsystems.

This is part of a continuing effort to clean up documentation.

Note: param type was not added in anticipation of eventually being able to carry from forward form the type hints in the signature.

The flake8 file will be updated later when all D107 errors reported by flake8-pydocstyle (being vetted) are fixed.