### PR TITLE
Add more vars to tox passenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,14 @@ commands =
 setenv =
   TERM = xterm-256color
 passenv =
+  CI
+  GITHUB_*
+  CONTAINER_*
+  DOCKER_*
   HOME
+  PYTEST_*
+  SSH_AUTH_SOCK
+  TERM
   USER
   XDIST_CPU
 


### PR DESCRIPTION
This adds a list of variables that we want to pass to tox
environments, some of them being critical for functioning of podman
and docker. Fixes the problem that prevented use of remote container
engines with tox.

The list was based on what we use on other similar projects, like
molecule-podman and molecule-docker.
