### PR TITLE
Remove link in `actions/run.py` to Interaction

### DIFF
--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -254,8 +254,7 @@ class Action(App):
 
         :param interaction: The interaction from the user
         :param app: The app instance
-        :return: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction` or
-            :data:`None`
+        :return: The pending interaction or none
         """
 
         self._prepare_to_run(app, interaction)


### PR DESCRIPTION
This caused an error in #818 

```
/home/docs/checkouts/readthedocs.org/user_builds/ansible-navigator/envs/818/lib/python3.8/site-packages/ansible_navigator/actions/run.py:docstring of ansible_navigator.actions.run.Action._prepare_to_quit:: WARNING: more than one target found for cross-reference 'Interaction': ansible_navigator.ui_framework.Interaction, ansible_navigator.ui_framework.ui.Interaction
```

Eventually we would like to carry over the type hints in the signature, so this should be necessary.  (The link to Interaction and None does currently work, it just has to clicked above the return)