### PR TITLE
[tests] Changes to frequently failing templar integration tests

### DIFF
--- a/tests/fixtures/integration/actions/templar/test_direct_interactive_ee.py/test/10.json
+++ b/tests/fixtures/integration/actions/templar/test_direct_interactive_ee.py/test/10.json
@@ -1,0 +1,35 @@
+{
+    "name": "test[10-:q!-exit vi]",
+    "index": 10,
+    "comment": "exit vi",
+    "additional_information": {
+        "look_fors": [],
+        "look_nots": [],
+        "compared_fixture": true
+    },
+    "output": [
+        "PLAY [run integration test play-1:0] *******************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************",
+        "TASK [debug print play-1 task-1] ***********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************",
+        "OK: [localhost] This is play-1 task-1",
+        " 0│---",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        " 3│event_loop: null",
+        " 4│host: localhost",
+        " 5│play: run integration test play-1",
+        " 6│play_pattern: localhost",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        " 8│remote_addr: localhost",
+        " 9│res:",
+        "10│  _ansible_no_log: false",
+        "11│  _ansible_verbose_always: true",
+        "12│  changed: false",
+        "13│  msg: This is play-1 task-1",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "15│task: debug print play-1 task-1",
+        "16│task_action: debug",
+        "17│task_args: ''",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "^f/PgUp page up                                                  ^b/PgDn page down                                                  ↑↓ scroll                                                  esc back                                                  - previous                                                  + next                                                  [0-9] goto                                                  :help help                                                     SUCCESSFUL"
+    ]
+}

--- a/tests/fixtures/integration/actions/templar/test_direct_interactive_ee.py/test/9.json
+++ b/tests/fixtures/integration/actions/templar/test_direct_interactive_ee.py/test/9.json
@@ -4,7 +4,7 @@
     "comment": "goto vi",
     "additional_information": {
         "look_fors": [
-            "---"
+            "name: run integration test play-1"
         ],
         "look_nots": [],
         "compared_fixture": false

--- a/tests/fixtures/integration/actions/templar/test_direct_interactive_noee.py/test/10.json
+++ b/tests/fixtures/integration/actions/templar/test_direct_interactive_noee.py/test/10.json
@@ -1,0 +1,35 @@
+{
+    "name": "test[10-:q!-exit vi]",
+    "index": 10,
+    "comment": "exit vi",
+    "additional_information": {
+        "look_fors": [],
+        "look_nots": [],
+        "compared_fixture": true
+    },
+    "output": [
+        "PLAY [run integration test play-1:0] *******************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************",
+        "TASK [debug print play-1 task-1] ***********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************",
+        "OK: [localhost] This is play-1 task-1",
+        " 0│---",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        " 3│event_loop: null",
+        " 4│host: localhost",
+        " 5│play: run integration test play-1",
+        " 6│play_pattern: localhost",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        " 8│remote_addr: localhost",
+        " 9│res:",
+        "10│  _ansible_no_log: false",
+        "11│  _ansible_verbose_always: true",
+        "12│  changed: false",
+        "13│  msg: This is play-1 task-1",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "15│task: debug print play-1 task-1",
+        "16│task_action: debug",
+        "17│task_args: ''",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "^f/PgUp page up                                                  ^b/PgDn page down                                                  ↑↓ scroll                                                  esc back                                                  - previous                                                  + next                                                  [0-9] goto                                                  :help help                                                     SUCCESSFUL"
+    ]
+}

--- a/tests/fixtures/integration/actions/templar/test_direct_interactive_noee.py/test/5.json
+++ b/tests/fixtures/integration/actions/templar/test_direct_interactive_noee.py/test/5.json
@@ -62,7 +62,7 @@
         " 48│    variables or expressions without necessarily halting the playbook.",
         " 49│  - Useful for debugging together with the 'when:' directive.",
         " 50│  - This module is also supported for Windows targets.",
-        " 51│  filename: /home/user/github/ansible-navigator/.tox/py38/lib/python3.8/site-packages/ansible/modules/debug.py",
+        " 51│  filename: /home/user/github/ansible-navigator/venv/lib64/python3.10/site-packages/ansible/modules/debug.py",
         " 52│  has_action: true",
         " 53│  module: debug",
         " 54│  options:",

--- a/tests/fixtures/integration/actions/templar/test_direct_interactive_noee.py/test/7.json
+++ b/tests/fixtures/integration/actions/templar/test_direct_interactive_noee.py/test/7.json
@@ -62,7 +62,7 @@
         " 48│    variables or expressions without necessarily halting the playbook.",
         " 49│  - Useful for debugging together with the 'when:' directive.",
         " 50│  - This module is also supported for Windows targets.",
-        " 51│  filename: /home/user/github/ansible-navigator/.tox/py38/lib/python3.8/site-packages/ansible/modules/debug.py",
+        " 51│  filename: /home/user/github/ansible-navigator/venv/lib64/python3.10/site-packages/ansible/modules/debug.py",
         " 52│  has_action: true",
         " 53│  module: debug",
         " 54│  options:",

--- a/tests/fixtures/integration/actions/templar/test_direct_interactive_noee.py/test/9.json
+++ b/tests/fixtures/integration/actions/templar/test_direct_interactive_noee.py/test/9.json
@@ -4,7 +4,7 @@
     "comment": "goto vi",
     "additional_information": {
         "look_fors": [
-            "---"
+            "name: run integration test play-1"
         ],
         "look_nots": [],
         "compared_fixture": false

--- a/tests/fixtures/integration/actions/templar/test_welcome_interactive_ee.py/test/10.json
+++ b/tests/fixtures/integration/actions/templar/test_welcome_interactive_ee.py/test/10.json
@@ -4,7 +4,7 @@
     "comment": "goto vi",
     "additional_information": {
         "look_fors": [
-            "---"
+            "name: run integration test play-1"
         ],
         "look_nots": [],
         "compared_fixture": false

--- a/tests/fixtures/integration/actions/templar/test_welcome_interactive_ee.py/test/11.json
+++ b/tests/fixtures/integration/actions/templar/test_welcome_interactive_ee.py/test/11.json
@@ -1,0 +1,35 @@
+{
+    "name": "test[11-:q!-exit vi]",
+    "index": 11,
+    "comment": "exit vi",
+    "additional_information": {
+        "look_fors": [],
+        "look_nots": [],
+        "compared_fixture": true
+    },
+    "output": [
+        "PLAY [run integration test play-1:0] *******************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************",
+        "TASK [debug print play-1 task-1] ***********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************",
+        "OK: [localhost] This is play-1 task-1",
+        " 0│---",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        " 3│event_loop: null",
+        " 4│host: localhost",
+        " 5│play: run integration test play-1",
+        " 6│play_pattern: localhost",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        " 8│remote_addr: localhost",
+        " 9│res:",
+        "10│  _ansible_no_log: false",
+        "11│  _ansible_verbose_always: true",
+        "12│  changed: false",
+        "13│  msg: This is play-1 task-1",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "15│task: debug print play-1 task-1",
+        "16│task_action: debug",
+        "17│task_args: ''",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "^f/PgUp page up                                                  ^b/PgDn page down                                                  ↑↓ scroll                                                  esc back                                                  - previous                                                  + next                                                  [0-9] goto                                                  :help help                                                     SUCCESSFUL"
+    ]
+}

--- a/tests/fixtures/integration/actions/templar/test_welcome_interactive_noee.py/test/10.json
+++ b/tests/fixtures/integration/actions/templar/test_welcome_interactive_noee.py/test/10.json
@@ -4,7 +4,7 @@
     "comment": "goto vi",
     "additional_information": {
         "look_fors": [
-            "---"
+            "name: run integration test play-1"
         ],
         "look_nots": [],
         "compared_fixture": false

--- a/tests/fixtures/integration/actions/templar/test_welcome_interactive_noee.py/test/11.json
+++ b/tests/fixtures/integration/actions/templar/test_welcome_interactive_noee.py/test/11.json
@@ -1,0 +1,35 @@
+{
+    "name": "test[11-:q!-exit vi]",
+    "index": 11,
+    "comment": "exit vi",
+    "additional_information": {
+        "look_fors": [],
+        "look_nots": [],
+        "compared_fixture": true
+    },
+    "output": [
+        "PLAY [run integration test play-1:0] *******************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************",
+        "TASK [debug print play-1 task-1] ***********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************",
+        "OK: [localhost] This is play-1 task-1",
+        " 0│---",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        " 3│event_loop: null",
+        " 4│host: localhost",
+        " 5│play: run integration test play-1",
+        " 6│play_pattern: localhost",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        " 8│remote_addr: localhost",
+        " 9│res:",
+        "10│  _ansible_no_log: false",
+        "11│  _ansible_verbose_always: true",
+        "12│  changed: false",
+        "13│  msg: This is play-1 task-1",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "15│task: debug print play-1 task-1",
+        "16│task_action: debug",
+        "17│task_args: ''",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "^f/PgUp page up                                                  ^b/PgDn page down                                                  ↑↓ scroll                                                  esc back                                                  - previous                                                  + next                                                  [0-9] goto                                                  :help help                                                     SUCCESSFUL"
+    ]
+}

--- a/tests/fixtures/integration/actions/templar/test_welcome_interactive_noee.py/test/6.json
+++ b/tests/fixtures/integration/actions/templar/test_welcome_interactive_noee.py/test/6.json
@@ -62,7 +62,7 @@
         " 48│    variables or expressions without necessarily halting the playbook.",
         " 49│  - Useful for debugging together with the 'when:' directive.",
         " 50│  - This module is also supported for Windows targets.",
-        " 51│  filename: /home/user/github/ansible-navigator/.tox/py38/lib/python3.8/site-packages/ansible/modules/debug.py",
+        " 51│  filename: /home/user/github/ansible-navigator/venv/lib64/python3.10/site-packages/ansible/modules/debug.py",
         " 52│  has_action: true",
         " 53│  module: debug",
         " 54│  options:",

--- a/tests/fixtures/integration/actions/templar/test_welcome_interactive_noee.py/test/8.json
+++ b/tests/fixtures/integration/actions/templar/test_welcome_interactive_noee.py/test/8.json
@@ -62,7 +62,7 @@
         " 48│    variables or expressions without necessarily halting the playbook.",
         " 49│  - Useful for debugging together with the 'when:' directive.",
         " 50│  - This module is also supported for Windows targets.",
-        " 51│  filename: /home/user/github/ansible-navigator/.tox/py38/lib/python3.8/site-packages/ansible/modules/debug.py",
+        " 51│  filename: /home/user/github/ansible-navigator/venv/lib64/python3.10/site-packages/ansible/modules/debug.py",
         " 52│  has_action: true",
         " 53│  module: debug",
         " 54│  options:",

--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -37,8 +37,8 @@ base_steps = (
     Step(
         user_input=":open {{ task_path }}",
         comment="goto vi",
-        search_within_response="---",
-        # look_fors=["---"],
+        search_within_response="name: run integration test play-1",
+        look_fors=["name: run integration test play-1"],
     ),
     Step(user_input=":q!", comment="exit vi"),
 )
@@ -82,10 +82,11 @@ class BaseClass:
         else:
             search_within_response = step.search_within_response
 
-        received_output = tmux_session.interaction(
+        original_output = tmux_session.interaction(
             value=step.user_input,
             search_within_response=search_within_response,
         )
+        received_output = original_output
 
         if step.mask:
             # mask out some configuration that is subject to change each run
@@ -128,5 +129,5 @@ class BaseClass:
                 expected_output = json.load(infile)["output"]
 
             assert expected_output == received_output, "\n" + "\n".join(
-                difflib.unified_diff(expected_output, received_output, "expected", "received"),
+                difflib.unified_diff(expected_output, original_output, "expected", "received"),
             )

--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -82,11 +82,11 @@ class BaseClass:
         else:
             search_within_response = step.search_within_response
 
-        original_output = tmux_session.interaction(
+        unmasked_output = tmux_session.interaction(
             value=step.user_input,
             search_within_response=search_within_response,
         )
-        received_output = original_output
+        received_output = unmasked_output
 
         if step.mask:
             # mask out some configuration that is subject to change each run
@@ -129,5 +129,5 @@ class BaseClass:
                 expected_output = json.load(infile)["output"]
 
             assert expected_output == received_output, "\n" + "\n".join(
-                difflib.unified_diff(expected_output, original_output, "expected", "received"),
+                difflib.unified_diff(expected_output, received_output, "expected", "received"),
             )

--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -38,7 +38,7 @@ base_steps = (
         user_input=":open {{ task_path }}",
         comment="goto vi",
         search_within_response="---",
-        look_fors=["---"],
+        # look_fors=["---"],
     ),
     Step(user_input=":q!", comment="exit vi"),
 )

--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -40,6 +40,7 @@ base_steps = (
         search_within_response="---",
         look_fors=["---"],
     ),
+    Step(user_input=":q!", comment="exit vi"),
 )
 
 


### PR DESCRIPTION
Noticed in #812 , many of the test failures were related to the templar integration tests.

Several changes were made, hoping to reduce the number of failures

1) Exit vi after opening it, I don't suspect this made a difference, but it seem like a polite thing to do and was left in
2) Added a new local to the base class called, unmasked output, because we log locals, we should now see both the masked output and unmasked output from the tmux session if this happens again
3) Changes the search_within_response and look_for for the vi test to seach and look for something that was not previously on the screen, I suspect we were assuming vi had started when in fact we simply caught the `---` from the previous TASK screen


Fixtures were updated and added needed


Note: the files that were changes in the `filename:` line can be ignored, that is not used for comparison and is a byproduct of env differences on the developer machine were the fixtures were built.  It should be sanitized at some point later....