### PR TITLE
Introduce an intermediate lint-candidates target

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -59,26 +59,23 @@ Prerequisites:
    ```
 
 4. We also suggest you to _optionally_ run the following check that is
-   not yet enforced (meaning you can skip it, especially since it's
-   annoyingly slow):
+   not yet enforced (meaning you can skip it):
 
    ```shell-session
-   $ tox -e lint-vetting
-   lint-vetting create: .tox/lint-vetting
-   lint-vetting installdeps: pre-commit, pylint ~= 2.8.0, pylint-pytest < 1.1.0
-   lint-vetting installed: ...
-   lint-vetting run-test-pre: PYTHONHASHSEED='2351399476'
-   lint-vetting run-test: commands[0] | python -m pre_commit run ...--all-files
+   $ tox -e lint-candidates
+   lint-candidates create: .tox/lint-candidates
+   lint-candidates installdeps: pre-commit
+   lint-candidates installed: ...
+   lint-candidates run-test-pre: PYTHONHASHSEED='2351399476'
+   lint-candidates run-test: commands[0] | python -m pre_commit run ...--all-files
    ...
-   [INFO] Initializing environment for https://github.com/asottile/add-trail...
-   ...
-   [INFO] Installing environment for https://github.com/asottile/add-trailin...
+   [INFO] Installing environment for https://github.com/PyCQA/flake8.git
    [INFO] Once installed this environment will be reused.
    [INFO] This may take a few minutes...
    ...
-   Add trailing commas...............................(no files to check)Skipped
-   - hook id: add-trailing-comma
+   An unenforced set of flake8 candidate rule candidates.................Passed
+   - hook id: flake8
    ...
    _________________________________ summary __________________________________
-   ERROR:   lint-vetting: commands failed
+   ERROR:   lint-candidates: commands failed
    ```

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -27,7 +27,7 @@ jobs:
         python-version:
           - 3.8
         include:
-          - tox_env: lint-vetting
+          - tox_env: lint-candidates
             devel: true
           - tox_env: py36
             python-version: 3.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -169,6 +169,22 @@ repos:
     - flake8-2020 >= 1.6.0
     - flake8-isort >= 4.1.1
   - id: flake8
+    alias: flake8-rule-candidates
+    name: An unenforced set of flake8 candidate rule candidates
+    args:
+    - --ignore=
+    - --extend-ignore=
+    - >-
+      --select=
+      D,
+      DAR,
+    language_version: python3
+    additional_dependencies:
+    - darglint
+    - flake8-docstrings
+    stages:
+    - manual
+  - id: flake8
     alias: flake8-extended
     name: >-
       An unenforced set of strict flake8 plugins,

--- a/tox.ini
+++ b/tox.ini
@@ -90,7 +90,24 @@ setenv =
   # NOTE: value of the `SKIP` env var must not be updated separately
   # NOTE: from changing the pre-commit setup.
   {[testenv]setenv}
-  SKIP = mypy-py310
+  SKIP = flake8-rule-candidates, mypy-py310
+
+
+[testenv:lint-candidates]
+description =
+  Code quality improvement candidate rules for flake8
+  under `{basepython}` ({envpython})
+commands =
+  {envpython} -m \
+    pre_commit run \
+    --show-diff-on-failure \
+    --hook-stage manual \
+    flake8-rule-candidates \
+    {posargs:--all-files -v}
+deps =
+  pre-commit
+isolated_build = true
+skip_install = true
 
 
 [testenv:lint-vetting]


### PR DESCRIPTION
This change exposes an additional vetting-like linting environment
that is limited to rules that are actively being addressed by the
contributors. This rules sub-list is to be kept small so that it
could be promoted put to voting and made enforced easily. Once the
rules are in a good shape, a new focused list of related rules can
take their place and become linting candidates.