### PR TITLE
Avoid using bash when calling pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,11 @@ commands =
   /bin/bash -c 'podman pull -q {[base]default_ee} || docker pull -q {[base]default_ee}'
   /bin/bash -c 'podman pull -q {[base]small_test_ee} || docker pull -q {[base]small_test_ee}'
   # most coverage options are kept in pyproject.toml
-  /bin/bash -c 'py.test -vvvv -n `python -c "import multiprocessing; import os; print(int(os.environ.get(\"XDIST_CPU\") or multiprocessing.cpu_count()))"` --dist=loadfile --maxfail=15 --durations=100 --cov --cov-report=xml:{toxworkdir}/coverage-{envname}.xml --showlocals {posargs}'
+  # if you want to limit multiprocessing locally, define PYTEST_ADDOPTS="-n0 --dist no"
+  pytest {posargs:-vvvv \
+    -n auto --dist=loadfile --maxfail=15 \
+    --durations=100 --cov --cov-report=xml:{toxworkdir}/coverage-{envname}.xml --showlocals \
+    {env:PYTEST_ADDOPTS}}
 setenv =
   TERM = xterm-256color
 passenv =


### PR DESCRIPTION
This change simplified the way we call pytest from tox, while still allowing user to customize the way pytest runs locally via [PYTEST_ADDOPTS](https://docs.pytest.org/en/latest/example/simple.html#how-to-change-command-line-options-defaults), which is more flexible.

In fact this change gives more control to the user as it can define any other options while removing the makeshift hack for controlling the multiprocessing only.

This change needs @cidrblock review in particular as it removing th XDIST_CPU which is used by him and will require him to evaluate the benefits of the new approach.