### PR TITLE
Move most coverage options to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,14 @@
 [tool.black]
 line-length = 100
 
+[tool.coverage.run]
+    branch = true
+    source_pkgs = ["ansible_navigator"]
+    source = ["share"]
+
+[tool.coverage.report]
+    show_missing = true
+
 [tool.isort]
 force_single_line = true # Force from .. import to be 1 per line, minimizing changes at time of implementation
 known_first_party = "ansible_navigator, key_value_store" # No effect at implementation, here anticipating future benefit

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,8 @@ commands =
   /bin/bash -c 'grep -iFInrq "UPDATE_FIXTURES = True" ./tests && exit 1 || exit 0'
   /bin/bash -c 'podman pull -q {[base]default_ee} || docker pull -q {[base]default_ee}'
   /bin/bash -c 'podman pull -q {[base]small_test_ee} || docker pull -q {[base]small_test_ee}'
-  /bin/bash -c 'py.test -vvvv -n `python -c "import multiprocessing; import os; print(int(os.environ.get(\"XDIST_CPU\") or multiprocessing.cpu_count()))"` --dist=loadfile --maxfail=15 --durations=100 --cov ansible_navigator --cov share --cov-report term-missing --cov-branch --cov-report=xml:{toxworkdir}/coverage-{envname}.xml --showlocals {posargs}'
+  # most coverage options are kept in pyproject.toml
+  /bin/bash -c 'py.test -vvvv -n `python -c "import multiprocessing; import os; print(int(os.environ.get(\"XDIST_CPU\") or multiprocessing.cpu_count()))"` --dist=loadfile --maxfail=15 --durations=100 --cov --cov-report=xml:{toxworkdir}/coverage-{envname}.xml --showlocals {posargs}'
 setenv =
   TERM = xterm-256color
 passenv =
@@ -44,14 +45,14 @@ passenv =
 
 [testenv:clean]
 description = Erase coverage data
-deps = coverage
+deps = coverage[toml]
 skip_install = true
 commands =
   coverage erase
 
 [testenv:report]
 description = Produce coverage report
-deps = coverage
+deps = coverage[toml]
 skip_install = true
 commands =
     coverage report


### PR DESCRIPTION
This simplifies pytest calling and also makes most coverage settings tox agnostic, so other tools can load them.
