### PR TITLE
chore: fix concurrency condition for pushes

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -2,7 +2,7 @@ name: tox
 
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
```
The workflow is not valid. .github/workflows/tox.yml (Line: 5, Col: 10): Unexpected type of value '', expected type: String.
```
Fixes problem seen at https://github.com/ansible/ansible-navigator/actions/runs/1769433832/workflow
by using https://github.community/t/concurrecy-not-work-for-push/183068
