### PR TITLE
[exec] *actually* set env vars from config

### DIFF
--- a/src/ansible_navigator/actions/exec.py
+++ b/src/ansible_navigator/actions/exec.py
@@ -80,7 +80,7 @@ class Action(App):
                 log_message,
                 self._args.set_environment_variable,
             )
-        envvars_to_set = {}
+            envvars_to_set = {}
 
         if self._args.display_color is False:
             envvars_to_set["ANSIBLE_NOCOLOR"] = "1"

--- a/tests/fixtures/integration/actions/exec/ansible-navigator.yaml
+++ b/tests/fixtures/integration/actions/exec/ansible-navigator.yaml
@@ -1,4 +1,8 @@
 ansible-navigator:
+  execution-environment:
+    environment-variables:
+      set:
+        ANSIBLE_COLLECTIONS_PATHS: /tmp/collections
   exec:
     command: echo test_data_from_config
     shell: False

--- a/tests/integration/actions/exec/test_stdout_config_file.py
+++ b/tests/integration/actions/exec/test_stdout_config_file.py
@@ -41,6 +41,14 @@ stdout_tests = (
         ).join(),
         look_nots=["/sbin"],
     ),
+    ShellCommand(
+        comment="ensure env vars get set from config",
+        user_input=StdoutCommand(
+            cmdline="--excmd '/bin/env'",
+            execution_environment=True,
+        ).join(),
+        look_fors=["ANSIBLE_COLLECTIONS_PATHS=/tmp/collections"],
+    ),
 )
 
 steps = add_indicies(stdout_tests)


### PR DESCRIPTION
Change:
- A misindentation caused 'ansible-navigator exec' to not actually get
  env vars from config.

Test Plan:
- new integration

Signed-off-by: Rick Elrod <rick@elrod.me>