### PR TITLE
Reduce pylint run time

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -302,9 +302,8 @@ repos:
     - jinja2
     - libtmux
     - onigurumacffi
-    - pylint-pytest < 1.1.0
+    - pytest
     - setuptools-scm
     - sphinx
     pass_filenames: false
-
 ...

--- a/go.sh
+++ b/go.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+for run in {1..5}
+do
+    pre-commit run pylint --all-files -v | grep duration
+    sleep 5
+done

--- a/go.sh
+++ b/go.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-for run in {1..5}
-do
-    pre-commit run pylint --all-files -v | grep duration
-    sleep 5
-done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,7 @@ skip_glob = ["tests/fixtures/common/collections*"] # Skip ansible content due to
     [tool.pylint.master]
     # tm_tokenize is virtually vendored and shouldn't be linted as such
     ignore = "tm_tokenize"
-
-    load-plugins = [
-      "pylint_pytest",  # suppresses false-positive violations in pytest tests
-    ]
+    jobs = 0
 
     [tool.pylint.messages_control]
     disable = [


### PR DESCRIPTION
Pylint was taking 30+s to run, this reduces it to less than 20.

- Remove pylint-pytest which is not currently needed
- Set jobs to 0 to use all CPUs

Details below

```
#!/bin/sh

for run in {1..5}
do
    pre-commit run pylint --all-files -v | grep duration
    sleep 5
done

---------------------------------------------------

Pre PR configuration:

- duration: 32.71s
- duration: 31.97s
- duration: 31.26s
- duration: 31.13s
- duration: 31.46s

Add pytest to dependencies in pyproject.toml:

- duration: 32.65s
- duration: 32.36s
- duration: 31.54s
- duration: 31.62s
- duration: 31.4s

Remove pylint-pytest from load_plugins and additional_dependencies:

- duration: 24.84s
- duration: 24.9s
- duration: 22.97s
- duration: 22.76s
- duration: 23.04s

Add jobs 0:

- duration: 17.15s
- duration: 16.91s
- duration: 16.58s
- duration: 16.48s
- duration: 18.97s

```

Reverts: #782 