### PR TITLE
Decrease probability of false-positive `templar` integration test failures

### DIFF
--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -27,13 +27,23 @@ base_steps = (
     Step(user_input=":{{ this[0] }}", comment="render menu as content"),
     Step(user_input=":back", comment="show play-1 details"),
     Step(user_input=":0", comment="task-1 details"),
-    Step(user_input=":doc", comment="doc for task", look_fors=["module: debug"], search_within_response="module: debug"),
+    Step(
+        user_input=":doc",
+        comment="doc for task",
+        look_fors=["module: debug"],
+        search_within_response="module: debug",
+    ),
     Step(
         user_input=":{{ examples }}",
         comment="dig examples",
         look_fors=["ansible.builtin.debug:"],
     ),
-    Step(user_input=":back", comment="show doc", look_fors=["module: debug"], search_within_response="module: debug"),
+    Step(
+        user_input=":back",
+        comment="show doc",
+        look_fors=["module: debug"],
+        search_within_response="module: debug",
+    ),
     Step(user_input=":back", comment="show task"),
     Step(
         user_input=":open {{ task_path }}",

--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -27,13 +27,13 @@ base_steps = (
     Step(user_input=":{{ this[0] }}", comment="render menu as content"),
     Step(user_input=":back", comment="show play-1 details"),
     Step(user_input=":0", comment="task-1 details"),
-    Step(user_input=":doc", comment="doc for task", look_fors=["module: debug"]),
+    Step(user_input=":doc", comment="doc for task", look_fors=["module: debug"], search_within_response="module: debug"),
     Step(
         user_input=":{{ examples }}",
         comment="dig examples",
         look_fors=["ansible.builtin.debug:"],
     ),
-    Step(user_input=":back", comment="show doc", look_fors=["module: debug"]),
+    Step(user_input=":back", comment="show doc", look_fors=["module: debug"], search_within_response="module: debug"),
     Step(user_input=":back", comment="show task"),
     Step(
         user_input=":open {{ task_path }}",


### PR DESCRIPTION
This adds a "search_within_response" to the steps that load a doc in the `templar` integration tests.

For those less familiar with the tmux tests, this is where we wait for a `search_within_response` value to be on the screen before looking for a `look_for` or simply return the response to compare against the fixture: https://github.com/ansible/ansible-navigator/blob/main/tests/integration/_tmux_session.py#L256


From https://github.com/ansible/ansible-navigator/issues/812 most of the recent failures are centered around the templar tests and loading a doc.

This has been run 18 times, with 2 failures unrelated to the `templar` tests, so I'm suggesting we merge this and reset the reporting in #812 from this point forward to identify new patterns.

