### PR TITLE
Eliminate a few flake8 violations with a vetted `autopep8`

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,10 @@
+[pep8]
+aggressive = 0
+in-place = true
+# Fixing E203 is disabled because it annoys black
+ignore =
+  E203,
+jobs = 0
+# Accessibility/large fonts and PEP8 unfriendly:
+max-line-length = 100
+recursive = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,13 @@ repos:
     - --py36-plus
     stages: ["manual"]
 
+- repo: https://github.com/pre-commit/mirrors-autopep8.git
+  rev: v1.6.0
+  hooks:
+  - id: autopep8
+    stages:
+    - manual
+
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.1
   hooks:

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -29,7 +29,6 @@ from . import run_action
 
 def color_menu(colno: int, colname: str, entry: Dict[str, Any]) -> Tuple[int, int]:
     # pylint: disable=unused-argument
-
     """color the menu"""
     if entry.get("__shadowed") is True:
         return 8, 0

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -31,7 +31,6 @@ from . import run_action
 
 def color_menu(colno: int, colname: str, entry: Dict[str, Any]) -> Tuple[int, int]:
     # pylint: disable=unused-argument
-
     """color the menu"""
     if entry["__default"] is False:
         return 3, 0

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -62,7 +62,6 @@ class Action(App):
 
     def color_menu(self, colno: int, colname: str, entry: Dict[str, Any]) -> Tuple[int, int]:
         # pylint: disable=unused-argument
-
         """color the menu"""
         # images list menu
         if "__full_name" in entry:

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -47,10 +47,17 @@ RESULT_TO_COLOR = [
     ("(?i)^in_progress$", 8),
 ]
 
-get_color = lambda word: next(  # noqa: E731
-    (x[1] for x in RESULT_TO_COLOR if re.match(x[0], word)),
-    0,
-)
+
+def get_color(status_word):
+    """Return a color value for a given status word."""
+    return next(
+        (
+            color_number
+            for status_pattern, color_number in RESULT_TO_COLOR
+            if re.match(status_pattern, status_word)
+        ),
+        0,
+    )
 
 
 def color_menu(_colno: int, colname: str, entry: Dict[str, Any]) -> Tuple[int, int]:

--- a/src/ansible_navigator/tm_tokenize/tokenize.py
+++ b/src/ansible_navigator/tm_tokenize/tokenize.py
@@ -17,7 +17,6 @@ def tokenize(
     line: str,
     first_line: bool,
 ) -> Tuple[State, Regions]:
-
     """tokenize a string into it's parts"""
     ret: List[Region] = []
     pos = 0

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -171,7 +171,11 @@ def hex_to_rgb_curses(value):
     :return: The colors scaled to 1000
     :rtype: tuple
     """
-    scale = lambda x: int(x * 1000 / 255)  # noqa: E731
+
+    def scale(color_value):
+        """Map an absolute single color value to a small integer."""
+        return int(color_value * 1000 / 255)
+
     red, green, blue = hex_to_rgb(value)
     return (scale(red), scale(green), scale(blue))
 

--- a/src/ansible_navigator/ui_framework/form_handler_options.py
+++ b/src/ansible_navigator/ui_framework/form_handler_options.py
@@ -48,7 +48,6 @@ class FormHandlerOptions(CursesWindow):
 
     def handle(self, idx, form_fields: List) -> Tuple[Union["FieldChecks", "FieldRadio"], int]:
         # pylint: disable=too-many-nested-blocks
-
         """handle the check box field"""
         form_field = form_fields[idx]
         active = 0

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,7 @@ setenv =
   # NOTE: value of the `SKIP` env var must not be updated separately
   # NOTE: from changing the pre-commit setup.
   {[testenv]setenv}
-  SKIP = flake8-extended, flake8-rule-candidates, mypy-py310
+  SKIP = autopep8, flake8-extended, flake8-rule-candidates, mypy-py310
 
 
 [testenv:lint-candidates]
@@ -92,6 +92,13 @@ description =
   Code quality improvement candidate rules for flake8
   under `{basepython}` ({envpython})
 commands =
+  {envpython} -m \
+    pre_commit run \
+    --show-diff-on-failure \
+    --hook-stage manual \
+    autopep8 \
+    {posargs:--all-files -v}
+
   {envpython} -m \
     pre_commit run \
     --show-diff-on-failure \


### PR DESCRIPTION
This patch takes care of small flake8/pydocstyle violations that can be autofixed like empty lines before docstrings or assigned lambdas (E731).

Extension of the pre-commit config is there to help out early adopters of linting candidates and does not affect anybody else in any other envs.