### PR TITLE
Reduce `pre-commit` verbosity in `tox.ini`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ description = Run pytest under {basepython} ({envpython})
 # one of it's layer
 allowlist_externals =
   cat
-  echo
   rm
   grep
 deps =
@@ -69,9 +68,6 @@ allowlist_externals = ansible-playbook
 [testenv:lint]
 description = Enforce quality standards under {basepython} ({envpython})
 install_command = pip install {opts} {packages}
-# NOTE: The following silences the list of installed python packages during the tox run
-# NOTE: it can be commented out as needed for troubleshooting
-list_dependencies_command = echo
 commands =
   pre-commit run {posargs:--show-diff-on-failure \
     --hook-stage manual \
@@ -105,9 +101,6 @@ commands =
 deps =
   pre-commit
 isolated_build = true
-# NOTE: The following silences the list of installed python packages during the tox run
-# NOTE: it can be commented out as needed for troubleshooting
-list_dependencies_command = echo
 skip_install = true
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ description = Run pytest under {basepython} ({envpython})
 # one of it's layer
 allowlist_externals =
   cat
+  echo
   rm
   grep
 deps =
@@ -68,10 +69,13 @@ allowlist_externals = ansible-playbook
 [testenv:lint]
 description = Enforce quality standards under {basepython} ({envpython})
 install_command = pip install {opts} {packages}
+# NOTE: The following silences the list of installed python packages during the tox run
+# NOTE: it can be commented out as needed for troubleshooting
+list_dependencies_command = echo
 commands =
   pre-commit run {posargs:--show-diff-on-failure \
     --hook-stage manual \
-    --all-files -v}
+    --all-files}
 deps =
   {[testenv]deps}
   -r{toxinidir}/docs/requirements.in
@@ -97,10 +101,13 @@ commands =
     --show-diff-on-failure \
     --hook-stage manual \
     flake8-rule-candidates \
-    {posargs:--all-files -v}
+    {posargs:--all-files}
 deps =
   pre-commit
 isolated_build = true
+# NOTE: The following silences the list of installed python packages during the tox run
+# NOTE: it can be commented out as needed for troubleshooting
+list_dependencies_command = echo
 skip_install = true
 
 


### PR DESCRIPTION
- Reduce the verbosity of the pre-commit output, when needed it can be enabled locally with `tox -e lint -- --all-files -v`
     