### PR TITLE
[image puller] fix tag parsing for port numbers

### DIFF
--- a/docs/changelog-fragments.d/863.bugfix.md
+++ b/docs/changelog-fragments.d/863.bugfix.md
@@ -1,0 +1,1 @@
+Fixed parsing of container image names to account for port numbers in registry servers.

--- a/src/ansible_navigator/image_manager/puller.py
+++ b/src/ansible_navigator/image_manager/puller.py
@@ -99,8 +99,18 @@ class ImagePuller:
         self._assessment.pull_required = pull
 
     def _extract_tag(self):
-        _image, _, image_tag = self._image.partition(":")
-        self._image_tag = image_tag or "latest"
+        image_pieces = self._image.split(":")
+        self._image_tag = "latest"
+        if len(image_pieces) > 1:
+            tag = image_pieces[-1]
+            if "/" not in tag:
+                # If there's a slash in the tag, it means we were probably given
+                # an image name that has a port number but no tag at the end.
+                # e.g.: registry.example.com:443/my/image
+                # In this case, we /don't/ want "443/my/image" to be considered
+                # a tag. Only if the ending doesn't have a slash in it, is it a
+                # valid tag.
+                self._image_tag = tag
         message = f"Image tag is: {self._image_tag}"
         self._log_message(level=logging.INFO, message=message)
 

--- a/tests/unit/image_manager/test_image_puller.py
+++ b/tests/unit/image_manager/test_image_puller.py
@@ -108,3 +108,28 @@ def test_will_have(valid_container_engine, pullable_image, data):
     assert image_puller.assessment.pull_required == data.pull_required
     image_puller.pull_stdout()
     assert image_puller.assessment.pull_required is False
+
+
+data_image_tag = [
+    ("foo", "latest"),
+    ("foo:bar", "bar"),
+    ("registry.redhat.io:443/ansible-automation-platform-21/ee-supported-rhel8", "latest"),
+    ("registry.redhat.io:443/ansible-automation-platform-21/ee-supported-rhel8:latest", "latest"),
+]
+
+
+@pytest.mark.parametrize(
+    "image, expected_tag",
+    data_image_tag,
+    ids=[
+        "simple image name, no tag specified",
+        "simple image name, with tag",
+        "complex image URL, with port but no tag",
+        "complex image URL, with port and tag",
+    ],
+)
+def test_tag_parsing(image, expected_tag):
+    """test that we parse image tags in a reasonable way"""
+    image_puller = ImagePuller("podman", image, "tag")
+    image_puller._extract_tag()  # pylint: disable=protected-access
+    assert image_puller._image_tag == expected_tag  # pylint: disable=protected-access


### PR DESCRIPTION
Change:
- Previously tag parsing broke if a port number for the registry was
  specified as part of the image URL.

Test Plan:
- New unit test

Tickets:
- Fixes #843

Signed-off-by: Rick Elrod <rick@elrod.me>