### PR TITLE
Disable anchors and aliases when serializing to yaml

### DIFF
--- a/src/ansible_navigator/_yaml.py
+++ b/src/ansible_navigator/_yaml.py
@@ -56,8 +56,13 @@ class HumanDumper(Dumper):
     # pylint: disable=too-many-ancestors
     """An instance of a pyyaml Dumper.
 
-    This deviates from the base to dump a multiline string in a human readable format.
+    This deviates from the base to dump a multiline string in a human readable format
+    and disables the use of anchors and aliases.
     """
+
+    def ignore_aliases(self, _data: Any) -> bool:
+        # Return true to disable use of anchors and aliases
+        return True
 
     def represent_scalar(
         self,

--- a/src/ansible_navigator/_yaml.py
+++ b/src/ansible_navigator/_yaml.py
@@ -61,7 +61,10 @@ class HumanDumper(Dumper):
     """
 
     def ignore_aliases(self, _data: Any) -> bool:
-        # Return true to disable use of anchors and aliases
+        """Return true to disable use of anchors and aliases.
+
+        :param _data: The data used to make the determination
+        """
         return True
 
     def represent_scalar(

--- a/src/ansible_navigator/_yaml.py
+++ b/src/ansible_navigator/_yaml.py
@@ -64,6 +64,7 @@ class HumanDumper(Dumper):
         """Return true to disable use of anchors and aliases.
 
         :param _data: The data used to make the determination
+        :returns: True, indicating aliases and anchors should not be used
         """
         return True
 

--- a/src/ansible_navigator/_yaml.py
+++ b/src/ansible_navigator/_yaml.py
@@ -61,7 +61,7 @@ class HumanDumper(Dumper):
     """
 
     def ignore_aliases(self, _data: Any) -> bool:
-        """Return true to disable use of anchors and aliases.
+        """Disable the use of anchors and aliases in the given data.
 
         :param _data: The data used to make the determination
         :returns: True, indicating aliases and anchors should not be used

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,5 @@ libtmux
 lxml
 pre-commit
 pytest-cov
+pytest-mock
 pytest-xdist

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,5 +3,4 @@ libtmux
 lxml
 pre-commit
 pytest-cov
-pytest-mock
 pytest-xdist

--- a/tests/unit/test_yaml.py
+++ b/tests/unit/test_yaml.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import patch
 
 from yaml import Dumper
+
 import ansible_navigator._yaml as yaml_import
 
 

--- a/tests/unit/test_yaml.py
+++ b/tests/unit/test_yaml.py
@@ -26,7 +26,7 @@ def test_no_anchor_alias():
 
 @patch("ansible_navigator._yaml.HumanDumper.ignore_aliases", Dumper.ignore_aliases)
 def test_anchor_alias():
-    """Ensure anchors and aliases are present with ignore_aliases defaulted."""
+    """Ensure anchors and aliases are present with ignore_aliases restored."""
     data = {"integer": 42}
     many_data = [data, data, data]
     result = yaml_import.human_dump(many_data)

--- a/tests/unit/test_yaml.py
+++ b/tests/unit/test_yaml.py
@@ -1,6 +1,10 @@
 """Tests related to the yaml abstraction layer.
 """
 
+from typing import Any
+from unittest.mock import patch
+
+from yaml import Dumper
 import ansible_navigator._yaml as yaml_import
 
 
@@ -9,3 +13,22 @@ def test_check_yaml_imports():
     assert yaml_import.yaml is not None
     assert yaml_import.Dumper is not None
     assert yaml_import.Loader is not None
+
+
+def test_no_anchor_alias():
+    """Ensure anchors and aliases are not present with ingore_aliases present."""
+    data = {"integer": 42}
+    many_data = [data, data, data]
+    result = yaml_import.human_dump(many_data)
+    assert "&id" not in result
+    assert "*id" not in result
+
+
+@patch("ansible_navigator._yaml.HumanDumper.ignore_aliases", Dumper.ignore_aliases)
+def test_anchor_alias():
+    """Ensure anchors and aliases are present with ignore_aliases defaulted."""
+    data = {"integer": 42}
+    many_data = [data, data, data]
+    result = yaml_import.human_dump(many_data)
+    assert "&id" in result
+    assert "*id" in result

--- a/tests/unit/test_yaml.py
+++ b/tests/unit/test_yaml.py
@@ -1,7 +1,6 @@
 """Tests related to the yaml abstraction layer.
 """
 
-from typing import Any
 from unittest.mock import patch
 
 from yaml import Dumper

--- a/tests/unit/test_yaml.py
+++ b/tests/unit/test_yaml.py
@@ -29,6 +29,6 @@ def test_anchor_alias():
     """Ensure anchors and aliases are present with ignore_aliases restored."""
     data = {"integer": 42}
     many_data = [data, data, data]
-    result = yaml_import.human_dump(many_data)
-    assert "&id" in result
-    assert "*id" in result
+    yaml_string = yaml_import.human_dump(many_data)
+    assert "&id" in yaml_string
+    assert "*id" in yaml_string


### PR DESCRIPTION
This will ensure anchors and aliases are not used when we show content as yaml on the screen.

This was found during work for the `:settings` subcommand stdout ouput because several settings had some key-values in common and they were anchored and aliased.

Tests to confirm.