### PR TITLE
Retry and warn for libtmux `server exited unexpectedly`

### DIFF
--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -76,7 +76,7 @@ class TmuxSession:
                 self._session = self._server.new_session(
                     session_name=self._session_name,
                     start_directory=self._cwd,
-                    # kill_session=True,
+                    kill_session=True,
                 )
                 break
             except libtmux.exc.LibTmuxException as exc:

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -69,11 +69,9 @@ class TmuxSession:
         https://github.com/ansible/ansible-navigator/issues/812
         """
         count = 1
-        tries = 5
+        tries = 3
         while count <= tries:
             try:
-                if count == 1:
-                    raise libtmux.exc.LibTmuxException("hello")
                 self._session = self._server.new_session(
                     session_name=self._session_name,
                     start_directory=self._cwd,

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -68,7 +68,6 @@ class TmuxSession:
         Retry here do to errors captured here:
         https://github.com/ansible/ansible-navigator/issues/812
         """
-
         count = 1
         tries = 5
         while count <= tries:

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -72,6 +72,8 @@ class TmuxSession:
         tries = 5
         while count <= tries:
             try:
+                if count == 1:
+                    raise libtmux.exc.LibTmuxException("hello")
                 self._session = self._server.new_session(
                     session_name=self._session_name,
                     start_directory=self._cwd,

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -3,6 +3,7 @@ import datetime
 import os
 import shlex
 import time
+import warnings
 
 from timeit import default_timer as timer
 from typing import List
@@ -50,6 +51,7 @@ class TmuxSession:
         self._pane_height = pane_height
         self._pane_width = pane_width
         self._pull_policy = pull_policy
+        self._session: libtmux.Session
         self._session_name = os.path.splitext(unique_test_id)[0]
         self._setup_capture: List
         self._setup_commands = setup_commands or []
@@ -60,16 +62,35 @@ class TmuxSession:
             # ensure CWD is top folder of library
             self._cwd = os.path.join(os.path.dirname(__file__), "..", "..")
 
+    def _build_tmux_session(self):
+        """Create a new tmux session.
+
+        Retry here do to errors captured here:
+        https://github.com/ansible/ansible-navigator/issues/812
+        """
+
+        count = 1
+        tries = 5
+        while count <= tries:
+            try:
+                self._session = self._server.new_session(
+                    session_name=self._session_name,
+                    start_directory=self._cwd,
+                    # kill_session=True,
+                )
+                break
+            except libtmux.exc.LibTmuxException as exc:
+                warnings.warn(f"tmux session failure #{count}: {str(exc)}", RuntimeWarning)
+                if count == tries:
+                    raise
+                count += 1
+
     def __enter__(self):
         # pylint: disable=attribute-defined-outside-init
         # pylint: disable=too-many-locals
         # pylint: disable=too-many-statements
         self._server = libtmux.Server()
-        self._session = self._server.new_session(
-            session_name=self._session_name,
-            start_directory=self._cwd,
-            kill_session=True,
-        )
+        self._build_tmux_session()
         self._window = self._session.new_window(self._session_name)
         self._pane = self._window.panes[0]
         self._pane.split_window(attach=False)

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands =
   /bin/bash -c 'podman pull -q {[base]default_ee} || docker pull -q {[base]default_ee}'
   /bin/bash -c 'podman pull -q {[base]small_test_ee} || docker pull -q {[base]small_test_ee}'
   # most coverage options are kept in pyproject.toml
-  /bin/bash -c 'py.test -vvvv -n `python -c "import multiprocessing; import os; print(int(os.environ.get(\"XDIST_CPU\") or multiprocessing.cpu_count()))"` --dist=loadfile --maxfail=15 --durations=100 --cov --cov-report=xml:{toxworkdir}/coverage-{envname}.xml --showlocals {posargs}'
+  /bin/bash -c 'py.test -vv -n `python -c "import multiprocessing; import os; print(int(os.environ.get(\"XDIST_CPU\") or multiprocessing.cpu_count()))"` --dist=loadfile --maxfail=15 --durations=100 --cov --cov-report=xml:{toxworkdir}/coverage-{envname}.xml --showlocals {posargs}'
 setenv =
   TERM = xterm-256color
 passenv =


### PR DESCRIPTION
We've seen a couple of these in the tests recently:

```
    
        if proc.stderr:
>           raise exc.LibTmuxException(proc.stderr)
E           libtmux.exc.LibTmuxException: ['server exited unexpectedly']
```
e.g. https://github.com/ansible/ansible-navigator/runs/5036171177?check_suite_focus=true

The message is coming from tmux itself, although raised by libtmux.

This includes some retry logic for the tmux session build, which is where the errors seem to be happening.

Each retry will be logged as warning like this (from a forced failure I created)

```
tests/integration/actions/templar/test_welcome_interactive_noee.py: 1 warning
  /home/runner/work/ansible-navigator/ansible-navigator/tests/integration/_tmux_session.py:84: RuntimeWarning: tmux session failure #1: hello
    warnings.warn(f"tmux session failure #{count}: {str(exc)}", RuntimeWarning)
```

Please add thoughts below, I'm generally ok with this even though it does not come with a complete understanding of what's going on.  

If this gets merged I'll reset the line in the tracking issue #812 