### PR TITLE
Documentation improvements in one `test_direct_interactive_ee_with_volmount.py` (D/DAR)

### DIFF
--- a/tests/integration/actions/collections/test_direct_interactive_ee_with_volmount.py
+++ b/tests/integration/actions/collections/test_direct_interactive_ee_with_volmount.py
@@ -1,5 +1,4 @@
-"""Tests for collections from CLI, interactive, with an EE and volmount.
-"""
+"""Tests for collections from CLI, interactive, with an EE and volume mount."""
 import pytest
 
 from .base import BaseClass


### PR DESCRIPTION
This puts the one-line doc string on one-line.

This file was not in the flake8 files, so no changes necessary there.