### PR TITLE
Guard against using unittest ecosystem within pylint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,14 @@ profile = "black" # Avoid conflict with black
 skip_glob = ["tests/fixtures/common/collections*"] # Skip ansible content due to ansible-test sanity ruleset
 
 [tool.pylint]
+    [tool.pylint.imports]
+    preferred-modules = [
+      # NOTE: The unittest replacements below help keep
+      # NOTE: the tests pytest ecosystem-oriented.
+      "unittest:pytest",
+      "unittest.mock:pytest-mock",
+    ]
+
     [tool.pylint.master]
     # tm_tokenize is virtually vendored and shouldn't be linted as such
     ignore = "tm_tokenize"

--- a/tests/integration/_cli2runner.py
+++ b/tests/integration/_cli2runner.py
@@ -1,5 +1,6 @@
 """test from CLI up to runner
 """
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-872
 from unittest import mock
 
 import pytest

--- a/tests/integration/test_execution_environment.py
+++ b/tests/integration/test_execution_environment.py
@@ -3,6 +3,7 @@
 import os
 import shlex
 
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-872
 from unittest import mock
 
 import pytest

--- a/tests/integration/test_execution_environment_image.py
+++ b/tests/integration/test_execution_environment_image.py
@@ -3,6 +3,7 @@
 import os
 import shlex
 
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-872
 from unittest import mock
 
 import pytest

--- a/tests/integration/test_pass_environment_variable.py
+++ b/tests/integration/test_pass_environment_variable.py
@@ -3,6 +3,7 @@
 import os
 import shlex
 
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-872
 from unittest import mock
 
 import pytest

--- a/tests/integration/test_set_environment_variable.py
+++ b/tests/integration/test_set_environment_variable.py
@@ -3,6 +3,7 @@
 import os
 import shlex
 
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-872
 from unittest import mock
 
 import pytest

--- a/tests/unit/actions/test_run.py
+++ b/tests/unit/actions/test_run.py
@@ -10,6 +10,8 @@ from typing import List
 from typing import NamedTuple
 from typing import Optional
 from typing import Union
+
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-872
 from unittest.mock import mock_open
 from unittest.mock import patch
 

--- a/tests/unit/configuration_subsystem/test_configurator.py
+++ b/tests/unit/configuration_subsystem/test_configurator.py
@@ -2,6 +2,7 @@
 """
 import os
 
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-872
 from unittest import mock
 from unittest.mock import patch
 

--- a/tests/unit/configuration_subsystem/test_invalid_params.py
+++ b/tests/unit/configuration_subsystem/test_invalid_params.py
@@ -2,6 +2,7 @@
 """
 import tempfile
 
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-872
 from unittest.mock import patch
 
 import pytest

--- a/tests/unit/configuration_subsystem/test_precedence.py
+++ b/tests/unit/configuration_subsystem/test_precedence.py
@@ -12,6 +12,7 @@ Note about decorators:
 import os
 import shlex
 
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-872
 from unittest import mock
 from unittest.mock import patch
 

--- a/tests/unit/configuration_subsystem/test_previous_cli.py
+++ b/tests/unit/configuration_subsystem/test_previous_cli.py
@@ -5,6 +5,8 @@ grouped here because they are all similar
 import os
 
 from copy import deepcopy
+
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-872
 from unittest import mock
 from unittest.mock import patch
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4,6 +4,8 @@ import shlex
 
 from copy import deepcopy
 from typing import NamedTuple
+
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-872
 from unittest.mock import patch
 
 import pytest

--- a/tests/unit/test_log_append.py
+++ b/tests/unit/test_log_append.py
@@ -1,6 +1,7 @@
 """Test appending to the log.
 """
 
+# pylint: disable=preferred-module  # FIXME: remove once migrated per GH-872
 from unittest import mock
 
 from ansible_navigator import cli


### PR DESCRIPTION
This patch implements recommendations to use `pytest`-native fixtures
instead of importing `unittest`-world helper untilities directly using
a built-in `pylint` rule `preferred-module`.