### PR TITLE
Correct spelling of indices throughout project

### DIFF
--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -121,7 +121,7 @@ class UserInterface(CursesWindow):
         self._kegexes = kegexes
         self._logger = logging.getLogger(__name__)
         self._menu_filter: Union[Pattern, None] = None
-        self._menu_indicies: Tuple[int, ...] = tuple()
+        self._menu_indices: Tuple[int, ...] = tuple()
 
         self._pbar_width = pbar_width
         self._status_width = status_width
@@ -672,23 +672,23 @@ class UserInterface(CursesWindow):
 
             # get the less or more, wrap, in case we jumped out of the menu indices
             if entry == "-":
-                less = list(reversed([i for i in self._menu_indicies if i - index < 0]))
-                more = list(reversed([i for i in self._menu_indicies if i - index > 0]))
+                less = list(reversed([i for i in self._menu_indices if i - index < 0]))
+                more = list(reversed([i for i in self._menu_indices if i - index > 0]))
 
-                ordered_indicies = less + more
-                if ordered_indicies:
-                    index = ordered_indicies[0]
+                ordered_indices = less + more
+                if ordered_indices:
+                    index = ordered_indices[0]
                     self.scroll(0)
                     entry = "KEY_F(5)"
                 continue
 
             if entry == "+":
-                more = [i for i in self._menu_indicies if i - index > 0]
-                less = [i for i in self._menu_indicies if i - index < 0]
+                more = [i for i in self._menu_indices if i - index > 0]
+                less = [i for i in self._menu_indices if i - index < 0]
 
-                ordered_indicies = more + less
-                if ordered_indicies:
-                    index = ordered_indicies[0]
+                ordered_indices = more + less
+                if ordered_indices:
+                    index = ordered_indices[0]
                     self.scroll(0)
                     entry = "KEY_F(5)"
                 continue
@@ -778,22 +778,22 @@ class UserInterface(CursesWindow):
             first_line_idx = max(0, last_line_idx - (self._screen_h - 3))
 
             if self.menu_filter():
-                self._menu_indicies = tuple(
+                self._menu_indices = tuple(
                     idx for idx, mi in enumerate(current) if self._obj_match_filter(mi, columns)
                 )
                 line_numbers = tuple(range(last_line_idx - first_line_idx + 1))
-                self._scroll = min(len(self._menu_indicies), self._scroll)
+                self._scroll = min(len(self._menu_indices), self._scroll)
             else:
-                self._menu_indicies = tuple(range(len(current)))
-                line_numbers = self._menu_indicies[first_line_idx : last_line_idx + 1]
+                self._menu_indices = tuple(range(len(current)))
+                line_numbers = self._menu_indices[first_line_idx : last_line_idx + 1]
 
-            showing_idxs = self._menu_indicies[first_line_idx : last_line_idx + 1]
+            showing_idxs = self._menu_indices[first_line_idx : last_line_idx + 1]
             menu_heading, menu_lines = self._get_heading_menu_items(current, columns, showing_idxs)
 
             entry = self._display(
                 lines=menu_lines,
                 line_numbers=line_numbers,
-                count=len(self._menu_indicies),
+                count=len(self._menu_indices),
                 heading=menu_heading,
                 indent_heading=True,
                 key_dict={"[0-9]": "goto"},
@@ -807,7 +807,7 @@ class UserInterface(CursesWindow):
             if name and action:
                 if name == "select":
                     if current:
-                        index = self._menu_indicies[int(entry) % len(self._menu_indicies)]
+                        index = self._menu_indices[int(entry) % len(self._menu_indices)]
                         action = action._replace(value=index)
                     else:
                         continue

--- a/tests/integration/_interactions.py
+++ b/tests/integration/_interactions.py
@@ -60,7 +60,7 @@ class Step(NamedTuple):
     search_within_response: Union[SearchFor, str, List] = SearchFor.HELP
 
 
-def add_indicies(steps):
+def add_indices(steps):
     """update the index of each"""
     return (step._replace(step_index=idx) for idx, step in enumerate(steps))
 

--- a/tests/integration/actions/builder/test_stdout_tmux.py
+++ b/tests/integration/actions/builder/test_stdout_tmux.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import SearchFor
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from .base import BUIDLER_FIXTURE
 from .base import BaseClass
 
@@ -105,7 +105,7 @@ stdout_tests = (
     ),
 )
 
-steps = add_indicies(stdout_tests)
+steps = add_indices(stdout_tests)
 
 
 def step_id(value):

--- a/tests/integration/actions/config/test_direct_interactive_ee.py
+++ b/tests/integration/actions/config/test_direct_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
 from .base import base_steps
@@ -14,7 +14,7 @@ CLI = Command(subcommand="config", execution_environment=True).join()
 
 initial_steps = (Step(user_input=CLI, comment="ansible-navigator config command top window"),)
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/config/test_direct_interactive_noee.py
+++ b/tests/integration/actions/config/test_direct_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
 from .base import base_steps
@@ -20,7 +20,7 @@ initial_steps = (
     ),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/config/test_stdout_tmux.py
+++ b/tests/integration/actions/config/test_stdout_tmux.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import SearchFor
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from .base import CONFIG_FIXTURE
 from .base import BaseClass
 
@@ -117,7 +117,7 @@ stdout_tests = (
     ),
 )
 
-steps = add_indicies(stdout_tests)
+steps = add_indices(stdout_tests)
 
 
 def step_id(value):

--- a/tests/integration/actions/config/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/config/test_welcome_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
 from .base import base_steps
@@ -17,7 +17,7 @@ initial_steps = (
     Step(user_input=":config", comment="enter config from welcome screen"),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/config/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/config/test_welcome_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
 from .base import base_steps
@@ -21,7 +21,7 @@ initial_steps = (
     ),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/config/test_welcome_interactive_param_use.py
+++ b/tests/integration/actions/config/test_welcome_interactive_param_use.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
 
@@ -26,7 +26,7 @@ steps = (
     ),
 )
 
-steps = add_indicies(steps)
+steps = add_indices(steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/config/test_welcome_interactive_specified_config.py
+++ b/tests/integration/actions/config/test_welcome_interactive_specified_config.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import CONFIG_FIXTURE
 from .base import BaseClass
@@ -27,7 +27,7 @@ steps = (
     ),
 )
 
-steps = add_indicies(steps)
+steps = add_indices(steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/exec/test_stdout_config_cli.py
+++ b/tests/integration/actions/exec/test_stdout_config_cli.py
@@ -5,7 +5,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import SearchFor
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from .base import BaseClass
 
 
@@ -59,7 +59,7 @@ stdout_tests = (
     ),
 )
 
-steps = add_indicies(stdout_tests)
+steps = add_indices(stdout_tests)
 
 
 def step_id(test_value: ShellCommand) -> str:

--- a/tests/integration/actions/exec/test_stdout_config_file.py
+++ b/tests/integration/actions/exec/test_stdout_config_file.py
@@ -5,7 +5,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import SearchFor
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from .base import TEST_CONFIG_FILE
 from .base import BaseClass
 
@@ -51,7 +51,7 @@ stdout_tests = (
     ),
 )
 
-steps = add_indicies(stdout_tests)
+steps = add_indices(stdout_tests)
 
 
 def step_id(test_value: ShellCommand) -> str:

--- a/tests/integration/actions/images/test_direct_interactive_ee.py
+++ b/tests/integration/actions/images/test_direct_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import IMAGE_SHORT
 from .base import BaseClass
@@ -17,7 +17,7 @@ initial_steps = (
     Step(user_input=CLI, comment="ansible-navigator images top window", look_fors=[IMAGE_SHORT]),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/images/test_direct_interactive_noee.py
+++ b/tests/integration/actions/images/test_direct_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import IMAGE_SHORT
 from .base import BaseClass
@@ -18,7 +18,7 @@ initial_steps = (
     Step(user_input=CLI, comment="ansible-navigator images top window", look_fors=[IMAGE_SHORT]),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/images/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/images/test_welcome_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import IMAGE_SHORT
 from .base import BaseClass
@@ -22,7 +22,7 @@ initial_steps = (
     ),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/images/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/images/test_welcome_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import IMAGE_SHORT
 from .base import BaseClass
@@ -23,7 +23,7 @@ initial_steps = (
     ),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/inventory/test_direct_interactive_ee.py
+++ b/tests/integration/actions/inventory/test_direct_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
 from .base import BaseClass
@@ -16,7 +16,7 @@ CLI = Command(subcommand="inventory", cmdline=cmdline, execution_environment=Tru
 
 initial_steps = (Step(user_input=CLI, comment="ansible-navigator inventory command top window"),)
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/inventory/test_direct_interactive_noee.py
+++ b/tests/integration/actions/inventory/test_direct_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
 from .base import BaseClass
@@ -16,7 +16,7 @@ CLI = Command(subcommand="inventory", cmdline=cmdline, execution_environment=Fal
 
 initial_steps = (Step(user_input=CLI, comment="ansible-navigator inventory command top window"),)
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/inventory/test_stdout_tmux.py
+++ b/tests/integration/actions/inventory/test_stdout_tmux.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import SearchFor
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
 from .base import BaseClass
 
@@ -83,7 +83,7 @@ stdout_tests = (
     ),
 )
 
-steps = add_indicies(stdout_tests)
+steps = add_indices(stdout_tests)
 
 
 def step_id(value):

--- a/tests/integration/actions/inventory/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/inventory/test_welcome_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
 from .base import BaseClass
@@ -19,7 +19,7 @@ initial_steps = (
     Step(user_input=cmdline, comment="ansible-navigator inventory command top window"),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/inventory/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/inventory/test_welcome_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
 from .base import BaseClass
@@ -19,7 +19,7 @@ initial_steps = (
     Step(user_input=cmdline, comment="ansible-navigator inventory command top window"),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/run/test_direct_interactive_ee.py
+++ b/tests/integration/actions/run/test_direct_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
 from .base import base_steps
@@ -23,7 +23,7 @@ initial_steps = (
     ),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/run/test_direct_interactive_noee.py
+++ b/tests/integration/actions/run/test_direct_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
 from .base import base_steps
@@ -23,7 +23,7 @@ initial_steps = (
     ),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/run/test_stdout_tmux.py
+++ b/tests/integration/actions/run/test_stdout_tmux.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import SearchFor
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from .base import BaseClass
 from .base import inventory_path
 from .base import playbook_path
@@ -80,7 +80,7 @@ stdout_tests = (
     ),
 )
 
-steps = add_indicies(stdout_tests)
+steps = add_indices(stdout_tests)
 
 
 def step_id(value):

--- a/tests/integration/actions/run/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/run/test_welcome_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
 from .base import base_steps
@@ -24,7 +24,7 @@ initial_steps = (
     ),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/run/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/run/test_welcome_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
 from .base import base_steps
@@ -24,7 +24,7 @@ initial_steps = (
     ),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/templar/test_direct_interactive_ee.py
+++ b/tests/integration/actions/templar/test_direct_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
 from .base import base_steps
@@ -23,7 +23,7 @@ initial_steps = (
     ),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/templar/test_direct_interactive_noee.py
+++ b/tests/integration/actions/templar/test_direct_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
 from .base import base_steps
@@ -23,7 +23,7 @@ initial_steps = (
     ),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/templar/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/templar/test_welcome_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
 from .base import base_steps
@@ -24,7 +24,7 @@ initial_steps = (
     ),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)

--- a/tests/integration/actions/templar/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/templar/test_welcome_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import Step
-from ..._interactions import add_indicies
+from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
 from .base import base_steps
@@ -24,7 +24,7 @@ initial_steps = (
     ),
 )
 
-steps = add_indicies(initial_steps + base_steps)
+steps = add_indices(initial_steps + base_steps)
 
 
 @pytest.mark.parametrize("step", steps, ids=step_id)


### PR DESCRIPTION
The word `indices` was misspelled in many locations, this corrects that. 