### PR TITLE
Correct abbreviation of `environment variable` from `envvar` to `env_var` where possible

### DIFF
--- a/docs/_ext/single_sourced_data.py
+++ b/docs/_ext/single_sourced_data.py
@@ -236,7 +236,7 @@ def _params_row_for_entry(entry: SettingsEntry, param_details: Dict) -> Tuple:
             default = entry.value.default
 
     choices = oxfordcomma(entry.choices, "or")
-    envvar = entry.environment_variable(APP.replace("-", "_"))
+    env_var = entry.environment_variable(APP.replace("-", "_"))
 
     settings = []
     if choices:
@@ -245,8 +245,8 @@ def _params_row_for_entry(entry: SettingsEntry, param_details: Dict) -> Tuple:
         settings.append(f"**Default:** {default}")
     if cli_parameters is not None:
         settings.append(f"**CLI:** {cli_parameters}")
-    if envvar is not None:
-        settings.append(f"**ENV:** {envvar}")
+    if env_var is not None:
+        settings.append(f"**ENV:** {env_var}")
 
     settings.extend(["**Settings file:**", *yaml_like])
 

--- a/src/ansible_navigator/actions/builder.py
+++ b/src/ansible_navigator/actions/builder.py
@@ -59,9 +59,9 @@ class Action(App):
             raise RuntimeError(msg)
 
         if isinstance(self._args.set_environment_variable, dict):
-            envvars_to_set = self._args.set_environment_variable.copy()
+            env_vars_to_set = self._args.set_environment_variable.copy()
         elif isinstance(self._args.set_environment_variable, Constants):
-            envvars_to_set = {}
+            env_vars_to_set = {}
         else:
             log_message = (
                 "The setting 'set_environment_variable' was neither a dictionary"
@@ -72,10 +72,10 @@ class Action(App):
                 log_message,
                 self._args.set_environment_variable,
             )
-        envvars_to_set = {}
+        env_vars_to_set = {}
 
         if self._args.display_color is False:
-            envvars_to_set["ANSIBLE_NOCOLOR"] = "1"
+            env_vars_to_set["ANSIBLE_NOCOLOR"] = "1"
 
         if self._args.execution_environment:
             self._logger.info("For builder subcommand execution-environment is disabled")
@@ -85,7 +85,7 @@ class Action(App):
             "host_cwd": os.path.abspath(os.path.expanduser(self._args.workdir)),
             "navigator_mode": self._args.mode,
             "pass_environment_variable": self._args.pass_environment_variable,
-            "set_environment_variable": envvars_to_set,
+            "set_environment_variable": env_vars_to_set,
             "timeout": self._args.ansible_runner_timeout,
         }
 

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -221,12 +221,12 @@ class Action(App):
             output, errors and return code from runner.
         """
         if isinstance(self._args.set_environment_variable, dict):
-            set_envvars = {**self._args.set_environment_variable}
+            set_env_vars = {**self._args.set_environment_variable}
         else:
-            set_envvars = {}
+            set_env_vars = {}
 
         if self._args.display_color is False:
-            set_envvars["ANSIBLE_NOCOLOR"] = "1"
+            set_env_vars["ANSIBLE_NOCOLOR"] = "1"
 
         kwargs = {
             "container_engine": self._args.container_engine,
@@ -235,7 +235,7 @@ class Action(App):
             "execution_environment": self._args.execution_environment,
             "navigator_mode": self._args.mode,
             "pass_environment_variable": self._args.pass_environment_variable,
-            "set_environment_variable": set_envvars,
+            "set_environment_variable": set_env_vars,
             "private_data_dir": self._args.ansible_runner_artifact_dir,
             "rotate_artifacts": self._args.ansible_runner_rotate_artifacts_count,
             "timeout": self._args.ansible_runner_timeout,

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -152,12 +152,12 @@ class Action(App):
             output, errors and return code from runner.
         """
         if isinstance(self._args.set_environment_variable, dict):
-            set_envvars = {**self._args.set_environment_variable}
+            set_env_vars = {**self._args.set_environment_variable}
         else:
-            set_envvars = {}
+            set_env_vars = {}
 
         if self._args.display_color is False or self._args.mode == "interactive":
-            set_envvars["ANSIBLE_NOCOLOR"] = "1"
+            set_env_vars["ANSIBLE_NOCOLOR"] = "1"
 
         kwargs = {
             "container_engine": self._args.container_engine,
@@ -165,7 +165,7 @@ class Action(App):
             "execution_environment": self._args.execution_environment,
             "navigator_mode": self._args.mode,
             "pass_environment_variable": self._args.pass_environment_variable,
-            "set_environment_variable": set_envvars,
+            "set_environment_variable": set_env_vars,
             "private_data_dir": self._args.ansible_runner_artifact_dir,
             "rotate_artifacts": self._args.ansible_runner_rotate_artifacts_count,
             "timeout": self._args.ansible_runner_timeout,

--- a/src/ansible_navigator/actions/exec.py
+++ b/src/ansible_navigator/actions/exec.py
@@ -67,9 +67,9 @@ class Action(App):
         :return: The stdout, stderr and return code from runner
         """
         if isinstance(self._args.set_environment_variable, dict):
-            envvars_to_set = self._args.set_environment_variable.copy()
+            env_vars_to_set = self._args.set_environment_variable.copy()
         elif isinstance(self._args.set_environment_variable, Constants):
-            envvars_to_set = {}
+            env_vars_to_set = {}
         else:
             log_message = (
                 "The setting 'set_environment_variable' was neither a dictionary"
@@ -80,10 +80,10 @@ class Action(App):
                 log_message,
                 self._args.set_environment_variable,
             )
-            envvars_to_set = {}
+            env_vars_to_set = {}
 
         if self._args.display_color is False:
-            envvars_to_set["ANSIBLE_NOCOLOR"] = "1"
+            env_vars_to_set["ANSIBLE_NOCOLOR"] = "1"
 
         kwargs = {
             "container_engine": self._args.container_engine,
@@ -92,7 +92,7 @@ class Action(App):
             "execution_environment": self._args.execution_environment,
             "navigator_mode": self._args.mode,
             "pass_environment_variable": self._args.pass_environment_variable,
-            "set_environment_variable": envvars_to_set,
+            "set_environment_variable": env_vars_to_set,
             "timeout": self._args.ansible_runner_timeout,
         }
 

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -494,12 +494,12 @@ class Action(App):
         self,
     ) -> Tuple[Union[None, str], Union[None, str], Union[None, int]]:
         if isinstance(self._args.set_environment_variable, dict):
-            set_envvars = {**self._args.set_environment_variable}
+            set_env_vars = {**self._args.set_environment_variable}
         else:
-            set_envvars = {}
+            set_env_vars = {}
 
         if self._args.display_color is False:
-            set_envvars["ANSIBLE_NOCOLOR"] = "1"
+            set_env_vars["ANSIBLE_NOCOLOR"] = "1"
 
         kwargs = {
             "container_engine": self._args.container_engine,
@@ -508,7 +508,7 @@ class Action(App):
             "execution_environment": self._args.execution_environment,
             "navigator_mode": self._args.mode,
             "pass_environment_variable": self._args.pass_environment_variable,
-            "set_environment_variable": set_envvars,
+            "set_environment_variable": set_env_vars,
             "private_data_dir": self._args.ansible_runner_artifact_dir,
             "rotate_artifacts": self._args.ansible_runner_rotate_artifacts_count,
             "timeout": self._args.ansible_runner_timeout,

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -546,12 +546,12 @@ class Action(App):
             mode = self.mode
 
         if isinstance(self._args.set_environment_variable, dict):
-            set_envvars = {**self._args.set_environment_variable}
+            set_env_vars = {**self._args.set_environment_variable}
         else:
-            set_envvars = {}
+            set_env_vars = {}
 
         if self._args.display_color is False:
-            set_envvars["ANSIBLE_NOCOLOR"] = "1"
+            set_env_vars["ANSIBLE_NOCOLOR"] = "1"
 
         kwargs = {
             "container_engine": self._args.container_engine,
@@ -561,7 +561,7 @@ class Action(App):
             "inventory": self._args.inventory,
             "navigator_mode": mode,
             "pass_environment_variable": self._args.pass_environment_variable,
-            "set_environment_variable": set_envvars,
+            "set_environment_variable": set_env_vars,
             "private_data_dir": self._args.ansible_runner_artifact_dir,
             "rotate_artifacts": self._args.ansible_runner_rotate_artifacts_count,
             "timeout": self._args.ansible_runner_timeout,

--- a/src/ansible_navigator/configuration_subsystem/configurator.py
+++ b/src/ansible_navigator/configuration_subsystem/configurator.py
@@ -195,13 +195,13 @@ class Configurator:
 
     def _apply_environment_variables(self) -> None:
         for entry in self._config.entries:
-            set_envvar = os.environ.get(entry.environment_variable(self._config.application_name))
-            if set_envvar is not None:
+            set_env_var = os.environ.get(entry.environment_variable(self._config.application_name))
+            if set_env_var is not None:
                 if self._initial or entry.change_after_initial:
                     if entry.cli_parameters is not None and entry.cli_parameters.nargs == "+":
-                        entry.value.current = set_envvar.split(",")
+                        entry.value.current = set_env_var.split(",")
                     else:
-                        entry.value.current = set_envvar
+                        entry.value.current = set_env_var
                     entry.value.source = C.ENVIRONMENT_VARIABLE
                 else:
                     message = f"'{entry.name}' cannot be reconfigured. (environment variables)"

--- a/src/ansible_navigator/configuration_subsystem/definitions.py
+++ b/src/ansible_navigator/configuration_subsystem/definitions.py
@@ -85,11 +85,11 @@ class SettingsEntry(SimpleNamespace):
     def environment_variable(self, prefix: str = "") -> str:
         """Generate an effective environment variable for this entry"""
         if self.environment_variable_override is not None:
-            envvar = self.environment_variable_override
+            env_var = self.environment_variable_override
         else:
-            envvar = f"{prefix}_{self.name.replace('--', '')}"
-        envvar = envvar.replace("-", "_").upper()
-        return envvar
+            env_var = f"{prefix}_{self.name.replace('--', '')}"
+        env_var = env_var.replace("-", "_").upper()
+        return env_var
 
     @property
     def invalid_choice(self) -> str:

--- a/src/ansible_navigator/runner/base.py
+++ b/src/ansible_navigator/runner/base.py
@@ -3,6 +3,8 @@ ansible-runner. Attributes common to all ansible-runner calls
 are defined within the base class
 """
 
+# cspell:ignore envvars
+
 import logging
 import os
 import shutil

--- a/tests/integration/_interactions.py
+++ b/tests/integration/_interactions.py
@@ -38,8 +38,8 @@ class Command(NamedTuple):
         args.extend(["--ll", self.log_level])
         args.extend(["--mode", self.mode])
         if self.pass_environment_variables:
-            for envvar in self.pass_environment_variables:
-                args.extend(["--penv", envvar])
+            for env_var in self.pass_environment_variables:
+                args.extend(["--penv", env_var])
         cmd = " ".join(shlex.quote(str(arg)) for arg in args)
         if self.preclear:
             return "clear && " + cmd

--- a/tests/integration/test_pass_environment_variable.py
+++ b/tests/integration/test_pass_environment_variable.py
@@ -94,4 +94,4 @@ class Test(Cli2Runner):
         _args, kwargs = mocked_runner.call_args
 
         for item in expected.items():
-            assert item in kwargs["envvars"].items()
+            assert item in kwargs["envvars"].items()  # cspell:ignore envvars

--- a/tests/integration/test_set_environment_variable.py
+++ b/tests/integration/test_set_environment_variable.py
@@ -93,4 +93,4 @@ class Test(Cli2Runner):
         _args, kwargs = mocked_runner.call_args
 
         for item in expected.items():
-            assert item in kwargs["envvars"].items()
+            assert item in kwargs["envvars"].items()  # cspell:ignore envvars

--- a/tests/unit/configuration_subsystem/data.py
+++ b/tests/unit/configuration_subsystem/data.py
@@ -206,7 +206,7 @@ def cli_data():
 
 CLI_DATA = cli_data()
 
-ENVVAR_DATA = [
+ENV_VAR_DATA = [
     ("ansible_runner_artifact_dir", "/tmp/test1", "/tmp/test1"),
     ("ansible_runner_rotate_artifacts_count", "10", 10),
     ("ansible_runner_timeout", "300", 300),
@@ -217,7 +217,7 @@ ENVVAR_DATA = [
     ("container_engine", "docker", "docker"),
     ("container_options", "--net=host", ["--net=host"]),
     ("display_color", "yellow is the color of a banana", False),
-    ("editor_command", "nano_envvar", "nano_envvar"),
+    ("editor_command", "nano_env_var", "nano_env_var"),
     ("editor_console", "false", False),
     ("exec_command", "/bin/foo", "/bin/foo"),
     ("exec_shell", "false", False),

--- a/tests/unit/configuration_subsystem/test_fixture_sanity.py
+++ b/tests/unit/configuration_subsystem/test_fixture_sanity.py
@@ -6,14 +6,14 @@ import os
 from ansible_navigator._yaml import Loader
 from ansible_navigator._yaml import yaml
 from ansible_navigator.configuration_subsystem import NavigatorConfiguration
-from .data import ENVVAR_DATA
+from .data import ENV_VAR_DATA
 from .defaults import TEST_FIXTURE_DIR
 
 
-def test_data_no_missing_envvar_data():
-    """Ensure the ENVVAR_DATA covers all entries"""
+def test_data_no_missing_env_var_data():
+    """Ensure the ENV_VAR_DATA covers all entries"""
     entry_names = [entry.name for entry in NavigatorConfiguration.entries]
-    data_names = [entry[0] for entry in ENVVAR_DATA]
+    data_names = [entry[0] for entry in ENV_VAR_DATA]
     assert entry_names == data_names
 
 

--- a/tests/unit/configuration_subsystem/test_precedence.py
+++ b/tests/unit/configuration_subsystem/test_precedence.py
@@ -26,7 +26,7 @@ from .data import BASE_EXPECTED
 from .data import BASE_LONG_CLI
 from .data import BASE_SHORT_CLI
 from .data import CLI_DATA
-from .data import ENVVAR_DATA
+from .data import ENV_VAR_DATA
 from .data import SETTINGS
 from .utils import config_post_process
 from .utils import id_for_base
@@ -42,7 +42,7 @@ from .utils import id_for_settings
 @patch("os.path.isfile", return_value=True)
 @pytest.mark.parametrize("base", (None, BASE_SHORT_CLI, BASE_LONG_CLI), ids=id_for_base)
 @pytest.mark.parametrize("cli_entry, expected", CLI_DATA, ids=id_for_cli)
-def test_all_entries_reflect_cli_given_envvars(
+def test_all_entries_reflect_cli_given_env_vars(
     _mf1,
     _mf2,
     generate_config,
@@ -59,14 +59,14 @@ def test_all_entries_reflect_cli_given_envvars(
         params = cli_entry_split + " ".join(base.splitlines()).split()
         expected = {**dict(expected), **dict(BASE_EXPECTED)}
 
-    envvars = {}
+    env_vars = {}
     for entry in NavigatorConfiguration.entries:
-        envvar_name = entry.environment_variable("ansible_navigator")
-        envvar_value = [value[1] for value in ENVVAR_DATA if value[0] == entry.name]
-        assert len(envvar_value) == 1, entry.name
-        envvars[envvar_name] = envvar_value[0]
+        env_var_name = entry.environment_variable("ansible_navigator")
+        env_var_value = [value[1] for value in ENV_VAR_DATA if value[0] == entry.name]
+        assert len(env_var_value) == 1, entry.name
+        env_vars[env_var_name] = env_var_value[0]
 
-    with mock.patch.dict(os.environ, envvars):
+    with mock.patch.dict(os.environ, env_vars):
         response = generate_config(params=params)
         assert response.exit_messages == []
         for key, value in expected.items():
@@ -125,7 +125,7 @@ def test_all_entries_reflect_cli_given_settings(
 @pytest.mark.parametrize("settings, source_other", SETTINGS, ids=id_for_settings)
 @pytest.mark.parametrize("base", (None, BASE_SHORT_CLI, BASE_LONG_CLI), ids=id_for_base)
 @pytest.mark.parametrize("cli_entry, expected", CLI_DATA, ids=id_for_cli)
-def test_all_entries_reflect_cli_given_settings_and_envars(
+def test_all_entries_reflect_cli_given_settings_and_env_vars(
     _mf1,
     _mf2,
     generate_config,
@@ -147,14 +147,14 @@ def test_all_entries_reflect_cli_given_settings_and_envars(
         params = shlex.split(cli_entry) + " ".join(base.splitlines()).split()
         expected = {**dict(expected), **dict(BASE_EXPECTED)}
 
-    envvars = {}
+    env_vars = {}
     for entry in NavigatorConfiguration.entries:
-        envvar_name = entry.environment_variable("ansible_navigator")
-        envvar_value = [value[1] for value in ENVVAR_DATA if value[0] == entry.name]
-        assert len(envvar_value) == 1, entry.name
-        envvars[envvar_name] = envvar_value[0]
+        env_var_name = entry.environment_variable("ansible_navigator")
+        env_var_value = [value[1] for value in ENV_VAR_DATA if value[0] == entry.name]
+        assert len(env_var_value) == 1, entry.name
+        env_vars[env_var_name] = env_var_value[0]
 
-    with mock.patch.dict(os.environ, envvars):
+    with mock.patch.dict(os.environ, env_vars):
         response = generate_config(params=params, setting_file_name=settings)
         assert response.exit_messages == []
         for key, value in expected.items():
@@ -188,8 +188,8 @@ def test_all_entries_reflect_default(_mocked_func, generate_config, entry):
 @patch("shutil.which", return_value="/path/to/container_engine")
 @patch("os.path.isfile", return_value=True)
 @pytest.mark.parametrize("settings, settings_file_type", SETTINGS, ids=id_for_settings)
-@pytest.mark.parametrize("entry, value, expected", ENVVAR_DATA)
-def test_all_entries_reflect_envvar_given_settings(
+@pytest.mark.parametrize("entry, value, expected", ENV_VAR_DATA)
+def test_all_entries_reflect_env_var_given_settings(
     _mf1,
     _mf2,
     generate_config,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -78,10 +78,10 @@ def test_env_var_is_file_path(
     anticpated_result: Optional[str],
 ) -> None:
     """test environment variable is a file path"""
-    envvar = "ANSIBLE_NAVIGATOR_CONFIG"
+    env_var = "ANSIBLE_NAVIGATOR_CONFIG"
     if set_env:
-        monkeypatch.setenv(envvar, file_path)
-    _messages, _exit_messages, result = utils.environment_variable_is_file_path(envvar, "config")
+        monkeypatch.setenv(env_var, file_path)
+    _messages, _exit_messages, result = utils.environment_variable_is_file_path(env_var, "config")
     assert result == anticpated_result
 
 


### PR DESCRIPTION
Replace the use of envvar with env_var where possible.

The only exception is when referring to the ansible-runner key, which now has an inline or file exception for cspell.

(`cspell` is a spell checker for code https://github.com/streetsidesoftware/cspell which I hope to incorporate into my docstring updates process to eliminate introducing any additional spelling errors into the project.)

