### PR TITLE
Correct spelling of support

### DIFF
--- a/src/ansible_navigator/ui_framework/curses_window.py
+++ b/src/ansible_navigator/ui_framework/curses_window.py
@@ -59,7 +59,7 @@ class CursesWindow:
         self._screen_miny = 3
         self._prefix_color = 8
         self._theme_dir: str
-        self._term_osc4_supprt: bool
+        self._term_osc4_support: bool
         self._ui_config = ui_config
         self._logger.debug("self._ui_config: %s", self._ui_config)
         self._set_colors()
@@ -179,19 +179,19 @@ class CursesWindow:
             curses.use_default_colors()
         except curses.error:
             self._logger.error("Errors setting up terminal, no color support")
-            self._term_osc4_supprt = False
+            self._term_osc4_support = False
             self._ui_config.colors_initialized = True
             return
 
         self._logger.debug("curses.COLORS: %s", curses.COLORS)
         self._logger.debug("curses.can_change_color: %s", curses.can_change_color())
 
-        self._term_osc4_supprt = curses.can_change_color()
+        self._term_osc4_support = curses.can_change_color()
         if self._ui_config.osc4 is False:
-            self._term_osc4_supprt = False
-        self._logger.debug("term_osc4_supprt: %s", self._term_osc4_supprt)
+            self._term_osc4_support = False
+        self._logger.debug("term_osc4_support: %s", self._term_osc4_support)
 
-        if self._term_osc4_supprt:
+        if self._term_osc4_support:
             with open(self._ui_config.terminal_colors_path, encoding="utf-8") as data_file:
                 colors = json.load(data_file)
 

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -526,7 +526,7 @@ class UserInterface(CursesWindow):
             Lines[LinePart[{"color": RGB, "chars": text, "column": n},...]]
         :return: the lines ready for curses
         """
-        if curses.COLORS > 16 and self._term_osc4_supprt:
+        if curses.COLORS > 16 and self._term_osc4_support:
             unique_colors = list(
                 set(chars["color"] for line in lines for chars in line if chars["color"]),
             )
@@ -584,7 +584,7 @@ class UserInterface(CursesWindow):
         :return: the colored line part
         """
         if lp_dict["color"]:
-            if self._term_osc4_supprt and curses.COLORS > 16:
+            if self._term_osc4_support and curses.COLORS > 16:
                 color = self._rgb_to_curses_color_idx[lp_dict["color"]]
             else:
                 red, green, blue = lp_dict["color"]


### PR DESCRIPTION
The word `support` was spelled incorrectly in a couple files, this corrects that.