### PR TITLE
Replace ``xform`` with ``serialization_format``

### DIFF
--- a/src/ansible_navigator/actions/help_doc.py
+++ b/src/ansible_navigator/actions/help_doc.py
@@ -38,7 +38,9 @@ class Action(App):
             help_md = fhand.read()
 
         while True:
-            interaction = interaction.ui.show(obj=help_md, xform="text.html.markdown")
+            interaction = interaction.ui.show(
+                obj=help_md, serialization_format="text.html.markdown"
+            )
             app.update()
             if interaction.name != "refresh":
                 break

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -195,7 +195,9 @@ class Action(App):
 
         if self._inventory_error:
             while True:
-                interaction = self._interaction.ui.show(self._inventory_error, xform="source.ansi")
+                interaction = self._interaction.ui.show(
+                    self._inventory_error, serialization_format="source.ansi"
+                )
                 if interaction.name != "refresh":
                     break
             self._prepare_to_exit(interaction)

--- a/src/ansible_navigator/actions/log.py
+++ b/src/ansible_navigator/actions/log.py
@@ -39,7 +39,7 @@ class Action(App):
             if auto_scroll:
                 interaction.ui.scroll(new_scroll)
 
-            interaction = interaction.ui.show(obj=dalog, xform="text.log")
+            interaction = interaction.ui.show(obj=dalog, serialization_format="text.log")
             if interaction.name != "refresh":
                 break
 

--- a/src/ansible_navigator/actions/open_file.py
+++ b/src/ansible_navigator/actions/open_file.py
@@ -86,16 +86,16 @@ class Action:
                 return None
 
         if not filename:
-            if interaction.ui.xform() == "text.html.markdown":
+            if interaction.ui.serialization_format() == "text.html.markdown":
                 with tempfile.NamedTemporaryFile(suffix=".md", delete=False) as temp_file:
                     filename = temp_file.name
                     with open(filename, "w", encoding="utf-8") as outfile:
                         outfile.write(obj)
-            elif interaction.ui.xform() == "source.yaml":
+            elif interaction.ui.serialization_format() == "source.yaml":
                 with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as temp_file:
                     filename = temp_file.name
                     human_dump(obj=obj, filename=filename)
-            elif interaction.ui.xform() == "source.json":
+            elif interaction.ui.serialization_format() == "source.json":
                 with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as temp_file:
                     filename = temp_file.name
                     with open(filename, "w", encoding="utf-8") as outfile:

--- a/src/ansible_navigator/actions/serialize_json.py
+++ b/src/ansible_navigator/actions/serialize_json.py
@@ -33,5 +33,5 @@ class Action:
         self._logger.debug("json requested")
         if interaction.ui is not None:
             interaction.ui.scroll(0)
-            xform = interaction.ui.xform("source.json", default=True)
-            self._logger.debug("Serialization set to %s", xform)
+            serialization_format = interaction.ui.serialization_format("source.json", default=True)
+            self._logger.debug("Serialization set to %s", serialization_format)

--- a/src/ansible_navigator/actions/serialize_yaml.py
+++ b/src/ansible_navigator/actions/serialize_yaml.py
@@ -33,5 +33,5 @@ class Action:
         self._logger.debug("yaml requested")
         if interaction.ui is not None:
             interaction.ui.scroll(0)
-            xform = interaction.ui.xform("source.yaml", default=True)
-            self._logger.debug("Serialization set to %s", xform)
+            serialization_format = interaction.ui.serialization_format("source.yaml", default=True)
+            self._logger.debug("Serialization set to %s", serialization_format)

--- a/src/ansible_navigator/actions/stdout.py
+++ b/src/ansible_navigator/actions/stdout.py
@@ -38,7 +38,9 @@ class Action(App):
             if auto_scroll:
                 interaction.ui.scroll(new_scroll)
             obj = "\n".join(app.stdout)
-            next_interaction: Interaction = interaction.ui.show(obj=obj, xform="source.ansi")
+            next_interaction: Interaction = interaction.ui.show(
+                obj=obj, serialization_format="source.ansi"
+            )
             if next_interaction.name != "refresh":
                 break
 

--- a/src/ansible_navigator/actions/template.py
+++ b/src/ansible_navigator/actions/template.py
@@ -83,8 +83,10 @@ class Action(App):
 
         while True:
             app.update()
-            xform = "source.txt" if isinstance(templated, str) else ""
-            next_interaction: Interaction = interaction.ui.show(obj=templated, xform=xform)
+            serialization_format = "source.txt" if isinstance(templated, str) else ""
+            next_interaction: Interaction = interaction.ui.show(
+                obj=templated, serialization_format=serialization_format
+            )
             if next_interaction.name != "refresh":
                 break
 

--- a/src/ansible_navigator/actions/welcome.py
+++ b/src/ansible_navigator/actions/welcome.py
@@ -44,7 +44,9 @@ class Action(App):
 
         while True:
             self._calling_app.update()
-            interaction = interaction.ui.show(obj=welcome_md, xform="text.html.markdown")
+            interaction = interaction.ui.show(
+                obj=welcome_md, serialization_format="text.html.markdown"
+            )
             app.update()
             if interaction.name != "refresh":
                 break

--- a/src/ansible_navigator/actions/write_file.py
+++ b/src/ansible_navigator/actions/write_file.py
@@ -78,7 +78,7 @@ class Action:
             elif filename.endswith(".json"):
                 write_as = "json"
             else:
-                write_as = interaction.ui.xform()
+                write_as = interaction.ui.serialization_format()
 
         if write_as == "text":
             with open(os.path.abspath(filename), fmode, encoding="utf-8") as outfile:

--- a/tests/integration/_action_run_test.py
+++ b/tests/integration/_action_run_test.py
@@ -120,7 +120,7 @@ class ActionRunTest:
             scroll=self.callable_pass_one_arg,
             show=self.callable_pass,
             update_status=self.callable_pass,
-            xform=self.callable_pass,
+            serialization_format=self.callable_pass,
         )
         match = re.match(self._app_action.Action.KEGEX, self._action_name)
         if not match:


### PR DESCRIPTION
``xform`` was used to store the the user's preference of `yaml vs. json`, this replaces it with `serialization_format`

Although the serialization format is also carried forward to the tokenzation process and coloring methods, this felt like a better choice than `xform`