### PR TITLE
Remove some abbreviations in menu builder

### DIFF
--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -750,7 +750,7 @@ class UserInterface(CursesWindow):
         :return: The heading and menu items
         """
         menu_builder = MenuBuilder(
-            pbar_width=self._pbar_width,
+            progress_bar_width=self._pbar_width,
             screen_w=self._screen_w,
             number_colors=curses.COLORS,
             color_menu_item=self._color_menu_item,


### PR DESCRIPTION
This removes some abbreviates in the UI menu builder and removes the use of `dyct` in the same file.

One change in ui.py where the menu builder is initialized.