### PR TITLE
Normalize references to screen/viewport height and width

### DIFF
--- a/src/ansible_navigator/action_runner.py
+++ b/src/ansible_navigator/action_runner.py
@@ -71,7 +71,7 @@ class ActionRunner(App):
         )
 
         self._ui = UserInterface(
-            screen_miny=3,
+            screen_min_height=3,
             kegexes=kegexes,
             refresh=refresh,
             ui_config=config,

--- a/src/ansible_navigator/ui_framework/curses_window.py
+++ b/src/ansible_navigator/ui_framework/curses_window.py
@@ -56,7 +56,7 @@ class CursesWindow:
 
         self._screen: Window
         self.win: Window
-        self._screen_miny = 3
+        self._screen_min_height = 3
         self._prefix_color = 8
         self._theme_dir: str
         self._term_osc4_support: bool
@@ -65,7 +65,7 @@ class CursesWindow:
         self._set_colors()
 
     @property
-    def _screen_w(self) -> int:
+    def _screen_width(self) -> int:
         """return the screen width
 
         :return: the current screen width
@@ -74,14 +74,14 @@ class CursesWindow:
         return self._screen.getmaxyx()[1]
 
     @property
-    def _screen_h(self) -> int:
+    def _screen_height(self) -> int:
         """return the screen height, or notify if too small
 
         :return: the current screen height
         :rtype: int
         """
         while True:
-            if self._screen.getmaxyx()[0] >= self._screen_miny:
+            if self._screen.getmaxyx()[0] >= self._screen_min_height:
                 return self._screen.getmaxyx()[0]
             curses.flash()
             curses.beep()
@@ -125,39 +125,45 @@ class CursesWindow:
         :param prefix: The prefix for the line
         :type prefix: str or None
         """
-        win = window
         if prefix:
             color = self._color_pair_or_none(self._prefix_color)
             if color is None:
-                win.addstr(lineno, 0, prefix)
+                window.addstr(lineno, 0, prefix)
             else:
-                win.addstr(lineno, 0, prefix, color)
+                window.addstr(lineno, 0, prefix, color)
         if line:
-            win.move(lineno, 0)
+            window.move(lineno, 0)
             for line_part in line:
                 column = line_part.column + len(prefix or "")
-                if column <= self._screen_w:
-                    text = line_part.string[0 : self._screen_w - column + 1]
+                if column <= self._screen_width:
+                    text = line_part.string[0 : self._screen_width - column + 1]
                     try:
                         color = self._color_pair_or_none(line_part.color)
                         if color is None:
-                            win.addstr(lineno, column, text)
+                            window.addstr(lineno, column, text)
                         else:
-                            win.addstr(lineno, column, text, color | line_part.decoration)
+                            window.addstr(lineno, column, text, color | line_part.decoration)
                     except curses.error:
                         # curses error at last column & row but I don't care
                         # because it still draws it
                         # https://stackoverflow.com/questions/10877469/
                         # ncurses-setting-last-character-on-screen-without-scrolling-enabled
-                        if lineno == win.getyx()[0] and column + len(text) == win.getyx()[1] + 1:
+                        if (
+                            lineno == window.getyx()[0]
+                            and column + len(text) == window.getyx()[1] + 1
+                        ):
                             pass
 
                         else:
                             self._logger.debug("curses error")
-                            self._logger.debug("screen_h: %s, lineno: %s", self._screen_h, lineno)
+                            self._logger.debug(
+                                "screen_height: %s, lineno: %s",
+                                self._screen_height,
+                                lineno,
+                            )
                             self._logger.debug(
                                 "screen_w: %s, column: %s text: %s, lentext: %s, end_col: %s",
-                                self._screen_w,
+                                self._screen_width,
                                 column,
                                 text,
                                 len(text),

--- a/src/ansible_navigator/ui_framework/form_presenter.py
+++ b/src/ansible_navigator/ui_framework/form_presenter.py
@@ -65,7 +65,7 @@ class FormPresenter(CursesWindow):
 
     @property
     def _field_win_width(self):
-        return self._screen_w - self._field_win_start
+        return self._screen_width - self._field_win_start
 
     def _dimensions(self):
         self._prompt_end = max([len(form_field.full_prompt) for form_field in self._form.fields])
@@ -101,8 +101,8 @@ class FormPresenter(CursesWindow):
         height += 2  # horizontal line + buttons
         self._form_height = height
 
-        self._pad_top = max(int((self._screen_h - self._form_height) * TOP_PAD_RATIO), 0)
-        self._pad_left = max(int((self._screen_w - self._form_width) * LEFT_PAD_RATIO), 0)
+        self._pad_top = max(int((self._screen_height - self._form_height) * TOP_PAD_RATIO), 0)
+        self._pad_left = max(int((self._screen_width - self._form_width) * LEFT_PAD_RATIO), 0)
 
     def _generate_form(self) -> Tuple[Tuple[int, CursesLine], ...]:
         lines = []
@@ -272,7 +272,7 @@ class FormPresenter(CursesWindow):
             pad.clear()
             for line in self._generate_form():
                 self._add_line(pad, *line)
-            pad.refresh(0, 0, 0, self._pad_left, self._screen_h - 1, self._screen_w - 1)
+            pad.refresh(0, 0, 0, self._pad_left, self._screen_height - 1, self._screen_width - 1)
 
             idx = idx % len(self._form.fields)
             form_field = self._form.fields[idx]

--- a/src/ansible_navigator/ui_framework/menu_builder.py
+++ b/src/ansible_navigator/ui_framework/menu_builder.py
@@ -25,7 +25,7 @@ class MenuBuilder:
     def __init__(
         self,
         progress_bar_width: int,
-        screen_w: int,
+        screen_width: int,
         number_colors: int,
         color_menu_item: Callable,
         ui_config: UIConfig,
@@ -33,7 +33,7 @@ class MenuBuilder:
         """Initialize the menu builder.
 
         :param progress_bar_width:  The width of the progress bar
-        :param screen_w: The current screen width
+        :param screen_width: The current screen width
         :param number_colors: The number of colors the current terminal supports
         :param color_menu_item: The callback for adding color to menu entries
         :param ui_config: The current user interface configuration
@@ -41,7 +41,7 @@ class MenuBuilder:
         # pylint: disable=too-many-arguments
         self._number_colors = number_colors
         self._progress_bar_width = progress_bar_width
-        self._screen_w = screen_w
+        self._screen_width = screen_width
         self._color_menu_item = color_menu_item
         self._ui_config = ui_config
 
@@ -71,7 +71,7 @@ class MenuBuilder:
         # add a space
         column_widths = [c + 1 for c in column_widths]
 
-        available = self._screen_w - line_prefix_w - 1  # scrollbar width
+        available = self._screen_width - line_prefix_w - 1  # scrollbar width
         adjusted_column_widths = distribute(available, column_widths)
 
         col_starts = [0]

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -90,7 +90,7 @@ class UserInterface(CursesWindow):
 
     def __init__(
         self,
-        screen_miny: int,
+        screen_min_height: int,
         kegexes: Callable[..., Any],
         refresh: int,
         ui_config: UIConfig,
@@ -99,7 +99,7 @@ class UserInterface(CursesWindow):
     ) -> None:
         """Initialize the user interface.
 
-        :param screen_miny: The minimum screen height
+        :param screen_min_height: The minimum screen height
         :param kegexes: A callable producing a list of action regular expressions to match against
         :param refresh: The screen refresh time is ms
         :param ui_config: the current UI configuration
@@ -128,7 +128,7 @@ class UserInterface(CursesWindow):
         self._prefix_color = 8
         self._refresh = [refresh]
         self._rgb_to_curses_color_idx: Dict[str, int] = {}
-        self._screen_miny = screen_miny
+        self._screen_min_height = screen_min_height
         self._scroll = 0
         self._xform = self._default_obj_serialization
         self._status = ""
@@ -237,7 +237,7 @@ class UserInterface(CursesWindow):
             status_width = self._pbar_width
         else:
             status_width = 0
-        gap = floor((self._screen_w - status_width - sum(colws)) / len(key_dict))
+        gap = floor((self._screen_width - status_width - sum(colws)) / len(key_dict))
         adj_colws = [c + gap for c in colws]
         col_starts = [0]
         for idx, colw in enumerate(adj_colws):
@@ -273,7 +273,7 @@ class UserInterface(CursesWindow):
             status = status.upper()  # upper
             footer.append(
                 CursesLinePart(
-                    column=self._screen_w - self._status_width - 1,
+                    column=self._screen_width - self._status_width - 1,
                     string=status,
                     color=self._status_color,
                     decoration=curses.A_REVERSE,
@@ -283,7 +283,7 @@ class UserInterface(CursesWindow):
 
     def _scroll_bar(
         self,
-        viewport_h: int,
+        viewport_height: int,
         len_heading: int,
         menu_size: int,
         body_start: int,
@@ -291,27 +291,27 @@ class UserInterface(CursesWindow):
     ) -> None:
         """Add a scroll bar if the length of the content is longer than the viewport height.
 
-        :param viewport_h: The height if the viewport
+        :param viewport_height: The height if the viewport
         :param len_heading: The height of the heading
         :param menu_size: The number of lines in the content
         :param body_start: Where we are in the body
         :param body_stop: The end of the body
         """
-        start_scroll_bar = body_start / menu_size * viewport_h
-        stop_scroll_bar = body_stop / menu_size * viewport_h
+        start_scroll_bar = body_start / menu_size * viewport_height
+        stop_scroll_bar = body_stop / menu_size * viewport_height
         len_scroll_bar = ceil(stop_scroll_bar - start_scroll_bar)
         color = self._prefix_color
         for idx in range(int(start_scroll_bar), int(start_scroll_bar + len_scroll_bar)):
             lineno = idx + len_heading
             line_part = CursesLinePart(
-                column=self._screen_w - 1,
+                column=self._screen_width - 1,
                 string="\u2592",
                 color=color,
                 decoration=0,
             )
             self._add_line(
                 window=self._screen,
-                lineno=min(lineno, viewport_h + len_heading),
+                lineno=min(lineno, viewport_height + len_heading),
                 line=tuple([line_part]),
             )
 
@@ -324,10 +324,10 @@ class UserInterface(CursesWindow):
         self.disable_refresh()
         form_field = FieldText(name="one_line", prompt="")
         clp = CursesLinePart(column=0, string=":", color=0, decoration=0)
-        input_at = self._screen_h - 1  # screen y is zero based
+        input_at = self._screen_height - 1  # screen y is zero based
         self._add_line(window=self._screen, lineno=input_at, line=tuple([clp]))
         self._screen.refresh()
-        self._one_line_input.win = curses.newwin(1, self._screen_w, input_at, 1)
+        self._one_line_input.win = curses.newwin(1, self._screen_width, input_at, 1)
         self._one_line_input.win.keypad(True)
         while True:
             user_input, char = self._one_line_input.handle(0, [form_field])
@@ -370,11 +370,11 @@ class UserInterface(CursesWindow):
         heading = heading or ()
         heading_len = len(heading)
         footer = self._footer(dict(**STND_KEYS, **key_dict, **END_KEYS))
-        footer_at = self._screen_h - 1  # screen is 0 based index
+        footer_at = self._screen_height - 1  # screen is 0 based index
         footer_len = 1
 
-        viewport_h = self._screen_h - len(heading) - footer_len
-        self.scroll(max(self.scroll(), viewport_h))
+        viewport_height = self._screen_height - len(heading) - footer_len
+        self.scroll(max(self.scroll(), viewport_height))
 
         index_width = len(str(count))
 
@@ -402,12 +402,12 @@ class UserInterface(CursesWindow):
                 )
 
             # Add the scroll bar
-            if count > viewport_h:
+            if count > viewport_height:
                 self._scroll_bar(
-                    viewport_h=viewport_h,
+                    viewport_height=viewport_height,
                     len_heading=len(heading),
                     menu_size=count,
-                    body_start=self._scroll - viewport_h,
+                    body_start=self._scroll - viewport_height,
                     body_stop=self._scroll,
                 )
 
@@ -425,7 +425,7 @@ class UserInterface(CursesWindow):
             return_value = None
             if key == "KEY_RESIZE":
                 new_scroll = min(
-                    self._scroll - viewport_h + self._screen_h - heading_len - footer_len,
+                    self._scroll - viewport_height + self._screen_height - heading_len - footer_len,
                     len(lines),
                 )
                 self.scroll(new_scroll)
@@ -433,16 +433,16 @@ class UserInterface(CursesWindow):
             elif key in keypad or key in other_valid_keys:
                 return_value = key
             elif key == "KEY_DOWN":
-                self.scroll(max(min(self.scroll() + 1, count), viewport_h))
+                self.scroll(max(min(self.scroll() + 1, count), viewport_height))
                 return_value = key
             elif key == "KEY_UP":
-                self.scroll(max(self.scroll() - 1, viewport_h))
+                self.scroll(max(self.scroll() - 1, viewport_height))
                 return_value = key
             elif key in ["^F", "KEY_NPAGE"]:
-                self.scroll(max(min(self.scroll() + viewport_h, count), viewport_h))
+                self.scroll(max(min(self.scroll() + viewport_height, count), viewport_height))
                 return_value = key
             elif key in ["^B", "KEY_PPAGE"]:
-                self.scroll(max(self.scroll() - viewport_h, viewport_h))
+                self.scroll(max(self.scroll() - viewport_height, viewport_height))
                 return_value = key
             elif key == ":":
                 colon_entry = self._get_input_line()
@@ -606,7 +606,7 @@ class UserInterface(CursesWindow):
         :return: the serialize lines ready for display
         :rtype: CursesLines
         """
-        heading = self._content_heading(obj, self._screen_w)
+        heading = self._content_heading(obj, self._screen_width)
         filtered_obj = self._filter_content_keys(obj) if self._hide_keys else obj
         lines = self._serialize_color(filtered_obj)
         return heading, lines
@@ -635,11 +635,17 @@ class UserInterface(CursesWindow):
             footer_len = 1
 
             if self.scroll() == 0:
-                last_line_idx = min(len(lines) - 1, self._screen_h - heading_len - footer_len - 1)
+                last_line_idx = min(
+                    len(lines) - 1,
+                    self._screen_height - heading_len - footer_len - 1,
+                )
             else:
                 last_line_idx = min(len(lines) - 1, self._scroll - 1)
 
-            first_line_idx = max(0, last_line_idx - (self._screen_h - 1 - heading_len - footer_len))
+            first_line_idx = max(
+                0,
+                last_line_idx - (self._screen_height - 1 - heading_len - footer_len),
+            )
 
             if len(objs) > 1:
                 key_dict = {"-": "previous", "+": "next", "[0-9]": "goto"}
@@ -661,8 +667,8 @@ class UserInterface(CursesWindow):
                 continue
 
             if entry == "KEY_RESIZE":
-                # only the heading knows about the screen_w and screen_h
-                heading = self._content_heading(objs[index], self._screen_w)
+                # only the heading knows about the screen width and height
+                heading = self._content_heading(objs[index], self._screen_width)
                 continue
 
             if entry == "_":
@@ -751,7 +757,7 @@ class UserInterface(CursesWindow):
         """
         menu_builder = MenuBuilder(
             progress_bar_width=self._pbar_width,
-            screen_w=self._screen_w,
+            screen_width=self._screen_width,
             number_colors=curses.COLORS,
             color_menu_item=self._color_menu_item,
             ui_config=self._ui_config,
@@ -771,11 +777,11 @@ class UserInterface(CursesWindow):
         while True:
 
             if self.scroll() == 0:
-                last_line_idx = min(len(current) - 1, self._screen_h - 3)
+                last_line_idx = min(len(current) - 1, self._screen_height - 3)
             else:
                 last_line_idx = min(len(current) - 1, self._scroll - 1)
 
-            first_line_idx = max(0, last_line_idx - (self._screen_h - 3))
+            first_line_idx = max(0, last_line_idx - (self._screen_height - 3))
 
             if self.menu_filter():
                 self._menu_indices = tuple(


### PR DESCRIPTION
This normalizes the way we refer to the height and width of both the screen and viewport.

There was a mix of x,y,_h,_w.  It is simply width and height now throughout.


Testing of resize, scrolling and refresh were done locally, in addition to the coverage GHAs will provide for rendering.