### PR TITLE
Unabbreviate chksum, fpath, cname in catalog_collections.py

### DIFF
--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -207,9 +207,9 @@ class Action(App):
         selected_collection = self._collections[self.steps.current.index]
         cname_col = f"__{selected_collection['known_as']}"
         plugins = []
-        for plugin_chksum, details in selected_collection["plugin_chksums"].items():
+        for plugin_checksum, details in selected_collection["plugin_checksums"].items():
             try:
-                plugin_json = self._collection_cache[plugin_chksum]
+                plugin_json = self._collection_cache[plugin_checksum]
                 loaded = json.loads(plugin_json)
 
                 plugin = loaded["plugin"]


### PR DESCRIPTION
This unabbreviates a few words in catalog_collections.py.

The only exception is where the final entry is built, as we need to carry forward the abbreviation from here:

https://github.com/ansible/ansible/blob/15ace5a854886cd75894e7214209e4b027034bdb/lib/ansible/galaxy/collection/__init__.py#L807

collections.py was changed as it is the recipient of the data.

Additional testing was done locally to ensure there were not issues with an existing collection cache as a new one is generated with our CI testing each time.

The checksum dictionary is not stored in the collection cache, so we don't require a version change of it here, only the checksum is used as the key in the collection cache.... whew.

![image](https://user-images.githubusercontent.com/18386516/152986961-743f5c91-7cd5-4dad-bd68-fc18f241a6e3.png)
