### PR TITLE
Replace `yahmool` in tests, update fixtures.

### DIFF
--- a/tests/fixtures/integration/actions/config/ansible.cfg
+++ b/tests/fixtures/integration/actions/config/ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-yaml_valid_extensions = .yahmool
+yaml_valid_extensions = .os2

--- a/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/8.json
+++ b/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/8.json
@@ -4,7 +4,7 @@
     "comment": "config specified configuration file with ee",
     "additional_information": {
         "look_fors": [
-            ".yahmool"
+            ".os2"
         ],
         "look_nots": [],
         "compared_fixture": false
@@ -34,6 +34,6 @@
         "WIN_ASYNC_STARTUP_TIMEOUT(default) = 5",
         "WORKER_SHUTDOWN_POLL_COUNT(default) = 0",
         "WORKER_SHUTDOWN_POLL_DELAY(default) = 0.1",
-        "YAML_FILENAME_EXTENSIONS(/home/user/github/ansible-navigator/tests/fixtures/integration/actions/config/ansible.cfg) = ['.yahmool'](venv) bash-5.1$"
+        "YAML_FILENAME_EXTENSIONS(/home/user/github/ansible-navigator/tests/fixtures/integration/actions/config/ansible.cfg) = ['.os2'](venv) bash-5.1$"
     ]
 }

--- a/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/9.json
+++ b/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/9.json
@@ -4,7 +4,7 @@
     "comment": "config specified configuration file without ee",
     "additional_information": {
         "look_fors": [
-            ".yahmool"
+            ".os2"
         ],
         "look_nots": [],
         "compared_fixture": false
@@ -34,6 +34,6 @@
         "WIN_ASYNC_STARTUP_TIMEOUT(default) = 5",
         "WORKER_SHUTDOWN_POLL_COUNT(default) = 0",
         "WORKER_SHUTDOWN_POLL_DELAY(default) = 0.1",
-        "YAML_FILENAME_EXTENSIONS(/home/user/github/ansible-navigator/tests/fixtures/integration/actions/config/ansible.cfg) = ['.yahmool'](venv) bash-5.1$"
+        "YAML_FILENAME_EXTENSIONS(/home/user/github/ansible-navigator/tests/fixtures/integration/actions/config/ansible.cfg) = ['.os2'](venv) bash-5.1$"
     ]
 }

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_specified_config.py/test/3.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_specified_config.py/test/3.json
@@ -5,7 +5,7 @@
     "additional_information": {
         "look_fors": [
             "YAML_FILENAME_EXTENSIONS",
-            "['.yahmool']"
+            "['.os2']"
         ],
         "look_nots": [],
         "compared_fixture": false
@@ -201,7 +201,7 @@
         "186│WIN_ASYNC_STARTUP_TIMEOUT                  True default                                                                           default                                                                           5",
         "187│WORKER_SHUTDOWN_POLL_COUNT                 True default                                                                           default                                                                           0",
         "188│WORKER_SHUTDOWN_POLL_DELAY                 True default                                                                           default                                                                           0.1",
-        "189│YAML_FILENAME_EXTENSIONS                  False /home/user/github/ansible-navigator/tests/fixtures/integration/actions/config//home/user/github/ansible-navigator/tests/fixtures/integration/actions/config/['.yahmool']",
+        "189│YAML_FILENAME_EXTENSIONS                  False /home/user/github/ansible-navigator/tests/fixtures/integration/actions/config//home/user/github/ansible-navigator/tests/fixtures/integration/actions/config/['.os2']",
         "^f/PgUp page up                                      ^b/PgDn page down                                      ↑↓ scroll                                      esc back                                      [0-9] goto                                      :help help"
     ]
 }

--- a/tests/integration/actions/config/test_stdout_tmux.py
+++ b/tests/integration/actions/config/test_stdout_tmux.py
@@ -104,7 +104,7 @@ stdout_tests = (
             execution_environment=True,
             pass_environment_variables=["PAGER"],
         ).join(),
-        look_fors=[".yahmool"],
+        look_fors=[".os2"],
     ),
     ShellCommand(
         comment="config specified configuration file without ee",
@@ -113,7 +113,7 @@ stdout_tests = (
             mode="stdout",
             execution_environment=False,
         ).join(),
-        look_fors=[".yahmool"],
+        look_fors=[".os2"],
     ),
 )
 

--- a/tests/integration/actions/config/test_welcome_interactive_specified_config.py
+++ b/tests/integration/actions/config/test_welcome_interactive_specified_config.py
@@ -23,7 +23,7 @@ steps = (
     Step(
         user_input=":config -c " + CONFIG_FIXTURE,
         comment="enter config from welcome screen, custom config, (no ee)",
-        look_fors=["YAML_FILENAME_EXTENSIONS", "['.yahmool']"],
+        look_fors=["YAML_FILENAME_EXTENSIONS", "['.os2']"],
     ),
 )
 


### PR DESCRIPTION
This repalce the bogus file extsion `.yahmool` with `.os2` in the tests.

Fixture updates were required as well.

When OS/2 is supported, I hope to be long gone.