### PR TITLE
Remove formatter from the checks

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,14 +14,6 @@ maintain it and you contribute.
 
 4. isort (sorts import statements)
 
-```{note}
-In early development cycles, a decision was made to use black as a formatter
-which is why current pull-requests are required to pass a
-`black --diff` check of the source tree. The decision to use `black` is
-left to individual developers as the formatting changes it makes can be
-achieved without it.
-```
-
 Details can be found below on how to run these manually, our CI will also
 check them for you.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,16 +17,6 @@ repos:
       - id: isort
         name: Sort import statements using isort
 
-  - repo: https://github.com/psf/black.git
-    rev: 22.1.0
-    hooks:
-      - id: black
-        language_version: python3
-        args:
-          - --diff
-          - --check
-          - .
-
   - repo: https://github.com/Lucas-C/pre-commit-hooks.git
     rev: v1.1.11
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,6 @@
     showcontent = true
 
 
-[tool.black]
-line-length = 100
-
 [tool.coverage.run]
     branch = true
     source_pkgs = ["ansible_navigator"]
@@ -63,7 +60,7 @@ known_first_party = "ansible_navigator, key_value_store" # No effect at implemen
 lines_after_imports = 2 # Ensures consistency for cases when there's variable vs function/class definitions after imports
 lines_between_types = 1 # Separate import/from with 1 line, minimizing changes at time of implementation
 no_lines_before = "LOCALFOLDER"  # Keeps local imports bundled with first-party
-profile = "black" # Avoid conflict with black
+profile = "black"
 skip_glob = ["tests/fixtures/common/collections*"] # Skip ansible content due to ansible-test sanity ruleset
 
 [tool.pylint]


### PR DESCRIPTION
This is necessary because it was never accepted by all DevTools
contributors and imposing it on unsuspecting victims is not fair.
The contribution guide says that it's not enforced but it's not
entirely correct -- it is not possible to contribute without having
to reproduce the same result as black emits.

This is undesirable because it puts extra burden on contributors who
want to see their code structured in a meaningful way. While black
helps with the style consistency, it's not the only way of achieving
it. And in its current state, it sometimes makes formatting changes
that don't make sense and work against readability. Unfortunately,
because of it's repressive nature, it's not possible to fix it while
having it enabled.

Black also hides a number of useful linting violations that, when
actually shown, can help the coders identify structural/architectural
problems.

As for alternatives, it's possible to maintain consistent code style
in a friendlier way by combining several other smaller formatters
(like autopep8, some configurations of yapf and pre-commit.com hooks)
that are as acceptable PEP 8-wise but give a bit more flexibility in
preserving structural readability of contributions. This is not to
say that people are now allowed to nitpick style in reviews but it
should be noted that sometimes important structural improvement
requests get mistaken for style change. When getting reviews, the
motivation of improving structure should be assumed, if the
suggested code snippets contains style updates, it can be disgregarded
for as long as the underlying idea is well understood and considered
by the PR submitter.