### PR TITLE
Remove rtype from docstrings

### DIFF
--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -736,7 +736,6 @@ class Action(App):
         """generate a menu of task for the currently selected play
 
         :return: The menu step
-        :rtype: Step
         """
         value = self.steps.current.selected["tasks"]
         step = Step(
@@ -752,7 +751,6 @@ class Action(App):
         """generate task content for the selected task
 
         :return: content which show a task
-        :rtype: Step
         """
         value = self.steps.current.value
         index = self.steps.current.index

--- a/src/ansible_navigator/steps.py
+++ b/src/ansible_navigator/steps.py
@@ -52,7 +52,6 @@ class Step:
         """return if this has changed
 
         :return: if this has changed
-        :rtype: bool
         """
         return self._index_changed or self._value_changed
 
@@ -72,7 +71,6 @@ class Step:
         """return the index
 
         :return: index (should be ``int``)
-        :rtype: Optional[int]
         """
         return self._index
 
@@ -92,7 +90,6 @@ class Step:
         """return the selected item
 
         :return: the selected item
-        :rtype: Optional[Dict[str, Any]]
         """
         if self._index is None or not self._value:
             return None
@@ -103,7 +100,6 @@ class Step:
         """return the value
 
         :return: the value
-        :rtype: list
         """
         return self._value
 

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -50,7 +50,6 @@ class ColorSchema:
         :param scope: The scope, aka format
         :type scope: str
         :return: the color in RGB format or None
-        :rtype: tuple or None
         """
         for name in reversed(scope):
             for parts in range(0, len(name.split("."))):
@@ -94,7 +93,6 @@ class Colorize:
         :param scope: The scope, aka the format of the string
         :type scope: str
         :return: A list of lines, each a list of dicts
-        :rtype: list
         """
         if scope == "source.ansi":
             return [ansi_to_curses(l) for l in doc.splitlines()]  # noqa: E741
@@ -140,7 +138,6 @@ def to_list(thing):
     :param thing: Maybe a list?
     :type thing: str or list
     :return: thing as list
-    :rtype: list
     """
     if not isinstance(thing, list):
         return [thing]
@@ -153,7 +150,6 @@ def hex_to_rgb(value):
     :param value: the hex color
     :type value: str
     :returns: RGB tuple
-    :rtype: tuple
     """
     if value:
         value = value.lstrip("#")
@@ -172,7 +168,6 @@ def hex_to_rgb_curses(value):
     :param value: an RGB color
     :type value: tuple
     :return: The colors scaled to 1000
-    :rtype: tuple
     """
     scale = lambda x: int(x * 1000 / 255)  # noqa: E731
     red, green, blue = hex_to_rgb(value)

--- a/src/ansible_navigator/ui_framework/curses_window.py
+++ b/src/ansible_navigator/ui_framework/curses_window.py
@@ -69,7 +69,6 @@ class CursesWindow:
         """return the screen width
 
         :return: the current screen width
-        :rtype: int
         """
         return self._screen.getmaxyx()[1]
 
@@ -78,7 +77,6 @@ class CursesWindow:
         """return the screen height, or notify if too small
 
         :return: the current screen height
-        :rtype: int
         """
         while True:
             if self._screen.getmaxyx()[0] >= self._screen_min_height:

--- a/src/ansible_navigator/ui_framework/menu_builder.py
+++ b/src/ansible_navigator/ui_framework/menu_builder.py
@@ -56,7 +56,6 @@ class MenuBuilder:
         :param cols: The columns (keys) to use in the dicts
         :param indices: A range of what's showing in the UI
         :return: the heading and body of the menu
-        :rtype: (CursesLines, CursesLines)
         """
         line_prefix_w = len(str(len(dicts))) + len("|")
 

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -184,7 +184,6 @@ class UserInterface(CursesWindow):
         :param value: the value to set the scroll to
         :type value: int
         :return: the current scroll
-        :rtype: int
         """
         if value is not None:
             if not isinstance(value, int):
@@ -198,7 +197,6 @@ class UserInterface(CursesWindow):
         :param value: the value to set the serialization format to
         :type value: str or None
         :return: the current serialization format
-        :rtype: str
         """
         if value is not None:
             self._serialization_format = value
@@ -211,7 +209,6 @@ class UserInterface(CursesWindow):
         """Limit the callables the actions can access
 
         :return: A tuple of available functions
-        :rtype: Ui
         """
         res = Ui(
             clear=self.clear,
@@ -230,7 +227,6 @@ class UserInterface(CursesWindow):
         :param key_dict: the keys and their description
         :type key_dict: dict
         :return: The footer line
-        :rtype: CursesLine
         """
         colws = [len(f"{str(k)}: {str(v)}") for k, v in key_dict.items()]
         if self._status:
@@ -319,7 +315,6 @@ class UserInterface(CursesWindow):
         """get one line of input from the user
 
         :return: the lines
-        :rtype: str
         """
         self.disable_refresh()
         form_field = FieldText(name="one_line", prompt="")
@@ -365,7 +360,6 @@ class UserInterface(CursesWindow):
         :param await_input: Should we wait for a key
         :type await_input: bool
         :return: the key pressed
-        :rtype: str
         """
         heading = heading or ()
         heading_len = len(heading)
@@ -464,7 +458,6 @@ class UserInterface(CursesWindow):
         :param entry: the user input
         :param current: the content on the screen
         :return: The name and matching action or not
-        :rtype: str, Action or None, None
         """
         if not entry.startswith("{{"):  # don't match pure template
             if "{{" in entry and "}}" in entry:
@@ -497,7 +490,6 @@ class UserInterface(CursesWindow):
         :param obj: the object to color
         :type obj: Any
         :return: The generated lines
-        :rtype: CursesLines
         """
 
         if self.serialization_format() == "source.ansi":
@@ -563,7 +555,6 @@ class UserInterface(CursesWindow):
         :type lines: list of lists of dicts
             Lines[LinePart[{"color": RGB, "chars": text, "column": n},...]]
         :return: all the lines
-        :rtype: CursesLines
         """
         return tuple(self._colored_line(line) for line in lines)
 
@@ -604,7 +595,6 @@ class UserInterface(CursesWindow):
         :param obj: the obj to serialize
         :type obj: Any
         :return: the serialize lines ready for display
-        :rtype: CursesLines
         """
         heading = self._content_heading(obj, self._screen_width)
         filtered_obj = self._filter_content_keys(obj) if self._hide_keys else obj
@@ -624,7 +614,6 @@ class UserInterface(CursesWindow):
         :param objs: A list of one or more object
         :param await_input: Should we wait for user input before returning
         :return: interaction with the user
-        :rtype: Interaction
         """
         heading, lines = self._filter_and_serialize(objs[index])
         while True:
@@ -739,7 +728,6 @@ class UserInterface(CursesWindow):
         :param value: the string to check
         :type value: str
         :return: the match if made
-        :rtype: Match or None
         """
         return regex.search(str(value))
 

--- a/src/ansible_navigator/utils.py
+++ b/src/ansible_navigator/utils.py
@@ -170,7 +170,6 @@ def escape_moustaches(obj):
     :param obj: something
     :type obj: Any
     :return: the obj with replacements made
-    :rtype: Any
     """
     replacements = (("{", "U+007B"), ("}", "U+007D"))
     return dispatch(obj, replacements)
@@ -494,7 +493,6 @@ def unescape_moustaches(obj):
     :param obj: something
     :type obj: Any
     :return: the obj with replacements made
-    :rtype: Any
     """
     replacements = (("U+007B", "{"), ("U+007D", "}"))
     return dispatch(obj, replacements)


### PR DESCRIPTION
This remove the use of `rtype` from some docstrings.

This was done early on, but soon after typing the project it stopped.