### PR TITLE
Update config interactive tests removing `look_fors/look_nots` adding `present/absent`

### DIFF
--- a/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/0.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/0.json
@@ -3,8 +3,8 @@
     "index": 0,
     "comment": "ansible-navigator config command top window",
     "additional_information": {
-        "look_for": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/1.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/1.json
@@ -3,8 +3,8 @@
     "index": 1,
     "comment": "filter for cache plugin timeout",
     "additional_information": {
-        "look_for": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/2.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/2.json
@@ -3,8 +3,8 @@
     "index": 2,
     "comment": "cache plugin details",
     "additional_information": {
-        "look_for": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/3.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/3.json
@@ -3,8 +3,8 @@
     "index": 3,
     "comment": "return to filtered list",
     "additional_information": {
-        "look_for": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/4.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/4.json
@@ -3,11 +3,11 @@
     "index": 4,
     "comment": "clear filter, full list",
     "additional_information": {
-        "look_for": [
+        "present": [
             "ACTION_WARNINGS",
             "CALLBACKS_ENABLED"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/5.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/5.json
@@ -3,8 +3,8 @@
     "index": 5,
     "comment": "filter off screen value",
     "additional_information": {
-        "look_for": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/6.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/6.json
@@ -3,8 +3,8 @@
     "index": 6,
     "comment": "YAML_FILENAME_EXTENSIONS details",
     "additional_information": {
-        "look_for": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/7.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/7.json
@@ -3,8 +3,8 @@
     "index": 7,
     "comment": "return to filtered list",
     "additional_information": {
-        "look_for": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/8.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_ee.py/test/8.json
@@ -3,11 +3,11 @@
     "index": 8,
     "comment": "clear filter, full list",
     "additional_information": {
-        "look_for": [
+        "present": [
             "ACTION_WARNINGS",
             "CALLBACKS_ENABLED"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/0.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/0.json
@@ -3,11 +3,11 @@
     "index": 0,
     "comment": "ansible-navigator config command top window",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "ACTION_WARNINGS",
             "CALLBACKS_ENABLED"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/1.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/1.json
@@ -3,8 +3,8 @@
     "index": 1,
     "comment": "filter for cache plugin timeout",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/2.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/2.json
@@ -3,8 +3,8 @@
     "index": 2,
     "comment": "cache plugin details",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/3.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/3.json
@@ -3,8 +3,8 @@
     "index": 3,
     "comment": "return to filtered list",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/4.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/4.json
@@ -3,11 +3,11 @@
     "index": 4,
     "comment": "clear filter, full list",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "ACTION_WARNINGS",
             "CALLBACKS_ENABLED"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/5.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/5.json
@@ -3,8 +3,8 @@
     "index": 5,
     "comment": "filter off screen value",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/6.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/6.json
@@ -3,8 +3,8 @@
     "index": 6,
     "comment": "YAML_FILENAME_EXTENSIONS details",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/7.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/7.json
@@ -3,8 +3,8 @@
     "index": 7,
     "comment": "return to filtered list",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/8.json
+++ b/tests/fixtures/integration/actions/config/test_direct_interactive_noee.py/test/8.json
@@ -3,11 +3,11 @@
     "index": 8,
     "comment": "clear filter, full list",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "ACTION_WARNINGS",
             "CALLBACKS_ENABLED"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/0.json
+++ b/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/0.json
@@ -3,10 +3,10 @@
     "index": 0,
     "comment": "config dump with ee",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "YAML_FILENAME_EXTENSIONS"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/1.json
+++ b/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/1.json
@@ -3,10 +3,10 @@
     "index": 1,
     "comment": "config dump without ee",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "YAML_FILENAME_EXTENSIONS"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/2.json
+++ b/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/2.json
@@ -3,10 +3,10 @@
     "index": 2,
     "comment": "config list with ee",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "YAML_FILENAME_EXTENSIONS"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/3.json
+++ b/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/3.json
@@ -3,10 +3,10 @@
     "index": 3,
     "comment": "config list without ee",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "YAML_FILENAME_EXTENSIONS"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/4.json
+++ b/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/4.json
@@ -3,10 +3,10 @@
     "index": 4,
     "comment": "config helpconfig with ee",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "usage: ansible-config [-h]"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/5.json
+++ b/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/5.json
@@ -3,10 +3,10 @@
     "index": 5,
     "comment": "config helpconfig without ee",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "usage: ansible-config [-h]"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/6.json
+++ b/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/6.json
@@ -3,10 +3,10 @@
     "index": 6,
     "comment": "config helpconfig fail with interactive with ee",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "--hc or --help-config is valid only when 'mode' argument is set to 'stdout'"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/7.json
+++ b/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/7.json
@@ -3,10 +3,10 @@
     "index": 7,
     "comment": "config helpconfig fail with interactive without ee",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "--hc or --help-config is valid only when 'mode' argument is set to 'stdout'"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/8.json
+++ b/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/8.json
@@ -3,10 +3,10 @@
     "index": 8,
     "comment": "config specified configuration file with ee",
     "additional_information": {
-        "look_fors": [
+        "present": [
             ".os2"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/9.json
+++ b/tests/fixtures/integration/actions/config/test_stdout_tmux.py/test/9.json
@@ -3,10 +3,10 @@
     "index": 9,
     "comment": "config specified configuration file without ee",
     "additional_information": {
-        "look_fors": [
+        "present": [
             ".os2"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/0.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/0.json
@@ -3,8 +3,8 @@
     "index": 0,
     "comment": "welcome screen",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/1.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/1.json
@@ -3,8 +3,8 @@
     "index": 1,
     "comment": "enter config from welcome screen",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/2.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/2.json
@@ -3,8 +3,8 @@
     "index": 2,
     "comment": "filter for cache plugin timeout",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/3.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/3.json
@@ -3,8 +3,8 @@
     "index": 3,
     "comment": "cache plugin details",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/4.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/4.json
@@ -3,8 +3,8 @@
     "index": 4,
     "comment": "return to filtered list",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/5.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/5.json
@@ -3,11 +3,11 @@
     "index": 5,
     "comment": "clear filter, full list",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "ACTION_WARNINGS",
             "CALLBACKS_ENABLED"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/6.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/6.json
@@ -3,8 +3,8 @@
     "index": 6,
     "comment": "filter off screen value",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/7.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/7.json
@@ -3,8 +3,8 @@
     "index": 7,
     "comment": "YAML_FILENAME_EXTENSIONS details",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/8.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/8.json
@@ -3,8 +3,8 @@
     "index": 8,
     "comment": "return to filtered list",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/9.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_ee.py/test/9.json
@@ -3,11 +3,11 @@
     "index": 9,
     "comment": "clear filter, full list",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "ACTION_WARNINGS",
             "CALLBACKS_ENABLED"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/0.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/0.json
@@ -3,8 +3,8 @@
     "index": 0,
     "comment": "welcome screen",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/1.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/1.json
@@ -3,11 +3,11 @@
     "index": 1,
     "comment": "enter config from welcome screen",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "ACTION_WARNINGS",
             "CALLBACKS_ENABLED"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/2.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/2.json
@@ -3,8 +3,8 @@
     "index": 2,
     "comment": "filter for cache plugin timeout",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/3.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/3.json
@@ -3,8 +3,8 @@
     "index": 3,
     "comment": "cache plugin details",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/4.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/4.json
@@ -3,8 +3,8 @@
     "index": 4,
     "comment": "return to filtered list",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/5.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/5.json
@@ -3,11 +3,11 @@
     "index": 5,
     "comment": "clear filter, full list",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "ACTION_WARNINGS",
             "CALLBACKS_ENABLED"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/6.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/6.json
@@ -3,8 +3,8 @@
     "index": 6,
     "comment": "filter off screen value",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/7.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/7.json
@@ -3,8 +3,8 @@
     "index": 7,
     "comment": "YAML_FILENAME_EXTENSIONS details",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/8.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/8.json
@@ -3,8 +3,8 @@
     "index": 8,
     "comment": "return to filtered list",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/9.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_noee.py/test/9.json
@@ -3,11 +3,11 @@
     "index": 9,
     "comment": "clear filter, full list",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "ACTION_WARNINGS",
             "CALLBACKS_ENABLED"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_param_use.py/test/0.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_param_use.py/test/0.json
@@ -3,8 +3,8 @@
     "index": 0,
     "comment": "welcome screen",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_param_use.py/test/1.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_param_use.py/test/1.json
@@ -3,11 +3,11 @@
     "index": 1,
     "comment": "enter config from welcome screen",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "ANSIBLE_CACHE_PLUGIN_TIMEOUT",
             "42"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_param_use.py/test/2.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_param_use.py/test/2.json
@@ -3,8 +3,8 @@
     "index": 2,
     "comment": "return to welcome screen",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_param_use.py/test/3.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_param_use.py/test/3.json
@@ -3,11 +3,11 @@
     "index": 3,
     "comment": "enter config from welcome screen",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "ANSIBLE_CACHE_PLUGIN_TIMEOUT",
             "42"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_specified_config.py/test/0.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_specified_config.py/test/0.json
@@ -3,8 +3,8 @@
     "index": 0,
     "comment": "welcome screen",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_specified_config.py/test/1.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_specified_config.py/test/1.json
@@ -3,11 +3,11 @@
     "index": 1,
     "comment": "enter config from welcome screen (no ee)",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "YAML_FILENAME_EXTENSIONS",
             "['.yml', '.yaml', '.json']"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_specified_config.py/test/2.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_specified_config.py/test/2.json
@@ -3,8 +3,8 @@
     "index": 2,
     "comment": "return to welcome screen",
     "additional_information": {
-        "look_fors": [],
-        "look_nots": [],
+        "present": [],
+        "absent": [],
         "compared_fixture": true
     },
     "output": [

--- a/tests/fixtures/integration/actions/config/test_welcome_interactive_specified_config.py/test/3.json
+++ b/tests/fixtures/integration/actions/config/test_welcome_interactive_specified_config.py/test/3.json
@@ -3,11 +3,11 @@
     "index": 3,
     "comment": "enter config from welcome screen, custom config, (no ee)",
     "additional_information": {
-        "look_fors": [
+        "present": [
             "YAML_FILENAME_EXTENSIONS",
             "['.os2']"
         ],
-        "look_nots": [],
+        "absent": [],
         "compared_fixture": false
     },
     "output": [

--- a/tests/integration/_common.py
+++ b/tests/integration/_common.py
@@ -69,7 +69,7 @@ def update_fixtures(
         fixture["additional_information"] = additional_information
         if additional_information.get("look_fors"):
             received_output = sanitize_output(received_output)
-        elif additional_information.get("look_for"):
+        elif additional_information.get("present"):
             received_output = sanitize_output(received_output)
     fixture["output"] = received_output
     with open(f"{dir_path}/{file_name}", "w", encoding="utf8") as fh:

--- a/tests/integration/_interactions.py
+++ b/tests/integration/_interactions.py
@@ -60,7 +60,7 @@ class Step(NamedTuple):
     search_within_response: Union[SearchFor, str, List] = SearchFor.HELP
 
 
-class TestStep(NamedTuple):
+class UiTestStep(NamedTuple):
     """A simulated user interaction with the user interface."""
 
     #: The string to send to the tmux session
@@ -68,9 +68,9 @@ class TestStep(NamedTuple):
     #: Explanation of what is being sent or done
     comment: str
     #: Search for in the response
-    look_for: List[str] = []
+    present: List[str] = []
     #: Ensure not in the response
-    look_nots: List[str] = []
+    absent: List[str] = []
     #: Should the output be masked prior to writing a fixture
     mask: bool = True
     #: The index of the step with the list of all steps

--- a/tests/integration/actions/config/base.py
+++ b/tests/integration/actions/config/base.py
@@ -9,7 +9,7 @@ from ....defaults import FIXTURES_DIR
 from ..._common import retrieve_fixture_for_step
 from ..._common import update_fixtures
 from ..._interactions import SearchFor
-from ..._interactions import TestStep
+from ..._interactions import UiTestStep
 from ..._tmux_session import TmuxSession
 
 
@@ -17,22 +17,22 @@ CONFIG_FIXTURE = os.path.join(FIXTURES_DIR, "integration", "actions", "config", 
 
 
 base_steps = (
-    TestStep(user_input=":f CACHE_PLUGIN_TIMEOUT", comment="filter for cache plugin timeout"),
-    TestStep(user_input=":0", comment="cache plugin details"),
-    TestStep(user_input=":back", comment="return to filtered list"),
-    TestStep(
+    UiTestStep(user_input=":f CACHE_PLUGIN_TIMEOUT", comment="filter for cache plugin timeout"),
+    UiTestStep(user_input=":0", comment="cache plugin details"),
+    UiTestStep(user_input=":back", comment="return to filtered list"),
+    UiTestStep(
         user_input=":f",
         comment="clear filter, full list",
-        look_for=["ACTION_WARNINGS", "CALLBACKS_ENABLED"],
+        present=["ACTION_WARNINGS", "CALLBACKS_ENABLED"],
         mask=True,
     ),
-    TestStep(user_input=":f yaml", comment="filter off screen value"),
-    TestStep(user_input=":3", comment="YAML_FILENAME_EXTENSIONS details"),
-    TestStep(user_input=":back", comment="return to filtered list"),
-    TestStep(
+    UiTestStep(user_input=":f yaml", comment="filter off screen value"),
+    UiTestStep(user_input=":3", comment="YAML_FILENAME_EXTENSIONS details"),
+    UiTestStep(user_input=":back", comment="return to filtered list"),
+    UiTestStep(
         user_input=":f",
         comment="clear filter, full list",
-        look_for=["ACTION_WARNINGS", "CALLBACKS_ENABLED"],
+        present=["ACTION_WARNINGS", "CALLBACKS_ENABLED"],
         mask=True,
     ),
 )
@@ -103,21 +103,21 @@ class BaseClass:
                 received_output,
                 step.comment,
                 additional_information={
-                    "look_for": step.look_for,
-                    "look_nots": step.look_nots,
-                    "compared_fixture": not any((step.look_for, step.look_nots)),
+                    "present": step.present,
+                    "absent": step.absent,
+                    "compared_fixture": not any((step.present, step.absent)),
                 },
             )
 
         page = " ".join(received_output)
 
-        if step.look_for:
-            assert all(look_for in page for look_for in step.look_for)
+        if step.present:
+            assert all(present in page for present in step.present)
 
-        if step.look_nots:
-            assert not any(look_not in page for look_not in step.look_nots)
+        if step.absent:
+            assert not any(look_not in page for look_not in step.absent)
 
-        if not any((step.look_for, step.look_nots)):
+        if not any((step.present, step.absent)):
             expected_output = retrieve_fixture_for_step(request, step.step_index)
             assert expected_output == received_output, "\n" + "\n".join(
                 difflib.unified_diff(expected_output, received_output, "expected", "received"),

--- a/tests/integration/actions/config/test_direct_interactive_ee.py
+++ b/tests/integration/actions/config/test_direct_interactive_ee.py
@@ -3,7 +3,7 @@
 import pytest
 
 from ..._interactions import Command
-from ..._interactions import TestStep
+from ..._interactions import UiTestStep
 from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
@@ -12,7 +12,7 @@ from .base import base_steps
 
 CLI = Command(subcommand="config", execution_environment=True).join()
 
-initial_steps = (TestStep(user_input=CLI, comment="ansible-navigator config command top window"),)
+initial_steps = (UiTestStep(user_input=CLI, comment="ansible-navigator config command top window"),)
 
 steps = add_indices(initial_steps + base_steps)
 

--- a/tests/integration/actions/config/test_direct_interactive_noee.py
+++ b/tests/integration/actions/config/test_direct_interactive_noee.py
@@ -3,7 +3,7 @@
 import pytest
 
 from ..._interactions import Command
-from ..._interactions import TestStep
+from ..._interactions import UiTestStep
 from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
@@ -13,10 +13,10 @@ from .base import base_steps
 CLI = Command(subcommand="config", execution_environment=False).join()
 
 initial_steps = (
-    TestStep(
+    UiTestStep(
         user_input=CLI,
         comment="ansible-navigator config command top window",
-        look_for=["ACTION_WARNINGS", "CALLBACKS_ENABLED"],
+        present=["ACTION_WARNINGS", "CALLBACKS_ENABLED"],
     ),
 )
 

--- a/tests/integration/actions/config/test_stdout_tmux.py
+++ b/tests/integration/actions/config/test_stdout_tmux.py
@@ -3,7 +3,7 @@ import pytest
 
 from ..._interactions import Command
 from ..._interactions import SearchFor
-from ..._interactions import TestStep
+from ..._interactions import UiTestStep
 from ..._interactions import add_indices
 from .base import CONFIG_FIXTURE
 from .base import BaseClass
@@ -16,7 +16,7 @@ class StdoutCommand(Command):
     preclear = True
 
 
-class ShellCommand(TestStep):
+class ShellCommand(UiTestStep):
     """a shell command"""
 
     search_within_response = SearchFor.PROMPT
@@ -30,7 +30,7 @@ stdout_tests = (
             mode="stdout",
             execution_environment=True,
         ).join(),
-        look_for=["YAML_FILENAME_EXTENSIONS"],
+        present=["YAML_FILENAME_EXTENSIONS"],
     ),
     ShellCommand(
         comment="config dump without ee",
@@ -39,7 +39,7 @@ stdout_tests = (
             mode="stdout",
             execution_environment=False,
         ).join(),
-        look_for=["YAML_FILENAME_EXTENSIONS"],
+        present=["YAML_FILENAME_EXTENSIONS"],
     ),
     ShellCommand(
         comment="config list with ee",
@@ -48,7 +48,7 @@ stdout_tests = (
             mode="stdout",
             execution_environment=True,
         ).join(),
-        look_for=["YAML_FILENAME_EXTENSIONS"],
+        present=["YAML_FILENAME_EXTENSIONS"],
     ),
     ShellCommand(
         comment="config list without ee",
@@ -57,7 +57,7 @@ stdout_tests = (
             mode="stdout",
             execution_environment=False,
         ).join(),
-        look_for=["YAML_FILENAME_EXTENSIONS"],
+        present=["YAML_FILENAME_EXTENSIONS"],
     ),
     ShellCommand(
         comment="config helpconfig with ee",
@@ -66,7 +66,7 @@ stdout_tests = (
             mode="stdout",
             execution_environment=True,
         ).join(),
-        look_for=["usage: ansible-config [-h]"],
+        present=["usage: ansible-config [-h]"],
     ),
     ShellCommand(
         comment="config helpconfig without ee",
@@ -75,7 +75,7 @@ stdout_tests = (
             mode="stdout",
             execution_environment=False,
         ).join(),
-        look_for=["usage: ansible-config [-h]"],
+        present=["usage: ansible-config [-h]"],
     ),
     ShellCommand(
         comment="config helpconfig fail with interactive with ee",
@@ -84,7 +84,7 @@ stdout_tests = (
             mode="interactive",
             execution_environment=True,
         ).join(),
-        look_for=["--hc or --help-config is valid only when 'mode' argument is set to 'stdout'"],
+        present=["--hc or --help-config is valid only when 'mode' argument is set to 'stdout'"],
     ),
     ShellCommand(
         comment="config helpconfig fail with interactive without ee",
@@ -93,7 +93,7 @@ stdout_tests = (
             mode="interactive",
             execution_environment=False,
         ).join(),
-        look_for=["--hc or --help-config is valid only when 'mode' argument is set to 'stdout'"],
+        present=["--hc or --help-config is valid only when 'mode' argument is set to 'stdout'"],
     ),
     ShellCommand(
         comment="config specified configuration file with ee",
@@ -104,7 +104,7 @@ stdout_tests = (
             execution_environment=True,
             pass_environment_variables=["PAGER"],
         ).join(),
-        look_for=[".os2"],
+        present=[".os2"],
     ),
     ShellCommand(
         comment="config specified configuration file without ee",
@@ -113,7 +113,7 @@ stdout_tests = (
             mode="stdout",
             execution_environment=False,
         ).join(),
-        look_for=[".os2"],
+        present=[".os2"],
     ),
 )
 

--- a/tests/integration/actions/config/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/config/test_welcome_interactive_ee.py
@@ -3,7 +3,7 @@
 import pytest
 
 from ..._interactions import Command
-from ..._interactions import TestStep
+from ..._interactions import UiTestStep
 from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
@@ -13,8 +13,8 @@ from .base import base_steps
 CLI = Command(execution_environment=True).join()
 
 initial_steps = (
-    TestStep(user_input=CLI, comment="welcome screen"),
-    TestStep(user_input=":config", comment="enter config from welcome screen"),
+    UiTestStep(user_input=CLI, comment="welcome screen"),
+    UiTestStep(user_input=":config", comment="enter config from welcome screen"),
 )
 
 steps = add_indices(initial_steps + base_steps)

--- a/tests/integration/actions/config/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/config/test_welcome_interactive_noee.py
@@ -3,7 +3,7 @@
 import pytest
 
 from ..._interactions import Command
-from ..._interactions import TestStep
+from ..._interactions import UiTestStep
 from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
@@ -13,11 +13,11 @@ from .base import base_steps
 CLI = Command(execution_environment=False).join()
 
 initial_steps = (
-    TestStep(user_input=CLI, comment="welcome screen"),
-    TestStep(
+    UiTestStep(user_input=CLI, comment="welcome screen"),
+    UiTestStep(
         user_input=":config",
         comment="enter config from welcome screen",
-        look_for=["ACTION_WARNINGS", "CALLBACKS_ENABLED"],
+        present=["ACTION_WARNINGS", "CALLBACKS_ENABLED"],
     ),
 )
 

--- a/tests/integration/actions/config/test_welcome_interactive_param_use.py
+++ b/tests/integration/actions/config/test_welcome_interactive_param_use.py
@@ -3,7 +3,7 @@
 import pytest
 
 from ..._interactions import Command
-from ..._interactions import TestStep
+from ..._interactions import UiTestStep
 from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import BaseClass
@@ -12,17 +12,17 @@ from .base import BaseClass
 CLI = Command(execution_environment=False).join()
 
 steps = (
-    TestStep(user_input=CLI, comment="welcome screen"),
-    TestStep(
+    UiTestStep(user_input=CLI, comment="welcome screen"),
+    UiTestStep(
         user_input=":config",
         comment="enter config from welcome screen",
-        look_for=["ANSIBLE_CACHE_PLUGIN_TIMEOUT", "42"],
+        present=["ANSIBLE_CACHE_PLUGIN_TIMEOUT", "42"],
     ),
-    TestStep(user_input=":back", comment="return to welcome screen"),
-    TestStep(
+    UiTestStep(user_input=":back", comment="return to welcome screen"),
+    UiTestStep(
         user_input=":config --ee True",
         comment="enter config from welcome screen",
-        look_for=["ANSIBLE_CACHE_PLUGIN_TIMEOUT", "42"],
+        present=["ANSIBLE_CACHE_PLUGIN_TIMEOUT", "42"],
     ),
 )
 

--- a/tests/integration/actions/config/test_welcome_interactive_specified_config.py
+++ b/tests/integration/actions/config/test_welcome_interactive_specified_config.py
@@ -3,7 +3,7 @@
 import pytest
 
 from ..._interactions import Command
-from ..._interactions import TestStep
+from ..._interactions import UiTestStep
 from ..._interactions import add_indices
 from ..._interactions import step_id
 from .base import CONFIG_FIXTURE
@@ -13,17 +13,17 @@ from .base import BaseClass
 CLI = Command(execution_environment=False).join()
 
 steps = (
-    TestStep(user_input=CLI, comment="welcome screen"),
-    TestStep(
+    UiTestStep(user_input=CLI, comment="welcome screen"),
+    UiTestStep(
         user_input=":config",
         comment="enter config from welcome screen (no ee)",
-        look_for=["YAML_FILENAME_EXTENSIONS", "['.yml', '.yaml', '.json']"],
+        present=["YAML_FILENAME_EXTENSIONS", "['.yml', '.yaml', '.json']"],
     ),
-    TestStep(user_input=":back", comment="return to welcome screen"),
-    TestStep(
+    UiTestStep(user_input=":back", comment="return to welcome screen"),
+    UiTestStep(
         user_input=":config -c " + CONFIG_FIXTURE,
         comment="enter config from welcome screen, custom config, (no ee)",
-        look_for=["YAML_FILENAME_EXTENSIONS", "['.os2']"],
+        present=["YAML_FILENAME_EXTENSIONS", "['.os2']"],
     ),
 )
 


### PR DESCRIPTION
- Replace `look_fors` with `present`
- Replace `look_nots`with `absent`
- Rather than reuse `Step` add `UiTestStep` (`Step` is used in the actions, better to avoid it`)
- Add a condition in `update_fixtures` in case `present` is present
- Fixtures updates to reflect name change

This was done in a manner such that each suite of action integration tests could be done separately.

When all are done, the extra config will be removed.