### PR TITLE
Remove unneeded code in tests 

### DIFF
--- a/tests/integration/_common.py
+++ b/tests/integration/_common.py
@@ -67,9 +67,7 @@ def update_fixtures(
     }
     if additional_information is not None:
         fixture["additional_information"] = additional_information
-        if additional_information.get("look_fors"):
-            received_output = sanitize_output(received_output)
-        elif additional_information.get("present"):
+        if additional_information.get("present"):
             received_output = sanitize_output(received_output)
     fixture["output"] = received_output
     with open(f"{dir_path}/{file_name}", "w", encoding="utf8") as fh:

--- a/tests/integration/_interactions.py
+++ b/tests/integration/_interactions.py
@@ -46,20 +46,6 @@ class Command(NamedTuple):
         return cmd
 
 
-class Step(NamedTuple):
-    """test data object"""
-
-    user_input: str
-    comment: str
-
-    look_fors: List[str] = []
-    look_nots: List[str] = []
-    mask: bool = True
-    playbook_status: Union[None, str] = None
-    step_index: int = 0
-    search_within_response: Union[SearchFor, str, List] = SearchFor.HELP
-
-
 class UiTestStep(NamedTuple):
     """A simulated user interaction with the user interface."""
 


### PR DESCRIPTION
This removes the code replaced in #972

- The `Step` class should no longer be used
- No tests should have a `look_fors` attribute now