### PR TITLE
Remove conflicting type in docstring

### DIFF
--- a/src/ansible_navigator/utils.py
+++ b/src/ansible_navigator/utils.py
@@ -168,7 +168,6 @@ def escape_moustaches(obj: Mapping) -> Mapping:
     """escape moustaches
 
     :param obj: something
-    :type obj: Any
     :return: the obj with replacements made
     """
     replacements = (("{", "U+007B"), ("}", "U+007D"))
@@ -491,7 +490,6 @@ def unescape_moustaches(obj: Mapping) -> Mapping:
     """unescape moustaches
 
     :param obj: something
-    :type obj: Any
     :return: the obj with replacements made
     """
     replacements = (("U+007B", "{"), ("U+007D", "}"))


### PR DESCRIPTION
This fixes a small inconsistency introduced in https://github.com/ansible/ansible-navigator/pull/926

where the type hint didn't match the type specified in the doc string.

I missed it :(