### PR TITLE
Allow 10 minutes for a builder build

### DIFF
--- a/tests/integration/actions/builder/base.py
+++ b/tests/integration/actions/builder/base.py
@@ -55,6 +55,7 @@ class BaseClass:
         received_output = tmux_session.interaction(
             value=step.user_input,
             search_within_response=search_within_response,
+            timeout=600,
         )
 
         fixtures_update_requested = (


### PR DESCRIPTION
Some timeouts have been seen https://github.com/ansible/ansible-navigator/runs/5162080013?check_suite_focus=true#step:7:3528

and in here: https://github.com/ansible/ansible-navigator/issues/812