### PR TITLE
Normalize stdout return from actions

### DIFF
--- a/src/ansible_navigator/action_base.py
+++ b/src/ansible_navigator/action_base.py
@@ -3,7 +3,6 @@ import logging
 
 from copy import deepcopy
 from typing import List
-from typing import NamedTuple
 from typing import Pattern
 from typing import Tuple
 from typing import Union
@@ -19,26 +18,6 @@ from .ui_framework import ui
 from .ui_framework import warning_notification
 from .utils import ExitMessage
 from .utils import LogMessage
-
-
-class RunReturn(NamedTuple):
-    """The base return object for any action's run method."""
-
-    #: A message to display immediately before exiting
-    message: str
-    #: The return code for the for the process
-    return_code: int
-
-
-class RunInteractiveReturn(RunReturn):
-    """The return object for an actions' run interactive method."""
-
-
-class RunStdoutReturn(RunReturn):
-    """The return object for an actions' run stdout method."""
-
-
-ActionReturn = Union[RunReturn, RunInteractiveReturn, RunStdoutReturn]
 
 
 class ActionBase:

--- a/src/ansible_navigator/action_base.py
+++ b/src/ansible_navigator/action_base.py
@@ -3,6 +3,7 @@ import logging
 
 from copy import deepcopy
 from typing import List
+from typing import NamedTuple
 from typing import Pattern
 from typing import Tuple
 from typing import Union
@@ -18,6 +19,26 @@ from .ui_framework import ui
 from .ui_framework import warning_notification
 from .utils import ExitMessage
 from .utils import LogMessage
+
+
+class RunReturn(NamedTuple):
+    """The base return object for any action's run method."""
+
+    #: A message to display immediately before exiting
+    message: str
+    #: The return code for the for the process
+    return_code: int
+
+
+class RunInteractiveReturn(RunReturn):
+    """The return object for an actions' run interactive method."""
+
+
+class RunStdoutReturn(RunReturn):
+    """The return object for an actions' run stdout method."""
+
+
+ActionReturn = Union[RunReturn, RunInteractiveReturn, RunStdoutReturn]
 
 
 class ActionBase:

--- a/src/ansible_navigator/action_defs.py
+++ b/src/ansible_navigator/action_defs.py
@@ -15,7 +15,7 @@ class RunReturn(NamedTuple):
 
 
 class RunInteractiveReturn(RunReturn):
-    """The return object for an actions' run interactive method."""
+    """The return object for an action's run interactive method."""
 
 
 class RunStdoutReturn(RunReturn):

--- a/src/ansible_navigator/action_defs.py
+++ b/src/ansible_navigator/action_defs.py
@@ -1,0 +1,25 @@
+"""Pre-defined objects used by actions."""
+
+
+from typing import NamedTuple
+from typing import Union
+
+
+class RunReturn(NamedTuple):
+    """The base return object for any action's run method."""
+
+    #: A message to display immediately before exiting
+    message: str
+    #: The return code for the for the process
+    return_code: int
+
+
+class RunInteractiveReturn(RunReturn):
+    """The return object for an actions' run interactive method."""
+
+
+class RunStdoutReturn(RunReturn):
+    """The return object for an actions' run stdout method."""
+
+
+ActionReturn = Union[RunReturn, RunInteractiveReturn, RunStdoutReturn]

--- a/src/ansible_navigator/action_defs.py
+++ b/src/ansible_navigator/action_defs.py
@@ -19,7 +19,7 @@ class RunInteractiveReturn(RunReturn):
 
 
 class RunStdoutReturn(RunReturn):
-    """The return object for an actions' run stdout method."""
+    """The return object for an action's run stdout method."""
 
 
 ActionReturn = Union[RunReturn, RunInteractiveReturn, RunStdoutReturn]

--- a/src/ansible_navigator/actions/__init__.py
+++ b/src/ansible_navigator/actions/__init__.py
@@ -12,12 +12,13 @@ Currently, the ``actions`` package is the only package supported for actions and
 is identified in the
 :class:`~ansible_navigator.configuration_subsystem.navigator_configuration.Internals`.
 """
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import Tuple
 from typing import Union
 
-from ..action_base import RunStdoutReturn
+from ..action_defs import RunStdoutReturn
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction

--- a/src/ansible_navigator/actions/__init__.py
+++ b/src/ansible_navigator/actions/__init__.py
@@ -12,10 +12,8 @@ Currently, the ``actions`` package is the only package supported for actions and
 is identified in the
 :class:`~ansible_navigator.configuration_subsystem.navigator_configuration.Internals`.
 """
-from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
-from typing import Tuple
 from typing import Union
 
 from ..action_defs import RunStdoutReturn

--- a/src/ansible_navigator/actions/__init__.py
+++ b/src/ansible_navigator/actions/__init__.py
@@ -17,6 +17,7 @@ from typing import Callable
 from typing import Tuple
 from typing import Union
 
+from ..action_base import RunStdoutReturn
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
@@ -31,7 +32,7 @@ kegexes: Callable = actions.kegexes_factory(__package__)
 
 run_action_stdout: Callable[
     [str, ApplicationConfiguration],
-    Tuple[str, int],
+    RunStdoutReturn,
 ] = actions.run_stdout_factory(
     __package__,
 )

--- a/src/ansible_navigator/actions/__init__.py
+++ b/src/ansible_navigator/actions/__init__.py
@@ -14,6 +14,7 @@ is identified in the
 """
 from typing import Any
 from typing import Callable
+from typing import Tuple
 from typing import Union
 
 from ..app_public import AppPublic
@@ -28,7 +29,10 @@ names = actions.names_factory(__package__)
 
 kegexes: Callable = actions.kegexes_factory(__package__)
 
-run_action_stdout: Callable[[str, ApplicationConfiguration], int] = actions.run_stdout_factory(
+run_action_stdout: Callable[
+    [str, ApplicationConfiguration],
+    Tuple[str, int],
+] = actions.run_stdout_factory(
     __package__,
 )
 

--- a/src/ansible_navigator/actions/_actions.py
+++ b/src/ansible_navigator/actions/_actions.py
@@ -15,7 +15,7 @@ from typing import Generator
 from typing import List
 from typing import Tuple
 
-from ..action_base import RunStdoutReturn
+from ..action_defs import RunStdoutReturn
 
 
 # ``mypy``/``pylint`` idiom for py36 compatibility

--- a/src/ansible_navigator/actions/_actions.py
+++ b/src/ansible_navigator/actions/_actions.py
@@ -167,7 +167,7 @@ def run_interactive_factory(package: str) -> Callable:
     return functools.partial(run_interactive, package)
 
 
-def run_stdout(package: str, action: str, *args: Any, **_kwargs: Any) -> Any:
+def run_stdout(package: str, action: str, *args: Any, **_kwargs: Any) -> Tuple[str, int]:
     """Call the given action's ``run_stdout()`` method.
 
     :param package: The name of the package

--- a/src/ansible_navigator/actions/_actions.py
+++ b/src/ansible_navigator/actions/_actions.py
@@ -15,6 +15,8 @@ from typing import Generator
 from typing import List
 from typing import Tuple
 
+from ..action_base import RunStdoutReturn
+
 
 # ``mypy``/``pylint`` idiom for py36 compatibility
 # https://github.com/python/typeshed/issues/3500#issuecomment-560958608
@@ -167,7 +169,7 @@ def run_interactive_factory(package: str) -> Callable:
     return functools.partial(run_interactive, package)
 
 
-def run_stdout(package: str, action: str, *args: Any, **_kwargs: Any) -> Tuple[str, int]:
+def run_stdout(package: str, action: str, *args: Any, **_kwargs: Any) -> RunStdoutReturn:
     """Call the given action's ``run_stdout()`` method.
 
     :param package: The name of the package

--- a/src/ansible_navigator/actions/builder.py
+++ b/src/ansible_navigator/actions/builder.py
@@ -10,7 +10,7 @@ from typing import Optional
 from typing import Tuple
 
 from ..action_base import ActionBase
-from ..action_base import RunStdoutReturn
+from ..action_defs import RunStdoutReturn
 from ..configuration_subsystem import ApplicationConfiguration
 from ..configuration_subsystem.definitions import Constants
 from ..runner import Command

--- a/src/ansible_navigator/actions/builder.py
+++ b/src/ansible_navigator/actions/builder.py
@@ -10,6 +10,7 @@ from typing import Optional
 from typing import Tuple
 
 from ..action_base import ActionBase
+from ..action_base import RunStdoutReturn
 from ..configuration_subsystem import ApplicationConfiguration
 from ..configuration_subsystem.definitions import Constants
 from ..runner import Command
@@ -29,7 +30,7 @@ class Action(ActionBase):
         """
         super().__init__(args=args, logger_name=__name__, name="builder")
 
-    def run_stdout(self) -> Tuple[str, int]:
+    def run_stdout(self) -> RunStdoutReturn:
         """Execute the ``builder`` request for mode stdout.
 
         :returns: The return code or 1. If the response from the runner invocation is None,
@@ -40,9 +41,9 @@ class Action(ActionBase):
         response = self._run_runner()
         if response is None:
             self._logger.error("Unexpected response: %s", response)
-            return ("Please review the log for errors.", 1)
-        _out, err, ret_code = response
-        return (err, ret_code)
+            return RunStdoutReturn(message="Please review the log for errors.", return_code=1)
+        _out, error, return_code = response
+        return RunStdoutReturn(message=error, return_code=return_code)
 
     def _run_runner(self) -> Optional[Tuple]:
         """Spin up runner.

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -15,6 +15,7 @@ from typing import Union
 from .._yaml import Loader
 from .._yaml import yaml
 from ..action_base import ActionBase
+from ..action_base import RunStdoutReturn
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..runner import AnsibleConfig
@@ -143,7 +144,7 @@ class Action(ActionBase):
         self._prepare_to_exit(interaction)
         return None
 
-    def run_stdout(self) -> Tuple[str, int]:
+    def run_stdout(self) -> RunStdoutReturn:
         """Execute the ``config`` request for mode stdout.
 
         :returns: The return code or 1. If the response from the runner invocation is None,
@@ -154,9 +155,9 @@ class Action(ActionBase):
         response = self._run_runner()
         if response is None:
             self._logger.error("Unexpected response: %s", response)
-            return ("Please review the log for errors.", 1)
-        _out, err, ret_code = response
-        return (err, ret_code)
+            return RunStdoutReturn(message="Please review the log for errors.", return_code=1)
+        _out, error, return_code = response
+        return RunStdoutReturn(message=error, return_code=return_code)
 
     def _take_step(self) -> None:
         """Take a step based on the current step or step back."""

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -15,7 +15,7 @@ from typing import Union
 from .._yaml import Loader
 from .._yaml import yaml
 from ..action_base import ActionBase
-from ..action_base import RunStdoutReturn
+from ..action_defs import RunStdoutReturn
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..runner import AnsibleConfig

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -143,17 +143,20 @@ class Action(ActionBase):
         self._prepare_to_exit(interaction)
         return None
 
-    def run_stdout(self) -> Union[None, int]:
+    def run_stdout(self) -> Tuple[str, int]:
         """Execute the ``config`` request for mode stdout.
 
-        :returns: Nothing or the error code
+        :returns: The return code or 1. If the response from the runner invocation is None,
+            indicates there is no console output to display, so assume an issue and return 1
+            along with a message to review the logs.
         """
         self._logger.debug("config requested in stdout mode")
         response = self._run_runner()
-        if response:
-            _, _, ret_code = response
-            return ret_code
-        return None
+        if response is None:
+            self._logger.error("Unexpected response: %s", response)
+            return ("Please review the log for errors.", 1)
+        _out, err, ret_code = response
+        return (err, ret_code)
 
     def _take_step(self) -> None:
         """Take a step based on the current step or step back."""

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -13,7 +13,7 @@ from typing import Tuple
 from typing import Union
 
 from ..action_base import ActionBase
-from ..action_base import RunStdoutReturn
+from ..action_defs import RunStdoutReturn
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..configuration_subsystem import Constants as C

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -13,6 +13,7 @@ from typing import Tuple
 from typing import Union
 
 from ..action_base import ActionBase
+from ..action_base import RunStdoutReturn
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..configuration_subsystem import Constants as C
@@ -127,7 +128,7 @@ class Action(ActionBase):
         self._prepare_to_exit(interaction)
         return next_interaction
 
-    def run_stdout(self) -> Tuple[str, int]:
+    def run_stdout(self) -> RunStdoutReturn:
         """Execute the ``doc`` request for mode stdout.
 
         :returns: The return code or 1. If the response from the runner invocation is None,
@@ -140,9 +141,9 @@ class Action(ActionBase):
         response = self._run_runner()
         if response is None:
             self._logger.error("Unexpected response: %s", response)
-            return ("Please review the log for errors.", 1)
-        _out, err, ret_code = response
-        return (err, ret_code)
+            return RunStdoutReturn(message="Please review the log for errors.", return_code=1)
+        _out, error, return_code = response
+        return RunStdoutReturn(message=error, return_code=return_code)
 
     def _run_runner(self) -> Union[None, dict, Tuple[str, str, int]]:
         # pylint: disable=too-many-branches

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -127,19 +127,22 @@ class Action(ActionBase):
         self._prepare_to_exit(interaction)
         return next_interaction
 
-    def run_stdout(self) -> Union[None, int]:
-        """Execute the ``config`` request for mode stdout.
+    def run_stdout(self) -> Tuple[str, int]:
+        """Execute the ``doc`` request for mode stdout.
 
-        :returns: Nothing or the error code
+        :returns: The return code or 1. If the response from the runner invocation is None,
+            indicates there is no console output to display, so assume an issue and return 1
+            along with a message to review the logs.
         """
         self._plugin_name = self._args.plugin_name
         self._plugin_type = self._args.plugin_type
         self._logger.debug("doc requested in stdout mode")
         response = self._run_runner()
-        if response:
-            _, _, ret_code = response
-            return ret_code
-        return None
+        if response is None:
+            self._logger.error("Unexpected response: %s", response)
+            return ("Please review the log for errors.", 1)
+        _out, err, ret_code = response
+        return (err, ret_code)
 
     def _run_runner(self) -> Union[None, dict, Tuple[str, str, int]]:
         # pylint: disable=too-many-branches

--- a/src/ansible_navigator/actions/exec.py
+++ b/src/ansible_navigator/actions/exec.py
@@ -7,7 +7,7 @@ from typing import Optional
 from typing import Tuple
 
 from ..action_base import ActionBase
-from ..action_base import RunStdoutReturn
+from ..action_defs import RunStdoutReturn
 from ..configuration_subsystem import ApplicationConfiguration
 from ..configuration_subsystem.definitions import Constants
 from ..runner import Command

--- a/src/ansible_navigator/actions/exec.py
+++ b/src/ansible_navigator/actions/exec.py
@@ -5,7 +5,6 @@ import shlex
 from typing import List
 from typing import Optional
 from typing import Tuple
-from typing import Union
 
 from ..action_base import ActionBase
 from ..configuration_subsystem import ApplicationConfiguration
@@ -49,17 +48,20 @@ class Action(ActionBase):
         """
         super().__init__(args=args, logger_name=__name__, name="exec")
 
-    def run_stdout(self) -> Union[None, int]:
-        """Run in mode stdout.
+    def run_stdout(self) -> Tuple[str, int]:
+        """Execute the ``exec`` request for mode stdout.
 
-        :returns: The return code or None
+        :returns: The return code or 1. If the response from the runner invocation is None,
+            indicates there is no console output to display, so assume an issue and return 1
+            along with a message to review the logs.
         """
         self._logger.debug("exec requested in stdout mode")
         response = self._run_runner()
-        if response:
-            _, _, ret_code = response
-            return ret_code
-        return None
+        if response is None:
+            self._logger.error("Unexpected response: %s", response)
+            return ("Please review the log for errors.", 1)
+        _out, err, ret_code = response
+        return (err, ret_code)
 
     def _run_runner(self) -> Optional[Tuple]:
         """Spin up runner.

--- a/src/ansible_navigator/actions/exec.py
+++ b/src/ansible_navigator/actions/exec.py
@@ -7,6 +7,7 @@ from typing import Optional
 from typing import Tuple
 
 from ..action_base import ActionBase
+from ..action_base import RunStdoutReturn
 from ..configuration_subsystem import ApplicationConfiguration
 from ..configuration_subsystem.definitions import Constants
 from ..runner import Command
@@ -48,7 +49,7 @@ class Action(ActionBase):
         """
         super().__init__(args=args, logger_name=__name__, name="exec")
 
-    def run_stdout(self) -> Tuple[str, int]:
+    def run_stdout(self) -> RunStdoutReturn:
         """Execute the ``exec`` request for mode stdout.
 
         :returns: The return code or 1. If the response from the runner invocation is None,
@@ -59,9 +60,9 @@ class Action(ActionBase):
         response = self._run_runner()
         if response is None:
             self._logger.error("Unexpected response: %s", response)
-            return ("Please review the log for errors.", 1)
-        _out, err, ret_code = response
-        return (err, ret_code)
+            return RunStdoutReturn(message="Please review the log for errors.", return_code=1)
+        _out, error, return_code = response
+        return RunStdoutReturn(message=error, return_code=return_code)
 
     def _run_runner(self) -> Optional[Tuple]:
         """Spin up runner.

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -13,7 +13,7 @@ from typing import Tuple
 from typing import Union
 
 from ..action_base import ActionBase
-from ..action_base import RunStdoutReturn
+from ..action_defs import RunStdoutReturn
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..runner import AnsibleInventory

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -235,16 +235,18 @@ class Action(ActionBase):
         self._prepare_to_exit(interaction)
         return None
 
-    def run_stdout(self) -> int:
+    def run_stdout(self) -> Tuple[str, int]:
         """Execute the ``inventory`` request for mode stdout.
 
-        :returns: The error code
+        :returns: The error code, 1 indicating failure, 0 success
         """
         self._logger.debug("inventory requested in stdout mode")
         if hasattr(self._args, "inventory") and self._args.inventory:
             self._inventories = self._args.inventory
         self._collect_inventory_details()
-        return 1 if self._runner.status == "failed" else 0
+        if self._runner.status == "failed":
+            return ("Please review the log for errors.", 1)
+        return ("", 0)
 
     def _take_step(self) -> None:
         """Take a step based on the current step or step back."""

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -13,6 +13,7 @@ from typing import Tuple
 from typing import Union
 
 from ..action_base import ActionBase
+from ..action_base import RunStdoutReturn
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..runner import AnsibleInventory
@@ -235,18 +236,19 @@ class Action(ActionBase):
         self._prepare_to_exit(interaction)
         return None
 
-    def run_stdout(self) -> Tuple[str, int]:
+    def run_stdout(self) -> RunStdoutReturn:
         """Execute the ``inventory`` request for mode stdout.
 
-        :returns: The error code, 1 indicating failure, 0 success
+        :returns: The return code, 0 or 1. If the runner status if failed, return 1
+            along with a message to review the logs.
         """
         self._logger.debug("inventory requested in stdout mode")
         if hasattr(self._args, "inventory") and self._args.inventory:
             self._inventories = self._args.inventory
         self._collect_inventory_details()
         if self._runner.status == "failed":
-            return ("Please review the log for errors.", 1)
-        return ("", 0)
+            return RunStdoutReturn(message="Please review the log for errors.", return_code=1)
+        return RunStdoutReturn(message="", return_code=0)
 
     def _take_step(self) -> None:
         """Take a step based on the current step or step back."""

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -258,7 +258,7 @@ class Action(ActionBase):
                 self._logger.debug("runner finished")
                 break
         return_code = self.runner.ansible_runner_instance.rc
-        if return_code:
+        if return_code != 0:
             return RunStdoutReturn(
                 message="Please review the log for errors.",
                 return_code=return_code,

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -21,7 +21,7 @@ from typing import Tuple
 from typing import Union
 
 from ..action_base import ActionBase
-from ..action_base import RunStdoutReturn
+from ..action_defs import RunStdoutReturn
 from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..runner import CommandAsync

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -156,10 +156,11 @@ def main():
         pull_image(args)
 
     run_return = run(args)
+    run_message = f"{run_return.message}\n"
     if run_return.return_code != 0 and run_return.message:
-        sys.stderr.write(run_return.message)
+        sys.stderr.write(run_message)
     elif run_return.message:
-        sys.stdout.write(run_return.message)
+        sys.stdout.write(run_message)
 
 
 if __name__ == "__main__":

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -156,7 +156,7 @@ def main():
         pull_image(args)
 
     run_return = run(args)
-    if run_return.return_code and run_return.message:
+    if run_return.return_code != 0 and run_return.message:
         sys.stderr.write(run_return.message)
     elif run_return.message:
         sys.stdout.write(run_return.message)

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -160,7 +160,6 @@ def main():
         sys.stderr.write(run_return.message)
     elif run_return.message:
         sys.stdout.write(run_return.message)
-    sys.exit(run_return.return_code)
 
 
 if __name__ == "__main__":

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -82,7 +82,7 @@ def run(args: ApplicationConfiguration) -> ActionReturn:
     """Run the appropriate subcommand.
 
     :param args: The current application settings
-    :returns: A message to display and return code.
+    :returns: A message to display and a return code.
     """
     if args.mode == "stdout":
         try:

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -12,10 +12,10 @@ from curses import wrapper
 from pathlib import Path
 from typing import List
 
-from .action_base import ActionReturn
-from .action_base import RunInteractiveReturn
-from .action_base import RunReturn
-from .action_base import RunStdoutReturn
+from .action_defs import ActionReturn
+from .action_defs import RunInteractiveReturn
+from .action_defs import RunReturn
+from .action_defs import RunStdoutReturn
 from .action_runner import ActionRunner
 from .actions import run_action_stdout
 from .configuration_subsystem import ApplicationConfiguration

--- a/tests/integration/_action_run_test.py
+++ b/tests/integration/_action_run_test.py
@@ -134,7 +134,7 @@ class ActionRunTest:
 
         return action
 
-    def run_action_stdout(self, **kwargs) -> Tuple[int, str, str]:
+    def run_action_stdout(self, **kwargs) -> Tuple[str, int, str, str]:
         # pylint: disable=too-many-locals
         """run the action"""
         self._app_args.update({"mode": "stdout"})
@@ -163,7 +163,7 @@ class ActionRunTest:
             sys.stderr = sys_stderr  # type: ignore
 
             # run the action
-            return_code = action.run_stdout()
+            action_return_code, action_return_message = action.run_stdout()
 
             # restore ``stdin``
             sys.stdin = __stdin__
@@ -178,4 +178,4 @@ class ActionRunTest:
             stderr = sys.stderr.read().decode()  # type: ignore
             sys.stderr = __stderr__
 
-        return return_code, stdout, stderr
+        return action_return_code, action_return_message, stdout, stderr

--- a/tests/integration/_action_run_test.py
+++ b/tests/integration/_action_run_test.py
@@ -11,7 +11,7 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
-from ansible_navigator.action_base import RunStdoutReturn
+from ansible_navigator.action_defs import RunStdoutReturn
 from ansible_navigator.app_public import AppPublic
 from ansible_navigator.configuration_subsystem import Constants as C
 from ansible_navigator.configuration_subsystem import NavigatorConfiguration

--- a/tests/integration/_action_run_test.py
+++ b/tests/integration/_action_run_test.py
@@ -11,6 +11,7 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
+from ansible_navigator.action_base import RunStdoutReturn
 from ansible_navigator.app_public import AppPublic
 from ansible_navigator.configuration_subsystem import Constants as C
 from ansible_navigator.configuration_subsystem import NavigatorConfiguration
@@ -134,7 +135,7 @@ class ActionRunTest:
 
         return action
 
-    def run_action_stdout(self, **kwargs) -> Tuple[str, int, str, str]:
+    def run_action_stdout(self, **kwargs) -> Tuple[RunStdoutReturn, str, str]:
         # pylint: disable=too-many-locals
         """run the action"""
         self._app_args.update({"mode": "stdout"})
@@ -163,7 +164,7 @@ class ActionRunTest:
             sys.stderr = sys_stderr  # type: ignore
 
             # run the action
-            action_return_code, action_return_message = action.run_stdout()
+            result = action.run_stdout()
 
             # restore ``stdin``
             sys.stdin = __stdin__
@@ -178,4 +179,4 @@ class ActionRunTest:
             stderr = sys.stderr.read().decode()  # type: ignore
             sys.stderr = __stderr__
 
-        return action_return_code, action_return_message, stdout, stderr
+        return result, stdout, stderr

--- a/tests/integration/test_stdout_exit_codes.py
+++ b/tests/integration/test_stdout_exit_codes.py
@@ -104,15 +104,15 @@ fixture_test_data = (
 @pytest.mark.parametrize("test_data", fixture_test_data, ids=id_test_data)
 def test(action_run_stdout, params, test_data):
     """test for a return code"""
-    actionruntest = action_run_stdout(action_name=test_data.action_name, **params)
-    action_return_message, action_return_code, stdout, stderr = actionruntest.run_action_stdout(
+    action_runner = action_run_stdout(action_name=test_data.action_name, **params)
+    run_stdout_return, stdout, stderr = action_runner.run_action_stdout(
         **dict(test_data.action_params),
     )
-    assert action_return_code == test_data.return_code
+    assert run_stdout_return.return_code == test_data.return_code
     if test_data.return_code == 0:
         assert test_data.present in stdout
-        assert test_data.message in action_return_message
+        assert test_data.message in run_stdout_return.message
     else:
         std_stream = stdout if params["execution_environment"] else stderr
         assert test_data.present in std_stream
-        assert test_data.message in action_return_message
+        assert test_data.message in run_stdout_return.message

--- a/tests/integration/test_stdout_exit_codes.py
+++ b/tests/integration/test_stdout_exit_codes.py
@@ -34,61 +34,67 @@ def id_test_data(value):
 
 
 class StdoutTest(NamedTuple):
-    """define the stdout test"""
+    """Definition of a stdout test."""
 
+    #: The name of the action
     action_name: str
+    #: Parameters for the action
     action_params: Tuple[Tuple, ...]
-    message: str
+    #: Text to search for
+    present: str
+    #: Expected return code
     return_code: int
+    #: Expected return message
+    message: str = ""
 
 
 fixture_test_data = (
     StdoutTest(
         action_name="config",
         action_params=(("cmdline", ["--help"]),),
-        message="usage: ansible-config",
+        present="usage: ansible-config",
         return_code=0,
     ),
     StdoutTest(
         action_name="config",
         action_params=(("cmdline", ["foo"]),),
-        message="invalid choice: 'foo'",
+        present="invalid choice: 'foo'",
         return_code=2,
     ),
     StdoutTest(
         action_name="doc",
         action_params=(("cmdline", ["--help"]),),
-        message="usage: ansible-doc",
+        present="usage: ansible-doc",
         return_code=0,
     ),
     StdoutTest(
         action_name="doc",
         action_params=(("cmdline", ["--json"]),),
-        message="Incorrect options passed",
+        present="Incorrect options passed",
         return_code=5,
     ),
     StdoutTest(
         action_name="inventory",
         action_params=(("cmdline", ["--help"]),),
-        message="usage: ansible-inventory",
+        present="usage: ansible-inventory",
         return_code=0,
     ),
     StdoutTest(
         action_name="inventory",
         action_params=(("cmdline", ["foo"]),),
-        message="No action selected",
+        present="No action selected",
         return_code=1,
     ),
     StdoutTest(
         action_name="run",
         action_params=(("playbook", PLAYBOOK), ("playbook_artifact_enable", False)),
-        message="success",
+        present="success",
         return_code=0,
     ),
     StdoutTest(
         action_name="run",
         action_params=(("playbook", "foo"), ("playbook_artifact_enable", False)),
-        message="foo could not be found",
+        present="foo could not be found",
         return_code=1,
     ),
 )
@@ -99,10 +105,14 @@ fixture_test_data = (
 def test(action_run_stdout, params, test_data):
     """test for a return code"""
     actionruntest = action_run_stdout(action_name=test_data.action_name, **params)
-    ret, out, err = actionruntest.run_action_stdout(**dict(test_data.action_params))
-    assert ret == test_data.return_code
+    action_return_message, action_return_code, stdout, stderr = actionruntest.run_action_stdout(
+        **dict(test_data.action_params),
+    )
+    assert action_return_code == test_data.return_code
     if test_data.return_code == 0:
-        assert test_data.message in out, (test_data.message, out, err)
+        assert test_data.present in stdout
+        assert test_data.message in action_return_message
     else:
-        std_stream = out if params["execution_environment"] else err
-        assert test_data.message in std_stream, (test_data.message, out, err)
+        std_stream = stdout if params["execution_environment"] else stderr
+        assert test_data.present in std_stream
+        assert test_data.message in action_return_message


### PR DESCRIPTION
Fixes #291

This normalizes the output of `run_stdout` across all actions to be predefined NamedTuple where a string is something needing to be displayed via stderr or stdout based on the return code.

Note that, there is no case where we do this by design, but it was accounted for in the `builder` action, so rather than have one be slightly different, the write of messages was moved up to `cli.py` and all actions may now return a string.

Tests updated to account for the return.

