### PR TITLE
Notification in `run`: Preparing for automation, please hold on

### DIFF
--- a/docs/changelog-fragments.d/948.feature.md
+++ b/docs/changelog-fragments.d/948.feature.md
@@ -1,0 +1,1 @@
+Added state notification when running a playbook during initialization. -- by {user}`cidrblock`

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -284,7 +284,7 @@ class Action(App):
 
         # Show a notification until the first the first message from the queue is processed
         if self._subaction_type == "run":
-            messages = ["Preparing for automation, please hold on..."]
+            messages = ["Preparing for automation, please wait..."]
             notification = nonblocking_notification(messages=messages)
             interaction.ui.show(notification)
             while not self._first_message_received:

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -30,6 +30,7 @@ from ..ui_framework import CursesLines
 from ..ui_framework import Interaction
 from ..ui_framework import dict_to_form
 from ..ui_framework import form_to_dict
+from ..ui_framework import nonblocking_notification
 from ..ui_framework import warning_notification
 from ..utils import abs_user_path
 from ..utils import human_time
@@ -204,6 +205,8 @@ class Action(App):
         self.runner: CommandAsync
         self._runner_finished: bool
         self._auto_scroll = False
+        #: Flag when the first message is received from runner
+        self._first_message_received: bool = False
 
         self._plays = Step(
             name="plays",
@@ -278,6 +281,14 @@ class Action(App):
             return None
 
         self.steps.append(self._plays)
+
+        # Show a notification until the first the first message from the queue is processed
+        if self._subaction_type == "run":
+            messages = ["Preparing for automation, please hold on..."]
+            notification = nonblocking_notification(messages=messages)
+            interaction.ui.show(notification)
+            while not self._first_message_received:
+                self.update()
 
         while True:
             self.update()
@@ -603,6 +614,8 @@ class Action(App):
         """Drain the runner queue"""
         drain_count = 0
         while not self._queue.empty():
+            if not self._first_message_received:
+                self._first_message_received = True
             message = self._queue.get()
             self._handle_message(message)
             drain_count += 1


### PR DESCRIPTION
Fixes #303 

This can last a second or 2, or less? depending on the development system and it's speed.

Users will see this until the first message is received from runner.

![image](https://user-images.githubusercontent.com/18386516/153941066-42ce8369-999f-4bfc-9f6a-b5337fd118d7.png)

Tested locally with and with out an EE.  Intentionally not added to the tests because of risk of it being missed on the screen.
