### PR TITLE
Add EE support status (enabled/disabled) to `:images` list output

### DIFF
--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -368,8 +368,10 @@ class Action(App):
             image["__full_name"] = f"{image['repository']}:{image['tag']}"
             image["__name"] = image["name"]
             if image["__full_name"] == self._args.execution_environment_image:
-                image["__name"] += " (primary)"
-                image["__name_tag"] += " (primary)"
+                ee_support = "enabled" if self._args.execution_environment else "disabled"
+                hint = f" (primary/{ee_support})"
+                image["__name"] += hint
+                image["__name_tag"] += hint
 
             try:
                 image["execution_environment"] = (

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/0.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/0.json
@@ -4,21 +4,21 @@
     "comment": "ansible-navigator images top window",
     "additional_information": {
         "present": [
-            "creator-ee"
+            "creator-ee (primary/enabled)"
         ],
         "absent": [],
         "compared_fixture": false
     },
     "output": [
         "  NAME                                                                                              TAG           EXECUTION ENVIRONMENT                      CREATED                   SIZE",
-        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      13 days ago               787 MB",
-        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      7 days ago                399 MB",
+        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      2 weeks ago               787 MB",
+        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      11 days ago               399 MB",
         "2│ansible-automation-platform-21-ee-supported-rhel8                                                 latest                         True                      3 weeks ago               1.13 GB",
-        "3│ansible-builder                                                                                   latest                        False                      8 days ago                781 MB",
-        "4│creator-ee (primary)                                                                              v0.2.0                         True                      2 months ago              1.33 GB",
+        "3│ansible-builder                                                                                   latest                        False                      11 days ago               781 MB",
+        "4│creator-ee (primary/enabled)                                                                      v0.2.0                         True                      2 months ago              1.33 GB",
         "5│ee-minimal-rhel8                                                                                  latest                         True                      3 weeks ago               399 MB",
-        "6│network_archive_ee                                                                                latest                         True                      7 days ago                484 MB",
-        "7│python-base                                                                                       latest                        False                      8 days ago                690 MB",
+        "6│network_archive_ee                                                                                latest                         True                      11 days ago               484 MB",
+        "7│python-base                                                                                       latest                        False                      11 days ago               690 MB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/1.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/1.json
@@ -10,8 +10,8 @@
         "compared_fixture": false
     },
     "output": [
-        "  NAME                                                      TAG                EXECUTION ENVIRONMENT                                        CREATED                              SIZE",
-        "0│creator-ee (primary)                                      v0.2.0                              True                                        2 months ago                         1.33 GB",
+        "  NAME                                                                    TAG               EXECUTION ENVIRONMENT                                  CREATED                         SIZE",
+        "0│creator-ee (primary/enabled)                                            v0.2.0                             True                                  2 months ago                    1.33 GB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/10.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/10.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/ENABLED)                                               DESCRIPTION",
+        "0│Image information                                                                 Information collected from image inspection",
+        "1│General information                                                               OS and python version information",
+        "2│Ansible version and collections                                                   Information about ansible and ansible collections",
+        "3│Python packages                                                                   Information about python and python packages",
+        "4│Operating system packages                                                         Information about operating system packages",
+        "5│Everything                                                                        All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/12.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/12.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/ENABLED)                                               DESCRIPTION",
+        "0│Image information                                                                 Information collected from image inspection",
+        "1│General information                                                               OS and python version information",
+        "2│Ansible version and collections                                                   Information about ansible and ansible collections",
+        "3│Python packages                                                                   Information about python and python packages",
+        "4│Operating system packages                                                         Information about operating system packages",
+        "5│Everything                                                                        All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/13.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/13.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (ALL IMAGE INFORMATION)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/ENABLED) (ALL IMAGE INFORMATION)",
         "   0│---                                                                                                                                                                                               ▒",
         "   1│ansible:",
         "   2│  ansible:",

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/2.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/2.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/ENABLED)                                               DESCRIPTION",
+        "0│Image information                                                                 Information collected from image inspection",
+        "1│General information                                                               OS and python version information",
+        "2│Ansible version and collections                                                   Information about ansible and ansible collections",
+        "3│Python packages                                                                   Information about python and python packages",
+        "4│Operating system packages                                                         Information about operating system packages",
+        "5│Everything                                                                        All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/3.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/3.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (INFORMATION COLLECTED FROM IMAGE INSPECTION)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/ENABLED) (INFORMATION COLLECTED FROM IMAGE INSPECTION)",
         "  0│---                                                                                                                                                                                                ▒",
         "  1│details:                                                                                                                                                                                           ▒",
         "  2│  annotations: {}",

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/4.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/4.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/ENABLED)                                               DESCRIPTION",
+        "0│Image information                                                                 Information collected from image inspection",
+        "1│General information                                                               OS and python version information",
+        "2│Ansible version and collections                                                   Information about ansible and ansible collections",
+        "3│Python packages                                                                   Information about python and python packages",
+        "4│Operating system packages                                                         Information about operating system packages",
+        "5│Everything                                                                        All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/5.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/5.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (OS AND PYTHON VERSION INFORMATION)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/ENABLED) (OS AND PYTHON VERSION INFORMATION)",
         " 0│---                                                                                                                                                                                                 ▒",
         " 1│friendly:                                                                                                                                                                                           ▒",
         " 2│  details: |-                                                                                                                                                                                       ▒",

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/6.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/6.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/ENABLED)                                               DESCRIPTION",
+        "0│Image information                                                                 Information collected from image inspection",
+        "1│General information                                                               OS and python version information",
+        "2│Ansible version and collections                                                   Information about ansible and ansible collections",
+        "3│Python packages                                                                   Information about python and python packages",
+        "4│Operating system packages                                                         Information about operating system packages",
+        "5│Everything                                                                        All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/7.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/7.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (INFORMATION ABOUT ANSIBLE AND ANSIBLE COLLECTIONS)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/ENABLED) (INFORMATION ABOUT ANSIBLE AND ANSIBLE COLLECTIONS)",
         " 0│---",
         " 1│ansible:",
         " 2│  collections:",

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/8.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/8.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/ENABLED)                                               DESCRIPTION",
+        "0│Image information                                                                 Information collected from image inspection",
+        "1│General information                                                               OS and python version information",
+        "2│Ansible version and collections                                                   Information about ansible and ansible collections",
+        "3│Python packages                                                                   Information about python and python packages",
+        "4│Operating system packages                                                         Information about operating system packages",
+        "5│Everything                                                                        All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/0.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/0.json
@@ -4,21 +4,21 @@
     "comment": "ansible-navigator images top window",
     "additional_information": {
         "present": [
-            "creator-ee"
+            "creator-ee (primary/disabled)"
         ],
         "absent": [],
         "compared_fixture": false
     },
     "output": [
         "  NAME                                                                                              TAG           EXECUTION ENVIRONMENT                      CREATED                   SIZE",
-        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      13 days ago               787 MB",
-        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      7 days ago                399 MB",
+        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      2 weeks ago               787 MB",
+        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      11 days ago               399 MB",
         "2│ansible-automation-platform-21-ee-supported-rhel8                                                 latest                         True                      3 weeks ago               1.13 GB",
-        "3│ansible-builder                                                                                   latest                        False                      8 days ago                781 MB",
-        "4│creator-ee (primary)                                                                              v0.2.0                         True                      2 months ago              1.33 GB",
+        "3│ansible-builder                                                                                   latest                        False                      11 days ago               781 MB",
+        "4│creator-ee (primary/disabled)                                                                     v0.2.0                         True                      2 months ago              1.33 GB",
         "5│ee-minimal-rhel8                                                                                  latest                         True                      3 weeks ago               399 MB",
-        "6│network_archive_ee                                                                                latest                         True                      7 days ago                484 MB",
-        "7│python-base                                                                                       latest                        False                      8 days ago                690 MB",
+        "6│network_archive_ee                                                                                latest                         True                      11 days ago               484 MB",
+        "7│python-base                                                                                       latest                        False                      11 days ago               690 MB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/1.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/1.json
@@ -10,8 +10,8 @@
         "compared_fixture": false
     },
     "output": [
-        "  NAME                                                      TAG                EXECUTION ENVIRONMENT                                        CREATED                              SIZE",
-        "0│creator-ee (primary)                                      v0.2.0                              True                                        2 months ago                         1.33 GB",
+        "  NAME                                                                      TAG              EXECUTION ENVIRONMENT                                 CREATED                         SIZE",
+        "0│creator-ee (primary/disabled)                                             v0.2.0                            True                                 2 months ago                    1.33 GB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/10.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/10.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/DISABLED)                                                DESCRIPTION",
+        "0│Image information                                                                   Information collected from image inspection",
+        "1│General information                                                                 OS and python version information",
+        "2│Ansible version and collections                                                     Information about ansible and ansible collections",
+        "3│Python packages                                                                     Information about python and python packages",
+        "4│Operating system packages                                                           Information about operating system packages",
+        "5│Everything                                                                          All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/12.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/12.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/DISABLED)                                                DESCRIPTION",
+        "0│Image information                                                                   Information collected from image inspection",
+        "1│General information                                                                 OS and python version information",
+        "2│Ansible version and collections                                                     Information about ansible and ansible collections",
+        "3│Python packages                                                                     Information about python and python packages",
+        "4│Operating system packages                                                           Information about operating system packages",
+        "5│Everything                                                                          All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/13.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/13.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (ALL IMAGE INFORMATION)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/DISABLED) (ALL IMAGE INFORMATION)",
         "   0│---                                                                                                                                                                                               ▒",
         "   1│ansible:",
         "   2│  ansible:",

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/2.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/2.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/DISABLED)                                                DESCRIPTION",
+        "0│Image information                                                                   Information collected from image inspection",
+        "1│General information                                                                 OS and python version information",
+        "2│Ansible version and collections                                                     Information about ansible and ansible collections",
+        "3│Python packages                                                                     Information about python and python packages",
+        "4│Operating system packages                                                           Information about operating system packages",
+        "5│Everything                                                                          All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/3.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/3.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (INFORMATION COLLECTED FROM IMAGE INSPECTION)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/DISABLED) (INFORMATION COLLECTED FROM IMAGE INSPECTION)",
         "  0│---                                                                                                                                                                                                ▒",
         "  1│details:                                                                                                                                                                                           ▒",
         "  2│  annotations: {}",

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/4.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/4.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/DISABLED)                                                DESCRIPTION",
+        "0│Image information                                                                   Information collected from image inspection",
+        "1│General information                                                                 OS and python version information",
+        "2│Ansible version and collections                                                     Information about ansible and ansible collections",
+        "3│Python packages                                                                     Information about python and python packages",
+        "4│Operating system packages                                                           Information about operating system packages",
+        "5│Everything                                                                          All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/5.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/5.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (OS AND PYTHON VERSION INFORMATION)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/DISABLED) (OS AND PYTHON VERSION INFORMATION)",
         " 0│---                                                                                                                                                                                                 ▒",
         " 1│friendly:                                                                                                                                                                                           ▒",
         " 2│  details: |-                                                                                                                                                                                       ▒",

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/6.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/6.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/DISABLED)                                                DESCRIPTION",
+        "0│Image information                                                                   Information collected from image inspection",
+        "1│General information                                                                 OS and python version information",
+        "2│Ansible version and collections                                                     Information about ansible and ansible collections",
+        "3│Python packages                                                                     Information about python and python packages",
+        "4│Operating system packages                                                           Information about operating system packages",
+        "5│Everything                                                                          All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/7.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/7.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (INFORMATION ABOUT ANSIBLE AND ANSIBLE COLLECTIONS)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/DISABLED) (INFORMATION ABOUT ANSIBLE AND ANSIBLE COLLECTIONS)",
         " 0│---",
         " 1│ansible:",
         " 2│  collections:",

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/8.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/8.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/DISABLED)                                                DESCRIPTION",
+        "0│Image information                                                                   Information collected from image inspection",
+        "1│General information                                                                 OS and python version information",
+        "2│Ansible version and collections                                                     Information about ansible and ansible collections",
+        "3│Python packages                                                                     Information about python and python packages",
+        "4│Operating system packages                                                           Information about operating system packages",
+        "5│Everything                                                                          All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/1.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/1.json
@@ -4,21 +4,21 @@
     "comment": "ansible-navigator images top window",
     "additional_information": {
         "present": [
-            "creator-ee"
+            "creator-ee (primary/enabled)"
         ],
         "absent": [],
         "compared_fixture": false
     },
     "output": [
         "  NAME                                                                                              TAG           EXECUTION ENVIRONMENT                      CREATED                   SIZE",
-        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      13 days ago               787 MB",
-        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      7 days ago                399 MB",
+        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      2 weeks ago               787 MB",
+        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      11 days ago               399 MB",
         "2│ansible-automation-platform-21-ee-supported-rhel8                                                 latest                         True                      3 weeks ago               1.13 GB",
-        "3│ansible-builder                                                                                   latest                        False                      8 days ago                781 MB",
-        "4│creator-ee (primary)                                                                              v0.2.0                         True                      2 months ago              1.33 GB",
+        "3│ansible-builder                                                                                   latest                        False                      11 days ago               781 MB",
+        "4│creator-ee (primary/enabled)                                                                      v0.2.0                         True                      2 months ago              1.33 GB",
         "5│ee-minimal-rhel8                                                                                  latest                         True                      3 weeks ago               399 MB",
-        "6│network_archive_ee                                                                                latest                         True                      7 days ago                484 MB",
-        "7│python-base                                                                                       latest                        False                      8 days ago                690 MB",
+        "6│network_archive_ee                                                                                latest                         True                      11 days ago               484 MB",
+        "7│python-base                                                                                       latest                        False                      11 days ago               690 MB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/11.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/11.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/ENABLED)                                               DESCRIPTION",
+        "0│Image information                                                                 Information collected from image inspection",
+        "1│General information                                                               OS and python version information",
+        "2│Ansible version and collections                                                   Information about ansible and ansible collections",
+        "3│Python packages                                                                   Information about python and python packages",
+        "4│Operating system packages                                                         Information about operating system packages",
+        "5│Everything                                                                        All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/13.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/13.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/ENABLED)                                               DESCRIPTION",
+        "0│Image information                                                                 Information collected from image inspection",
+        "1│General information                                                               OS and python version information",
+        "2│Ansible version and collections                                                   Information about ansible and ansible collections",
+        "3│Python packages                                                                   Information about python and python packages",
+        "4│Operating system packages                                                         Information about operating system packages",
+        "5│Everything                                                                        All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/14.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/14.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (ALL IMAGE INFORMATION)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/ENABLED) (ALL IMAGE INFORMATION)",
         "   0│---                                                                                                                                                                                               ▒",
         "   1│ansible:",
         "   2│  ansible:",

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/2.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/2.json
@@ -10,8 +10,8 @@
         "compared_fixture": false
     },
     "output": [
-        "  NAME                                                      TAG                EXECUTION ENVIRONMENT                                        CREATED                              SIZE",
-        "0│creator-ee (primary)                                      v0.2.0                              True                                        2 months ago                         1.33 GB",
+        "  NAME                                                                    TAG               EXECUTION ENVIRONMENT                                  CREATED                         SIZE",
+        "0│creator-ee (primary/enabled)                                            v0.2.0                             True                                  2 months ago                    1.33 GB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/3.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/3.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/ENABLED)                                               DESCRIPTION",
+        "0│Image information                                                                 Information collected from image inspection",
+        "1│General information                                                               OS and python version information",
+        "2│Ansible version and collections                                                   Information about ansible and ansible collections",
+        "3│Python packages                                                                   Information about python and python packages",
+        "4│Operating system packages                                                         Information about operating system packages",
+        "5│Everything                                                                        All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/4.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/4.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (INFORMATION COLLECTED FROM IMAGE INSPECTION)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/ENABLED) (INFORMATION COLLECTED FROM IMAGE INSPECTION)",
         "  0│---                                                                                                                                                                                                ▒",
         "  1│details:                                                                                                                                                                                           ▒",
         "  2│  annotations: {}",

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/5.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/5.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/ENABLED)                                               DESCRIPTION",
+        "0│Image information                                                                 Information collected from image inspection",
+        "1│General information                                                               OS and python version information",
+        "2│Ansible version and collections                                                   Information about ansible and ansible collections",
+        "3│Python packages                                                                   Information about python and python packages",
+        "4│Operating system packages                                                         Information about operating system packages",
+        "5│Everything                                                                        All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/6.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/6.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (OS AND PYTHON VERSION INFORMATION)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/ENABLED) (OS AND PYTHON VERSION INFORMATION)",
         " 0│---                                                                                                                                                                                                 ▒",
         " 1│friendly:                                                                                                                                                                                           ▒",
         " 2│  details: |-                                                                                                                                                                                       ▒",

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/7.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/7.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/ENABLED)                                               DESCRIPTION",
+        "0│Image information                                                                 Information collected from image inspection",
+        "1│General information                                                               OS and python version information",
+        "2│Ansible version and collections                                                   Information about ansible and ansible collections",
+        "3│Python packages                                                                   Information about python and python packages",
+        "4│Operating system packages                                                         Information about operating system packages",
+        "5│Everything                                                                        All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/8.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/8.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (INFORMATION ABOUT ANSIBLE AND ANSIBLE COLLECTIONS)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/ENABLED) (INFORMATION ABOUT ANSIBLE AND ANSIBLE COLLECTIONS)",
         " 0│---",
         " 1│ansible:",
         " 2│  collections:",

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/9.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/9.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/ENABLED)                                               DESCRIPTION",
+        "0│Image information                                                                 Information collected from image inspection",
+        "1│General information                                                               OS and python version information",
+        "2│Ansible version and collections                                                   Information about ansible and ansible collections",
+        "3│Python packages                                                                   Information about python and python packages",
+        "4│Operating system packages                                                         Information about operating system packages",
+        "5│Everything                                                                        All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/1.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/1.json
@@ -4,21 +4,21 @@
     "comment": "ansible-navigator images top window",
     "additional_information": {
         "present": [
-            "creator-ee"
+            "creator-ee (primary/disabled)"
         ],
         "absent": [],
         "compared_fixture": false
     },
     "output": [
         "  NAME                                                                                              TAG           EXECUTION ENVIRONMENT                      CREATED                   SIZE",
-        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      13 days ago               787 MB",
-        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      7 days ago                399 MB",
+        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      2 weeks ago               787 MB",
+        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      11 days ago               399 MB",
         "2│ansible-automation-platform-21-ee-supported-rhel8                                                 latest                         True                      3 weeks ago               1.13 GB",
-        "3│ansible-builder                                                                                   latest                        False                      8 days ago                781 MB",
-        "4│creator-ee (primary)                                                                              v0.2.0                         True                      2 months ago              1.33 GB",
+        "3│ansible-builder                                                                                   latest                        False                      11 days ago               781 MB",
+        "4│creator-ee (primary/disabled)                                                                     v0.2.0                         True                      2 months ago              1.33 GB",
         "5│ee-minimal-rhel8                                                                                  latest                         True                      3 weeks ago               399 MB",
-        "6│network_archive_ee                                                                                latest                         True                      7 days ago                484 MB",
-        "7│python-base                                                                                       latest                        False                      8 days ago                690 MB",
+        "6│network_archive_ee                                                                                latest                         True                      11 days ago               484 MB",
+        "7│python-base                                                                                       latest                        False                      11 days ago               690 MB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/11.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/11.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/DISABLED)                                                DESCRIPTION",
+        "0│Image information                                                                   Information collected from image inspection",
+        "1│General information                                                                 OS and python version information",
+        "2│Ansible version and collections                                                     Information about ansible and ansible collections",
+        "3│Python packages                                                                     Information about python and python packages",
+        "4│Operating system packages                                                           Information about operating system packages",
+        "5│Everything                                                                          All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/13.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/13.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/DISABLED)                                                DESCRIPTION",
+        "0│Image information                                                                   Information collected from image inspection",
+        "1│General information                                                                 OS and python version information",
+        "2│Ansible version and collections                                                     Information about ansible and ansible collections",
+        "3│Python packages                                                                     Information about python and python packages",
+        "4│Operating system packages                                                           Information about operating system packages",
+        "5│Everything                                                                          All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/14.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/14.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (ALL IMAGE INFORMATION)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/DISABLED) (ALL IMAGE INFORMATION)",
         "   0│---                                                                                                                                                                                               ▒",
         "   1│ansible:",
         "   2│  ansible:",

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/2.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/2.json
@@ -10,8 +10,8 @@
         "compared_fixture": false
     },
     "output": [
-        "  NAME                                                      TAG                EXECUTION ENVIRONMENT                                        CREATED                              SIZE",
-        "0│creator-ee (primary)                                      v0.2.0                              True                                        2 months ago                         1.33 GB",
+        "  NAME                                                                      TAG              EXECUTION ENVIRONMENT                                 CREATED                         SIZE",
+        "0│creator-ee (primary/disabled)                                             v0.2.0                            True                                 2 months ago                    1.33 GB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/3.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/3.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/DISABLED)                                                DESCRIPTION",
+        "0│Image information                                                                   Information collected from image inspection",
+        "1│General information                                                                 OS and python version information",
+        "2│Ansible version and collections                                                     Information about ansible and ansible collections",
+        "3│Python packages                                                                     Information about python and python packages",
+        "4│Operating system packages                                                           Information about operating system packages",
+        "5│Everything                                                                          All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/4.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/4.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (INFORMATION COLLECTED FROM IMAGE INSPECTION)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/DISABLED) (INFORMATION COLLECTED FROM IMAGE INSPECTION)",
         "  0│---                                                                                                                                                                                                ▒",
         "  1│details:                                                                                                                                                                                           ▒",
         "  2│  annotations: {}",

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/5.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/5.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/DISABLED)                                                DESCRIPTION",
+        "0│Image information                                                                   Information collected from image inspection",
+        "1│General information                                                                 OS and python version information",
+        "2│Ansible version and collections                                                     Information about ansible and ansible collections",
+        "3│Python packages                                                                     Information about python and python packages",
+        "4│Operating system packages                                                           Information about operating system packages",
+        "5│Everything                                                                          All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/6.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/6.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (OS AND PYTHON VERSION INFORMATION)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/DISABLED) (OS AND PYTHON VERSION INFORMATION)",
         " 0│---                                                                                                                                                                                                 ▒",
         " 1│friendly:                                                                                                                                                                                           ▒",
         " 2│  details: |-                                                                                                                                                                                       ▒",

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/7.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/7.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/DISABLED)                                                DESCRIPTION",
+        "0│Image information                                                                   Information collected from image inspection",
+        "1│General information                                                                 OS and python version information",
+        "2│Ansible version and collections                                                     Information about ansible and ansible collections",
+        "3│Python packages                                                                     Information about python and python packages",
+        "4│Operating system packages                                                           Information about operating system packages",
+        "5│Everything                                                                          All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/8.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/8.json
@@ -10,7 +10,7 @@
         "compared_fixture": false
     },
     "output": [
-        "CREATOR-EE:V0.2.0 (PRIMARY) (INFORMATION ABOUT ANSIBLE AND ANSIBLE COLLECTIONS)",
+        "CREATOR-EE:V0.2.0 (PRIMARY/DISABLED) (INFORMATION ABOUT ANSIBLE AND ANSIBLE COLLECTIONS)",
         " 0│---",
         " 1│ansible:",
         " 2│  collections:",

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/9.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/9.json
@@ -10,13 +10,13 @@
         "compared_fixture": false
     },
     "output": [
-        "  CREATOR-EE:V0.2.0 (PRIMARY)                                                  DESCRIPTION",
-        "0│Image information                                                            Information collected from image inspection",
-        "1│General information                                                          OS and python version information",
-        "2│Ansible version and collections                                              Information about ansible and ansible collections",
-        "3│Python packages                                                              Information about python and python packages",
-        "4│Operating system packages                                                    Information about operating system packages",
-        "5│Everything                                                                   All image information",
+        "  CREATOR-EE:V0.2.0 (PRIMARY/DISABLED)                                                DESCRIPTION",
+        "0│Image information                                                                   Information collected from image inspection",
+        "1│General information                                                                 OS and python version information",
+        "2│Ansible version and collections                                                     Information about ansible and ansible collections",
+        "3│Python packages                                                                     Information about python and python packages",
+        "4│Operating system packages                                                           Information about operating system packages",
+        "5│Everything                                                                          All image information",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/integration/actions/images/test_direct_interactive_ee.py
+++ b/tests/integration/actions/images/test_direct_interactive_ee.py
@@ -17,7 +17,7 @@ initial_steps = (
     UiTestStep(
         user_input=CLI,
         comment="ansible-navigator images top window",
-        present=[IMAGE_SHORT],
+        present=[f"{IMAGE_SHORT} (primary/enabled)"],
     ),
 )
 

--- a/tests/integration/actions/images/test_direct_interactive_noee.py
+++ b/tests/integration/actions/images/test_direct_interactive_noee.py
@@ -18,7 +18,7 @@ initial_steps = (
     UiTestStep(
         user_input=CLI,
         comment="ansible-navigator images top window",
-        present=[IMAGE_SHORT],
+        present=[f"{IMAGE_SHORT} (primary/disabled)"],
     ),
 )
 

--- a/tests/integration/actions/images/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/images/test_welcome_interactive_ee.py
@@ -18,7 +18,7 @@ initial_steps = (
     UiTestStep(
         user_input=":images",
         comment="ansible-navigator images top window",
-        present=[IMAGE_SHORT],
+        present=[f"{IMAGE_SHORT} (primary/enabled)"],
     ),
 )
 

--- a/tests/integration/actions/images/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/images/test_welcome_interactive_noee.py
@@ -19,7 +19,7 @@ initial_steps = (
     UiTestStep(
         user_input=":images",
         comment="ansible-navigator images top window",
-        present=[IMAGE_SHORT],
+        present=[f"{IMAGE_SHORT} (primary/disabled)"],
     ),
 )
 


### PR DESCRIPTION
Fixes #415 

This is what it looks like now:

![image](https://user-images.githubusercontent.com/18386516/153955108-fb537bb3-7288-45f7-a361-6213a8ebeaf3.png)

Tests updated to confirm
