### PR TITLE
Add pull_arguments

### DIFF
--- a/docs/changelog-fragments.d/952.feature.md
+++ b/docs/changelog-fragments.d/952.feature.md
@@ -1,0 +1,3 @@
+Added ability to pass additional arguments to the execution environment pull command.
+
+-- by {user}`cidrblock`

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -49,7 +49,8 @@ def pull_image(args):
     image_puller = ImagePuller(
         container_engine=args.container_engine,
         image=args.execution_environment_image,
-        pull_policy=args.pull_policy,
+        arguments=args.pull_arguments,
+        policy=args.pull_policy,
     )
     image_puller.assess()
     if image_puller.assessment.exit_messages:

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -50,7 +50,7 @@ def pull_image(args):
         container_engine=args.container_engine,
         image=args.execution_environment_image,
         arguments=args.pull_arguments,
-        policy=args.pull_policy,
+        pull_policy=args.pull_policy,
     )
     image_puller.assess()
     if image_puller.assessment.exit_messages:

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -480,7 +480,7 @@ NavigatorConfiguration = ApplicationConfiguration(
             short_description=(
                 "Specify any additional parameters that should be added to the"
                 " pull command when pulling an execution environment from a container"
-                " registry. e.g. --pa \"'--tls-verify=false'\""
+                " registry. e.g. --pa='--tls-verify=false'"
             ),
             value=SettingsEntryValue(),
         ),

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -478,7 +478,7 @@ NavigatorConfiguration = ApplicationConfiguration(
             cli_parameters=CliParameters(action="append", nargs="+", short="--pa"),
             settings_file_path_override="execution-environment.pull.arguments",
             short_description=(
-                "Specify any additional parameters that should be appended to the"
+                "Specify any additional parameters that should be added to the"
                 " pull command when pulling an execution environment from a container"
                 " registry. e.g. --pa \"'--tls-verify=false'\""
             ),

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -474,6 +474,17 @@ NavigatorConfiguration = ApplicationConfiguration(
             value=SettingsEntryValue(default="module"),
         ),
         SettingsEntry(
+            name="pull_arguments",
+            cli_parameters=CliParameters(action="append", nargs="+", short="--pa"),
+            settings_file_path_override="execution-environment.pull.arguments",
+            short_description=(
+                "Specify any additional parameters that should be appended to the"
+                " pull command when pulling an execution environment from a container"
+                " registry. e.g. --pa \"'--tls-verify=false'\""
+            ),
+            value=SettingsEntryValue(),
+        ),
+        SettingsEntry(
             name="pull_policy",
             choices=["always", "missing", "never", "tag"],
             cli_parameters=CliParameters(short="--pp"),

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -850,7 +850,7 @@ class NavigatorPostProcessor:
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
         # pylint: disable=unused-argument
-        """Post process ```pull_arguments```
+        """Post process ``pull_arguments``
 
         :param entry: The current settings entry
         :param config: The full application configuration

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -845,6 +845,27 @@ class NavigatorPostProcessor:
 
     @staticmethod
     @_post_processor
+    def pull_arguments(
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
+    ) -> PostProcessorReturn:
+        # pylint: disable=unused-argument
+        """Post process ```pull_arguments```
+
+        :param entry: The current settings entry
+        :param config: The full application configuration
+        :return: An instance of the standard post process return object
+        """
+        messages: List[LogMessage] = []
+        exit_messages: List[ExitMessage] = []
+        if entry.value.source == C.ENVIRONMENT_VARIABLE:
+            entry.value.current = to_list(entry.value.current)
+        if entry.value.current is not C.NOT_SET:
+            entry.value.current = flatten_list(entry.value.current)
+        return messages, exit_messages
+
+    @staticmethod
+    @_post_processor
     def set_environment_variable(
         entry: SettingsEntry,
         config: ApplicationConfiguration,

--- a/src/ansible_navigator/image_manager/puller.py
+++ b/src/ansible_navigator/image_manager/puller.py
@@ -132,7 +132,7 @@ class ImagePuller:
         messages = [("Execution environment image name:", self._image)]
         messages.append(("Execution environment image tag:", self._image_tag))
         if isinstance(self._arguments, list):
-            arguments = shlex_join(arguments)
+            arguments = shlex_join(self._arguments)
         else:
             arguments = "None"
         messages.append(("Execution environment pull arguments:", arguments))

--- a/src/ansible_navigator/image_manager/puller.py
+++ b/src/ansible_navigator/image_manager/puller.py
@@ -143,7 +143,7 @@ class ImagePuller:
         """print a little value added information"""
         messages = [("Execution environment image name:", self._image)]
         messages.append(("Execution environment image tag:", self._image_tag))
-        arguments = shlex_join(self._arguments) or "None"
+        arguments = shlex_join(self._arguments) or None
         messages.append(("Execution environment pull arguments:", arguments))
         messages.append(("Execution environment pull policy:", self._pull_policy))
         messages.append(("Execution environment pull needed:", self._pull_required))
@@ -154,8 +154,8 @@ class ImagePuller:
         print("\u002d" * width)
         column_width = max((len(m[0]) for m in messages))
         for msg, value in messages:
-            print(f"{msg.ljust(column_width)} {value}")
-            self._log_message(message=f"{msg}: {value}", level=logging.INFO)
+            print(f"{msg.ljust(column_width)} {value!s}")
+            self._log_message(message=f"{msg!s}: {value!s}", level=logging.INFO)
         print("\u002d" * width)
         print("Updating the execution environment")
         print("\u002d" * width)

--- a/src/ansible_navigator/image_manager/puller.py
+++ b/src/ansible_navigator/image_manager/puller.py
@@ -32,11 +32,11 @@ class ImagePuller:
         :param arguments: Additional arguments to be appended to the pull policy
         :param pull_policy: The current pull policy from the settings
         """
-        self._arguments: List = arguments
+        self._arguments: List[str] = arguments
         self._assessment = ImageAssessment
-        self._container_engine = container_engine
+        self._container_engine: str = container_engine
         self._exit_messages: List[ExitMessage] = []
-        self._image = image
+        self._image: str = image
         self._image_present: bool
         self._image_tag: str
         self._logger = logging.getLogger(__name__)

--- a/src/ansible_navigator/image_manager/puller.py
+++ b/src/ansible_navigator/image_manager/puller.py
@@ -5,7 +5,9 @@ import subprocess
 
 from types import SimpleNamespace
 from typing import List
+from typing import Union
 
+from ..configuration_subsystem import Constants
 from ..utils import ExitMessage
 from ..utils import ExitPrefix
 from ..utils import LogMessage
@@ -24,7 +26,13 @@ class ImagePuller:
     # pylint: disable=too-many-instance-attributes
     """Image puller"""
 
-    def __init__(self, container_engine: str, image: str, arguments: List[str], pull_policy: str):
+    def __init__(
+        self,
+        container_engine: str,
+        image: str,
+        arguments: Union[Constants, List[str]],
+        pull_policy: str,
+    ):
         """Initialize the container image puller.
 
         :param container_engine: The name of the container engine
@@ -32,7 +40,7 @@ class ImagePuller:
         :param arguments: Additional arguments to be appended to the pull policy
         :param pull_policy: The current pull policy from the settings
         """
-        self._arguments: List[str] = arguments
+        self._arguments: Union[Constants, List[str]] = arguments
         self._assessment = ImageAssessment
         self._container_engine: str = container_engine
         self._exit_messages: List[ExitMessage] = []

--- a/src/ansible_navigator/image_manager/puller.py
+++ b/src/ansible_navigator/image_manager/puller.py
@@ -40,7 +40,11 @@ class ImagePuller:
         :param arguments: Additional arguments to be appended to the pull policy
         :param pull_policy: The current pull policy from the settings
         """
-        self._arguments: Union[Constants, List[str]] = arguments
+        if isinstance(arguments, list):
+            self._arguments = arguments
+        else:
+            self._arguments = []
+
         self._assessment = ImageAssessment
         self._container_engine: str = container_engine
         self._exit_messages: List[ExitMessage] = []
@@ -139,10 +143,7 @@ class ImagePuller:
         """print a little value added information"""
         messages = [("Execution environment image name:", self._image)]
         messages.append(("Execution environment image tag:", self._image_tag))
-        if isinstance(self._arguments, list):
-            arguments = shlex_join(self._arguments)
-        else:
-            arguments = "None"
+        arguments = shlex_join(self._arguments) or "None"
         messages.append(("Execution environment pull arguments:", arguments))
         messages.append(("Execution environment pull policy:", self._pull_policy))
         messages.append(("Execution environment pull needed:", self._pull_required))
@@ -165,9 +166,10 @@ class ImagePuller:
         :returns: The list of command parts
         """
         command_line = [self._container_engine, "pull"]
-        if isinstance(self._arguments, list):
-            for argument in self._arguments:
-                command_line.extend(shlex.split(argument))
+        # In case the settings file has an entry with a space
+        # e.g. ``--authfile file.txt``, split all of the entries
+        for argument in self._arguments:
+            command_line.extend(shlex.split(argument))
         command_line.append(self._image)
         return command_line
 

--- a/src/ansible_navigator/utils/functions.py
+++ b/src/ansible_navigator/utils/functions.py
@@ -8,6 +8,7 @@ import os
 import re
 import shlex
 import shutil
+import shlex
 import sys
 import sysconfig
 

--- a/src/ansible_navigator/utils/functions.py
+++ b/src/ansible_navigator/utils/functions.py
@@ -6,8 +6,8 @@ import html
 import logging
 import os
 import re
-import shutil
 import shlex
+import shutil
 import sys
 import sysconfig
 

--- a/src/ansible_navigator/utils/functions.py
+++ b/src/ansible_navigator/utils/functions.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import shutil
+import shlex
 import sys
 import sysconfig
 
@@ -441,6 +442,13 @@ def round_half_up(number: Union[float, int]) -> int:
     """
     rounded = decimal.Decimal(number).quantize(decimal.Decimal("1"), rounding=decimal.ROUND_HALF_UP)
     return int(rounded)
+
+
+def shlex_join(tokens) -> str:
+    """Concatenate the tokens of a list and return a string."""
+    if sys.version_info >= (3, 8):
+        return shlex.join(tokens)
+    return " ".join(shlex.quote(token) for token in tokens)
 
 
 def str2bool(value: Any) -> bool:

--- a/src/ansible_navigator/utils/functions.py
+++ b/src/ansible_navigator/utils/functions.py
@@ -8,7 +8,6 @@ import os
 import re
 import shlex
 import shutil
-import shlex
 import sys
 import sysconfig
 

--- a/src/ansible_navigator/utils/functions.py
+++ b/src/ansible_navigator/utils/functions.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any
+from typing import Iterable
 from typing import List
 from typing import Mapping
 from typing import NamedTuple
@@ -444,10 +445,16 @@ def round_half_up(number: Union[float, int]) -> int:
     return int(rounded)
 
 
-def shlex_join(tokens) -> str:
-    """Concatenate the tokens of a list and return a string."""
+def shlex_join(tokens: Iterable[str]) -> str:
+    """Concatenate the tokens of a list and return a string.
+
+    ``shlex.join`` was new in version 3.8
+
+    :param tokens: The iterable of strings to join
+    :returns: The iterable joined with spaces
+    """
     if sys.version_info >= (3, 8):
-        return shlex.join(tokens)
+        return shlex.join(split_command=tokens)
     return " ".join(shlex.quote(token) for token in tokens)
 
 

--- a/src/ansible_navigator/utils/key_value_store.py
+++ b/src/ansible_navigator/utils/key_value_store.py
@@ -9,6 +9,7 @@ from typing import Tuple
 from typing import Union
 
 
+<<<<<<< HEAD
 if sys.version_info >= (3, 9):
     from collections.abc import ItemsView
     from collections.abc import KeysView
@@ -32,6 +33,33 @@ class KVSValuesView(ValuesView[str]):
 
 
 class KeyValueStore(MutableMapping[str, str]):
+||||||| parent of d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
+class KeyValueStore(dict):
+=======
+if sys.version_info >= (3, 9):
+    from collections.abc import ItemsView
+    from collections.abc import KeysView
+    from collections.abc import ValuesView
+else:
+    from typing import ItemsView
+    from typing import KeysView
+    from typing import ValuesView
+
+
+class KVSKeysView(KeysView[str]):
+    """A glorified KeysView specific to, and returned by, methods in KeyValueStore"""
+
+
+class KVSItemsView(ItemsView[str, str]):
+    """A glorified ItemsView specific to, and returned by, methods in KeyValueStore"""
+
+
+class KVSValuesView(ValuesView[str]):
+    """A glorified ValuesView specific to, and returned by, methods in KeyValueStore"""
+
+
+class KeyValueStore(MutableMapping[str, str]):
+>>>>>>> d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
     """An interface to use a sqlite database as a key-value store."""
 
     def __init__(self, filename: Union[str, Path]):
@@ -44,6 +72,7 @@ class KeyValueStore(MutableMapping[str, str]):
         cursor = self.conn.cursor()
         cursor.execute("CREATE TABLE IF NOT EXISTS kv (key text unique, value text)")
 
+<<<<<<< HEAD
     @property
     def path(self) -> str:
         """Provide the filename where the KVS is stored on disk.
@@ -53,19 +82,46 @@ class KeyValueStore(MutableMapping[str, str]):
         return self._path
 
     def close(self) -> None:
+||||||| parent of d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
+    def close(self):
+=======
+    @property
+    def path(self) -> str:
+        """The filename where the KVS is stored on disk."""
+        return self._path
+
+    def close(self) -> None:
+>>>>>>> d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
         """Close the connection to the database."""
         self.conn.commit()
         self.conn.close()
 
+<<<<<<< HEAD
     def open(self) -> sqlite3.Connection:
         """Establish the connection to the database.
+||||||| parent of d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
+    def open(self):
+        """Establish the connection to the database."""
+        self.conn = sqlite3.connect(self.path)
+=======
+    def open(self) -> sqlite3.Connection:
+        """Establish the connection to the database."""
+        self.conn = sqlite3.connect(self.path)
+        return self.conn
+>>>>>>> d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
 
+<<<<<<< HEAD
         :returns: A connection to the database
         """
         self.conn = sqlite3.connect(self.path)
         return self.conn
 
     def __len__(self) -> int:
+||||||| parent of d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
+    def __len__(self):
+=======
+    def __len__(self) -> int:
+>>>>>>> d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
         """Count the number of keys in the key-value store.
 
         :returns: The number of keys
@@ -179,6 +235,7 @@ class KeyValueStore(MutableMapping[str, str]):
         :returns: The keys in the key-value store
         """
         return self.iterkeys()
+<<<<<<< HEAD
 
     def __repr__(self) -> str:
         """Represent the key-value store.
@@ -189,3 +246,17 @@ class KeyValueStore(MutableMapping[str, str]):
         if not self:
             return f"{self.__class__.__name__}()"
         return f"{self.__class__.__name__}({list(self.items())})"
+||||||| parent of d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
+=======
+
+    def __repr__(self) -> str:
+        """
+        KVS repr
+
+        :returns: The KVS repr.
+        """
+        # Loosely based on collections.OrderedDict#__repr__
+        if not self:
+            return f"{self.__class__.__name__}()"
+        return f"{self.__class__.__name__}({list(self.items())})"
+>>>>>>> d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))

--- a/src/ansible_navigator/utils/key_value_store.py
+++ b/src/ansible_navigator/utils/key_value_store.py
@@ -178,12 +178,23 @@ class KeyValueStore(MutableMapping[str, str]):
         """
         return KVSItemsView(self)
 
+<<<<<<< HEAD
     # mypy complains about this 'str' because it's more specific than the 'object'
     # that dict's Mapping superclass wants. However, it's correct in our case.
     # Our sqlite table expects string keys (column type 'text'). It's an error to
     # pass something else. If we pass something too weird, the sqlite3 lib will
     # throw an error at runtime.
     def __contains__(self, key: str) -> bool:  # type: ignore[override]
+||||||| parent of d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
+    def __contains__(self, key):
+=======
+    # mypy complains about this 'str' because it's more specific than the 'object'
+    # that dict's Mapping superclass wants. However, it's correct in our case.
+    # Our sqlite table expects string keys (column type 'text'). It's an error to
+    # pass something else. If we pass something too weird, the sqlite3 lib will
+    # throw an error at runrtime.
+    def __contains__(self, key: str) -> bool:  # type: ignore[override]
+>>>>>>> d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
         """Check if a given key is in the key-value store.
 
         This provides dictionary like  `some_key in` support for the key-value store.

--- a/src/ansible_navigator/utils/key_value_store.py
+++ b/src/ansible_navigator/utils/key_value_store.py
@@ -9,7 +9,6 @@ from typing import Tuple
 from typing import Union
 
 
-<<<<<<< HEAD
 if sys.version_info >= (3, 9):
     from collections.abc import ItemsView
     from collections.abc import KeysView
@@ -33,33 +32,6 @@ class KVSValuesView(ValuesView[str]):
 
 
 class KeyValueStore(MutableMapping[str, str]):
-||||||| parent of d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
-class KeyValueStore(dict):
-=======
-if sys.version_info >= (3, 9):
-    from collections.abc import ItemsView
-    from collections.abc import KeysView
-    from collections.abc import ValuesView
-else:
-    from typing import ItemsView
-    from typing import KeysView
-    from typing import ValuesView
-
-
-class KVSKeysView(KeysView[str]):
-    """A glorified KeysView specific to, and returned by, methods in KeyValueStore"""
-
-
-class KVSItemsView(ItemsView[str, str]):
-    """A glorified ItemsView specific to, and returned by, methods in KeyValueStore"""
-
-
-class KVSValuesView(ValuesView[str]):
-    """A glorified ValuesView specific to, and returned by, methods in KeyValueStore"""
-
-
-class KeyValueStore(MutableMapping[str, str]):
->>>>>>> d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
     """An interface to use a sqlite database as a key-value store."""
 
     def __init__(self, filename: Union[str, Path]):
@@ -72,7 +44,6 @@ class KeyValueStore(MutableMapping[str, str]):
         cursor = self.conn.cursor()
         cursor.execute("CREATE TABLE IF NOT EXISTS kv (key text unique, value text)")
 
-<<<<<<< HEAD
     @property
     def path(self) -> str:
         """Provide the filename where the KVS is stored on disk.
@@ -82,46 +53,19 @@ class KeyValueStore(MutableMapping[str, str]):
         return self._path
 
     def close(self) -> None:
-||||||| parent of d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
-    def close(self):
-=======
-    @property
-    def path(self) -> str:
-        """The filename where the KVS is stored on disk."""
-        return self._path
-
-    def close(self) -> None:
->>>>>>> d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
         """Close the connection to the database."""
         self.conn.commit()
         self.conn.close()
 
-<<<<<<< HEAD
     def open(self) -> sqlite3.Connection:
         """Establish the connection to the database.
-||||||| parent of d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
-    def open(self):
-        """Establish the connection to the database."""
-        self.conn = sqlite3.connect(self.path)
-=======
-    def open(self) -> sqlite3.Connection:
-        """Establish the connection to the database."""
-        self.conn = sqlite3.connect(self.path)
-        return self.conn
->>>>>>> d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
 
-<<<<<<< HEAD
         :returns: A connection to the database
         """
         self.conn = sqlite3.connect(self.path)
         return self.conn
 
     def __len__(self) -> int:
-||||||| parent of d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
-    def __len__(self):
-=======
-    def __len__(self) -> int:
->>>>>>> d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
         """Count the number of keys in the key-value store.
 
         :returns: The number of keys
@@ -178,23 +122,12 @@ class KeyValueStore(MutableMapping[str, str]):
         """
         return KVSItemsView(self)
 
-<<<<<<< HEAD
     # mypy complains about this 'str' because it's more specific than the 'object'
     # that dict's Mapping superclass wants. However, it's correct in our case.
     # Our sqlite table expects string keys (column type 'text'). It's an error to
     # pass something else. If we pass something too weird, the sqlite3 lib will
     # throw an error at runtime.
     def __contains__(self, key: str) -> bool:  # type: ignore[override]
-||||||| parent of d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
-    def __contains__(self, key):
-=======
-    # mypy complains about this 'str' because it's more specific than the 'object'
-    # that dict's Mapping superclass wants. However, it's correct in our case.
-    # Our sqlite table expects string keys (column type 'text'). It's an error to
-    # pass something else. If we pass something too weird, the sqlite3 lib will
-    # throw an error at runrtime.
-    def __contains__(self, key: str) -> bool:  # type: ignore[override]
->>>>>>> d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
         """Check if a given key is in the key-value store.
 
         This provides dictionary like  `some_key in` support for the key-value store.
@@ -246,7 +179,6 @@ class KeyValueStore(MutableMapping[str, str]):
         :returns: The keys in the key-value store
         """
         return self.iterkeys()
-<<<<<<< HEAD
 
     def __repr__(self) -> str:
         """Represent the key-value store.
@@ -257,17 +189,3 @@ class KeyValueStore(MutableMapping[str, str]):
         if not self:
             return f"{self.__class__.__name__}()"
         return f"{self.__class__.__name__}({list(self.items())})"
-||||||| parent of d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))
-=======
-
-    def __repr__(self) -> str:
-        """
-        KVS repr
-
-        :returns: The KVS repr.
-        """
-        # Loosely based on collections.OrderedDict#__repr__
-        if not self:
-            return f"{self.__class__.__name__}()"
-        return f"{self.__class__.__name__}({list(self.items())})"
->>>>>>> d622215e (Rework KVS with types and extend MutableMapping instead of dict (#988))

--- a/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
+++ b/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
@@ -44,7 +44,7 @@ ansible-navigator:
     pull-policy: never
     pull:
       arguments:
-      - "--tls-verify=false"
+        - "--tls-verify=false"
     volume-mounts:
       - src: "/test1"
         dest: "/test1"

--- a/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
+++ b/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
@@ -42,6 +42,9 @@ ansible-navigator:
         KEY3: VALUE3
     image: test_image:latest
     pull-policy: never
+    pull:
+      arguments:
+      - "--tls-verify=false"
     volume-mounts:
     - src: "/test1"
       dest: "/test1"

--- a/tests/unit/configuration_subsystem/data.py
+++ b/tests/unit/configuration_subsystem/data.py
@@ -243,6 +243,7 @@ ENV_VAR_DATA = [
     ("playbook_artifact_save_as", "/tmp/save.json", "/tmp/save.json"),
     ("plugin_name", "shell", "shell"),
     ("plugin_type", "become", "become"),
+    ("pull_arguments", "--tls-verify=false", ["--tls-verify=false"]),
     ("pull_policy", "never", "never"),
     ("set_environment_variable", "T1=A,T2=B,T3=C", {"T1": "A", "T2": "B", "T3": "C"}),
     ("workdir", "/tmp/", "/tmp/"),

--- a/tests/unit/image_manager/test_image_puller.py
+++ b/tests/unit/image_manager/test_image_puller.py
@@ -151,9 +151,11 @@ def test_pull_with_args():
     image_puller = ImagePuller(
         container_engine="podman",
         image="my_image",
-        arguments=["--tls-verify=false"],
+        arguments=["--tls-verify false"],
         pull_policy="tag",
     )
     result = image_puller._generate_pull_command()  # pylint: disable=protected-access
-    expected = "podman pull --tls-verify=false my_image"
-    assert result == shlex.split(expected)
+    expected_list = ["podman", "pull", "--tls-verify", "false", "my_image"]
+    assert result == expected_list
+    expected_string = "podman pull --tls-verify false my_image"
+    assert result == shlex.split(expected_string)

--- a/tests/unit/image_manager/test_image_puller.py
+++ b/tests/unit/image_manager/test_image_puller.py
@@ -41,7 +41,7 @@ def test_do_have(valid_container_engine, data):
         container_engine=valid_container_engine,
         image=DEFAULT_CONTAINER_IMAGE,
         arguments=Constants.NOT_SET,
-        policy=data.pull_policy,
+        pull_policy=data.pull_policy,
     )
     image_puller.assess()
     assert image_puller.assessment.pull_required == data.pull_required
@@ -63,7 +63,7 @@ def test_do_have_but_latest(valid_container_engine, data):
         container_engine=valid_container_engine,
         image=SMALL_TEST_IMAGE,
         arguments=Constants.NOT_SET,
-        policy=data.pull_policy,
+        pull_policy=data.pull_policy,
     )
     image_puller.assess()
     assert image_puller.assessment.pull_required == data.pull_required
@@ -85,7 +85,7 @@ def test_missing_locally(valid_container_engine, data):
         container_engine=valid_container_engine,
         image=uuid_str,
         arguments=Constants.NOT_SET,
-        policy=data.pull_policy,
+        pull_policy=data.pull_policy,
     )
     image_puller.assess()
     assert image_puller.assessment.pull_required == data.pull_required
@@ -108,7 +108,7 @@ def test_will_have(valid_container_engine, pullable_image, data):
         container_engine=valid_container_engine,
         image=pullable_image,
         arguments=Constants.NOT_SET,
-        policy=data.pull_policy,
+        pull_policy=data.pull_policy,
     )
     image_puller.assess()
     assert image_puller.assessment.pull_required == data.pull_required
@@ -140,7 +140,7 @@ def test_tag_parsing(image, expected_tag):
         container_engine="podman",
         image=image,
         arguments=Constants.NOT_SET,
-        policy="tag",
+        pull_policy="tag",
     )
     image_puller._extract_tag()  # pylint: disable=protected-access
     assert image_puller._image_tag == expected_tag  # pylint: disable=protected-access
@@ -152,7 +152,7 @@ def test_pull_with_args():
         container_engine="podman",
         image="my_image",
         arguments=["--tls-verify=false"],
-        policy="tag",
+        pull_policy="tag",
     )
     result = image_puller._generate_pull_command()  # pylint: disable=protected-access
     expected = "podman pull --tls-verify=false my_image"


### PR DESCRIPTION
Fixes #505 
Fixes #632 

This add a `--pull-arguments` command line parameter which will pass additional args to the pull policy command.

- json schema updates WIP: https://github.com/ansible-community/schemas/issues/150
- test updates
- shortened `pull_policy` to `policy` in puller to match incoming `arguments`

This turns `pull` into a dictionary, `pull-policy` will need to be changes, and will cause a major release

See: https://github.com/ansible/ansible-navigator/issues/951