### PR TITLE
minimize x2 open of same file and race condition

### DIFF
--- a/src/ansible_navigator/_yaml.py
+++ b/src/ansible_navigator/_yaml.py
@@ -44,7 +44,7 @@ def human_dump(obj: Any, filename: Any = None, file_mode: str = "w") -> Optional
     dumper = HumanDumper
     if filename is not None:
         try:
-            # expcect fileobj as arg, fall back to file name
+            # expect fileobj as arg, fall back to file name
             yaml.dump(obj, filename, Dumper=dumper, **YamlStyle()._asdict())
         except TypeError:
             with open(filename, file_mode, encoding="utf-8") as fh:

--- a/src/ansible_navigator/_yaml.py
+++ b/src/ansible_navigator/_yaml.py
@@ -31,25 +31,24 @@ class YamlStyle(NamedTuple):
     allow_unicode: bool = True
 
 
-def human_dump(obj: Any, filename: str = None, file_mode: str = "w") -> Optional[str]:
+def human_dump(obj: Any, filename: Any = None, file_mode: str = "w") -> Optional[str]:
     """Serialize an object to yaml.
 
     This allows for the consistent representation across the application.
 
     :param obj: The object to serialize
-    :param filename: The filename of the file in which the obj should be written
-    :param file_mode: The mode to use for file writing
+    :param filename : A file object or filename to write the obj to
+    :param file_mode: The mode to use for file writing, if a file name is provided
     :return: Either the serialized obj or None if written to a file
     """
     dumper = HumanDumper
     if filename is not None:
-        with open(filename, file_mode, encoding="utf-8") as fh:
-            yaml.dump(
-                obj,
-                fh,
-                Dumper=dumper,
-                **YamlStyle()._asdict(),
-            )
+        try:
+            # expcect fileobj as arg, fall back to file name
+            yaml.dump(obj, filename, Dumper=dumper, **YamlStyle()._asdict())
+        except TypeError:
+            with open(filename, file_mode, encoding="utf-8") as fh:
+                yaml.dump(obj, fh, Dumper=dumper, **YamlStyle()._asdict())
         return None
     return yaml.dump(obj, Dumper=dumper, **YamlStyle()._asdict())
 

--- a/src/ansible_navigator/_yaml.py
+++ b/src/ansible_navigator/_yaml.py
@@ -31,7 +31,11 @@ class YamlStyle(NamedTuple):
     allow_unicode: bool = True
 
 
-def human_dump(obj: Any, filename: Any = None, file_mode: str = "w") -> Optional[str]:
+def human_dump(
+    obj: Any,
+    filename: Union[io.TextIOWrapper, str] = None,
+    file_mode: str = "w",
+) -> Optional[str]:
     """Serialize an object to yaml.
 
     This allows for the consistent representation across the application.

--- a/src/ansible_navigator/_yaml.py
+++ b/src/ansible_navigator/_yaml.py
@@ -1,5 +1,6 @@
 """A wrapper for pyyaml."""
 # pylint: disable=unused-import
+import io
 import re
 
 from typing import Any

--- a/src/ansible_navigator/actions/open_file.py
+++ b/src/ansible_navigator/actions/open_file.py
@@ -122,7 +122,7 @@ class Action:
                     filename = temp_file.name
 
         # There is still a race condition between writing the file and opening it in the editor
-        # but since most editors won't take filehandles nor content on a pipe, it is inevitable.
+        # but since many editors won't take filehandles nor content on a pipe, it is inevitable.
         # The mitigation is that tempfile uses restrictive permissions on said file.
         command = self._args.editor_command.format(filename=filename, line_number=line_number)
         is_console = self._args.editor_console


### PR DESCRIPTION
 file was already open when we reopen waste of filehandles
 race condition between initial open and reopen to write that could
 be used to alter file destination

 have to alter human_dump to allow for filehandle so it can also eliminate
 x2 open and race for that case

 still has race condition between file being written and editor opening it
 
some editors can read the data 'stdin', skipping the tempfile, but it makes it awkward for user to save normally