### PR TITLE
Set the python version for lint-candidates to 3.10 in GHA

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,11 +6,11 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  create: # is used for publishing to PyPI and TestPyPI
-    tags: # any tag regardless of its name, no branches
+  create:  # is used for publishing to PyPI and TestPyPI
+    tags:  # any tag regardless of its name, no branches
       - "**"
-  push: # only publishes pushes to the main branch to TestPyPI
-    branches: # any integration branch but not tag
+  push:  # only publishes pushes to the main branch to TestPyPI
+    branches:  # any integration branch but not tag
       - "main"
   pull_request:
 
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0 # needed by setuptools-scm
+          fetch-depth: 0  # needed by setuptools-scm
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -71,12 +71,12 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           directory: .tox
-          files: "coverage-*.xml"
+          files: 'coverage-*.xml'
           name: ${{ matrix.tox_env }}
-          verbose: true # optional (default = false)
+          verbose: true  # optional (default = false)
         if: ${{ startsWith(matrix.tox_env, 'py') }}
 
-  check: # This job does nothing and is only used for the branch protection
+  check:  # This job does nothing and is only used for the branch protection
     if: always()
 
     needs:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,11 +6,11 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  create:  # is used for publishing to PyPI and TestPyPI
-    tags:  # any tag regardless of its name, no branches
+  create: # is used for publishing to PyPI and TestPyPI
+    tags: # any tag regardless of its name, no branches
       - "**"
-  push:  # only publishes pushes to the main branch to TestPyPI
-    branches:  # any integration branch but not tag
+  push: # only publishes pushes to the main branch to TestPyPI
+    branches: # any integration branch but not tag
       - "main"
   pull_request:
 
@@ -29,6 +29,7 @@ jobs:
         include:
           - tox_env: lint-candidates
             devel: true
+            python-version: "3.10"
           - tox_env: py36
             python-version: 3.6
           - tox_env: py37
@@ -43,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0  # needed by setuptools-scm
+          fetch-depth: 0 # needed by setuptools-scm
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -70,12 +71,12 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           directory: .tox
-          files: 'coverage-*.xml'
+          files: "coverage-*.xml"
           name: ${{ matrix.tox_env }}
-          verbose: true  # optional (default = false)
+          verbose: true # optional (default = false)
         if: ${{ startsWith(matrix.tox_env, 'py') }}
 
-  check:  # This job does nothing and is only used for the branch protection
+  check: # This job does nothing and is only used for the branch protection
     if: always()
 
     needs:

--- a/tox.ini
+++ b/tox.ini
@@ -93,6 +93,8 @@ deps =
   -r{toxinidir}/docs/requirements.in
 setenv =
   {[testenv]setenv}
+isolated_build = true
+skip_install = true
 
 [testenv:build-docs]
 allowlist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,6 @@ deps =
 setenv =
   {[testenv]setenv}
 
-
 [testenv:build-docs]
 allowlist_externals =
   git

--- a/tox.ini
+++ b/tox.ini
@@ -83,16 +83,15 @@ setenv =
 description = All enforced standards and docstring, spelling and mypy using 3.10
 install_command = pip install {opts} {packages}
 commands =
-  python --version
-  pre-commit run {posargs:--hook-stage manual \
+  pre-commit run {posargs: \
+    --hook-stage manual \
     --all-files}
 deps =
   {[testenv]deps}
   -r{toxinidir}/docs/requirements.in
 setenv =
   {[testenv]setenv}
-isolated_build = true
-skip_install = true
+
 
 [testenv:build-docs]
 allowlist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -83,6 +83,7 @@ setenv =
 description = All enforced standards and docstring, spelling and mypy using 3.10
 install_command = pip install {opts} {packages}
 commands =
+  python --version
   pre-commit run {posargs:--hook-stage manual \
     --all-files}
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -83,12 +83,9 @@ setenv =
 description = All enforced standards and docstring, spelling and mypy using 3.10
 install_command = pip install {opts} {packages}
 commands =
-  {envpython} -m \
-    pre_commit run \
-    --hook-stage manual \
-    {posargs:--all-files}
+  pre-commit run {posargs:--hook-stage manual \
+    --all-files}
 deps =
-  pre-commit
   {[testenv]deps}
   -r{toxinidir}/docs/requirements.in
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,8 @@ setenv =
 description = All enforced standards and docstring, spelling and mypy using 3.10
 install_command = pip install {opts} {packages}
 commands =
-  pre-commit run {posargs: \
+  {envpython} -m \
+  pre_commit run {posargs: \
     --hook-stage manual \
     --all-files}
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -84,10 +84,11 @@ description = All enforced standards and docstring, spelling and mypy using 3.10
 install_command = pip install {opts} {packages}
 commands =
   {envpython} -m \
-  pre_commit run {posargs: \
+    pre_commit run \
     --hook-stage manual \
-    --all-files}
+    {posargs:--all-files}
 deps =
+  pre-commit
   {[testenv]deps}
   -r{toxinidir}/docs/requirements.in
 setenv =


### PR DESCRIPTION
Necessary because it is now running the full suite of pre-commit checks.

Resolves an issue introduced in #973 

This is the error seen: https://github.com/ansible/ansible-navigator/runs/5250061633?check_suite_focus=true#step:7:34