### PR TITLE
Centralize mypy configuration, increase coverage and a few type fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -178,6 +178,7 @@ repos:
           - types-PyYAML
           - types-dataclasses
           - types-docutils
+          - types-setuptools # Avoid mypy trying to do it in precommit-ci
           - types-typed-ast
         args:
           - --python-version=3.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -163,7 +163,6 @@ repos:
           - sphinx
           - types-PyYAML
           - types-docutils
-          - types-setuptools
         args:
           - --python-version=3.10
         pass_filenames: false
@@ -179,7 +178,6 @@ repos:
           - types-PyYAML
           - types-dataclasses
           - types-docutils
-          - types-setuptools
           - types-typed-ast
         args:
           - --python-version=3.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,15 +143,15 @@ repos:
   - repo: https://github.com/pre-commit/mirrors-mypy.git
     rev: v0.931
     hooks:
-      # NOTE: The 3.10 dependencies should include all dependancies for all interpreter
+      # NOTE: The latest version dependencies should include all dependancies for all interpreter
       # NOTE: versions so the configuration doesn' grow out of control.
       # NOTE: As new interpreters are added or removed, the dependency list should be auditted
-      # NOTE: For version specific dependendcies, please not the interpreter version.
+      # NOTE: For version specific dependendcies, please note the interpreter version.
       # NOTE: These are ordered from latest version to earliest for no particular reason
       # NOTE: other than a way to keep them organized.
       - id: mypy
-        alias: mypy-py310
-        name: MyPy, for Python 3.10
+        alias: mypy-py311
+        name: MyPy, for Python 3.11
         additional_dependencies: &_mypy_deps
           - importlib_resources # Needed for checking py3.6 with a later interpreter
           - importlib_metadata # Needed for checking py3.6 with a later interpreter
@@ -164,28 +164,29 @@ repos:
           - types-setuptools # Avoid mypy trying to do it for 3.6 in precommit-ci
           - types-typed-ast # Avoid mypy trying to do it for 3.6 in precommit-ci
         args:
-          - --python-version=3.10
+          - --python-version=3.11
         pass_filenames: false
       - id: mypy
-        alias: mypy-py39
+        name: MyPy, for Python 3.10
+        additional_dependencies: *_mypy_deps
+        args:
+          - --python-version=3.10
+      - id: mypy
         name: MyPy, for Python 3.9
         additional_dependencies: *_mypy_deps
         args:
           - --python-version=3.9
       - id: mypy
-        alias: mypy-py38
         name: MyPy, for Python 3.8
         additional_dependencies: *_mypy_deps
         args:
           - --python-version=3.8
       - id: mypy
-        alias: mypy-py37
         name: MyPy, for Python 3.7
         additional_dependencies: *_mypy_deps
         args:
           - --python-version=3.7
       - id: mypy
-        alias: mypy-py36
         name: MyPy, for Python 3.6
         additional_dependencies: *_mypy_deps
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,61 +154,27 @@ repos:
       # NOTE: CI automations run both checks. Whenever the versions are
       # NOTE: updated in this config, a symmetric action must be performed
       # NOTE: in `tox.ini` as well.
-      - &_base-mypy-setup-map
-        id: mypy
+      - id: mypy
         alias: mypy-py310
         name: MyPy, for Python 3.10
         additional_dependencies:
-          - lxml == 4.6.4 # needed for `--txt-report`
-          - types-docutils
-          - types-PyYAML
+          - jinja2
+          - pytest
+          - sphinx
         args:
-          # FIXME: get rid of missing imports ignore
-          - --ignore-missing-imports
-          - --install-types
-          - --namespace-packages
-          - --non-interactive
-          - --pretty
           - --python-version=3.10
-          - --show-column-numbers
-          - --show-error-codes
-          - --show-error-context
-          #- --strict
-          #- --strict-optional
-          - --txt-report
-          - .tox/.tmp/.mypy/
-          - docs/
-          - share/
-          - src/
-          - tests/
         pass_filenames: false
-      - <<: *_base-mypy-setup-map
+      - id: mypy
         alias: mypy-py36
         name: MyPy, for Python 3.6
         additional_dependencies:
-          - lxml == 4.6.4 # needed for `--txt-report`
-          - types-dataclasses
-          - types-docutils
-          - types-PyYAML
+          - importlib_resources # Needed for checking py3.6 with a py3.10 interpreter
+          - importlib_metadata # Needed for checking py3.6 with a py3.10 interpreter
+          - jinja2
+          - pytest
+          - sphinx
         args:
-          # FIXME: get rid of missing imports ignore
-          - --ignore-missing-imports
-          - --install-types
-          - --namespace-packages
-          - --non-interactive
-          - --pretty
           - --python-version=3.6
-          - --show-column-numbers
-          - --show-error-codes
-          - --show-error-context
-          #- --strict
-          #- --strict-optional
-          - --txt-report
-          - .tox/.tmp/.mypy/
-          - docs/
-          - share/
-          - src/
-          - tests/
 
   - repo: https://github.com/pycqa/pylint.git
     rev: v2.12.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -161,6 +161,9 @@ repos:
           - jinja2
           - pytest
           - sphinx
+          - types-PyYAML
+          - types-docutils
+          - types-setuptools
         args:
           - --python-version=3.10
         pass_filenames: false
@@ -173,6 +176,11 @@ repos:
           - jinja2
           - pytest
           - sphinx
+          - types-PyYAML
+          - types-dataclasses
+          - types-docutils
+          - types-setuptools
+          - types-typed-ast
         args:
           - --python-version=3.6
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,43 +143,51 @@ repos:
   - repo: https://github.com/pre-commit/mirrors-mypy.git
     rev: v0.931
     hooks:
-      # NOTE: Here MyPy is executed twice -- once for the highest and once
-      # NOTE: for the lowest supported version. They are hardcoded in the
-      # NOTE: hook invocations below. Whenever one of these versions needs
-      # NOTE: to be updated, the values in the `alias` and `name` fields
-      # NOTE: should be adjusted along with the `--python-version` CLI
-      # NOTE: option.
-      # NOTE: The external developer environment is configured to only run
-      # NOTE: the check with the lowest version on the tox side while the
-      # NOTE: CI automations run both checks. Whenever the versions are
-      # NOTE: updated in this config, a symmetric action must be performed
-      # NOTE: in `tox.ini` as well.
+      # NOTE: The 3.10 dependencies should include all dependancies for all interpreter
+      # NOTE: versions so the configuration doesn' grow out of control.
+      # NOTE: As new interpreters are added or removed, the dependency list should be auditted
+      # NOTE: For version specific dependendcies, please not the interpreter version.
+      # NOTE: These are ordered from latest version to earliest for no particular reason
+      # NOTE: other than a way to keep them organized.
       - id: mypy
         alias: mypy-py310
         name: MyPy, for Python 3.10
-        additional_dependencies:
+        additional_dependencies: &_mypy_deps
+          - importlib_resources # Needed for checking py3.6 with a later interpreter
+          - importlib_metadata # Needed for checking py3.6 with a later interpreter
           - jinja2
           - pytest
           - sphinx
           - types-PyYAML
+          - types-dataclasses # Needed for checking py3.6 with a later interpreter
           - types-docutils
+          - types-setuptools # Avoid mypy trying to do it for 3.6 in precommit-ci
+          - types-typed-ast # Avoid mypy trying to do it for 3.6 in precommit-ci
         args:
           - --python-version=3.10
         pass_filenames: false
       - id: mypy
+        alias: mypy-py39
+        name: MyPy, for Python 3.9
+        additional_dependencies: *_mypy_deps
+        args:
+          - --python-version=3.9
+      - id: mypy
+        alias: mypy-py38
+        name: MyPy, for Python 3.8
+        additional_dependencies: *_mypy_deps
+        args:
+          - --python-version=3.8
+      - id: mypy
+        alias: mypy-py37
+        name: MyPy, for Python 3.7
+        additional_dependencies: *_mypy_deps
+        args:
+          - --python-version=3.7
+      - id: mypy
         alias: mypy-py36
         name: MyPy, for Python 3.6
-        additional_dependencies:
-          - importlib_resources # Needed for checking py3.6 with a py3.10 interpreter
-          - importlib_metadata # Needed for checking py3.6 with a py3.10 interpreter
-          - jinja2
-          - pytest
-          - sphinx
-          - types-PyYAML
-          - types-dataclasses
-          - types-docutils
-          - types-setuptools # Avoid mypy trying to do it in precommit-ci
-          - types-typed-ast
+        additional_dependencies: *_mypy_deps
         args:
           - --python-version=3.6
 

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -13,6 +13,8 @@ ignorePaths:
   - docs/requirements.in
   # Ignore licenses
   - licenses/*
+  # Ignore mypy configuration file
+  - mypy.ini
   # The shared file for tool configuration
   - pyproject.toml
   # The setup file

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,7 +141,7 @@ extensions = [
 
 # Conditional third-party extensions:
 try:
-    import sphinxcontrib.spelling as _sphinxcontrib_spelling
+    import sphinxcontrib.spelling as _sphinxcontrib_spelling  # type: ignore[import]
 except ImportError:
     extensions.append("spelling_stub_ext")
 else:
@@ -251,7 +251,7 @@ apidoc_module_dir = "../src/ansible_navigator"
 apidoc_module_first = False
 apidoc_output_dir = "pkg"
 apidoc_separate_modules = True
-apidoc_toc_file = None
+apidoc_toc_file: None = None
 
 # -- Options for linkcheck builder -------------------------------------------
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,33 @@
+[mypy]
+files = docs,share,src,tests
+install_types = true
+namespace_packages = true
+non_interactive = true
+pretty = true
+show_column_numbers = true
+show_error_codes = true
+show_error_context = true
+# strict = true
+# strict_optional = true
+
+
+# 3rd party ignores
+[mypy-ansible_runner]
+# No type hints as of version 2.1.1
+ignore_missing_imports = True
+
+[mypy-importlib_resources]
+# No type hints as of version 5.4.0
+ignore_missing_imports = True
+
+[mypy-libtmux]
+# No type hints as of version 0.10.3
+ignore_missing_imports = True
+
+[mypy-onigurumacffi]
+# No type hints as of version 1.1.0
+ignore_missing_imports = True
+
+[mypy-setuptools_scm]
+# https://github.com/pypa/setuptools/issues/2345
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,7 +10,6 @@ show_error_context = true
 # strict = true
 # strict_optional = true
 
-
 # 3rd party ignores
 [mypy-ansible_runner]
 # No type hints as of version 2.1.1

--- a/src/ansible_navigator/initialization.py
+++ b/src/ansible_navigator/initialization.py
@@ -26,7 +26,9 @@ from .utils import find_settings_file
 
 if TYPE_CHECKING:
 
-    from ...share.ansible_navigator.utils import key_value_store  # type: ignore[misc]
+    from ...share.ansible_navigator.utils import (  # type: ignore[import, misc] # isort: skip
+        key_value_store,
+    )
 
 
 def error_and_exit_early(exit_messages: List[ExitMessage]) -> NoReturn:

--- a/src/ansible_navigator/runner/ansible_config.py
+++ b/src/ansible_navigator/runner/ansible_config.py
@@ -5,7 +5,7 @@ to run the ansible-config command
 from typing import Optional
 from typing import Tuple
 
-from ansible_runner import get_ansible_config  # type: ignore[import]
+from ansible_runner import get_ansible_config
 
 from .base import Base
 

--- a/src/ansible_navigator/runner/ansible_doc.py
+++ b/src/ansible_navigator/runner/ansible_doc.py
@@ -8,7 +8,7 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
-from ansible_runner import get_plugin_docs  # type: ignore[import]
+from ansible_runner import get_plugin_docs
 
 from .base import Base
 

--- a/src/ansible_navigator/runner/ansible_inventory.py
+++ b/src/ansible_navigator/runner/ansible_inventory.py
@@ -6,7 +6,7 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
-from ansible_runner import get_inventory  # type: ignore[import]
+from ansible_runner import get_inventory
 
 from .base import Base
 

--- a/src/ansible_navigator/runner/base.py
+++ b/src/ansible_navigator/runner/base.py
@@ -17,7 +17,7 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-from ansible_runner import Runner  # type: ignore[import]
+from ansible_runner import Runner
 
 
 class Base:

--- a/src/ansible_navigator/runner/command_async.py
+++ b/src/ansible_navigator/runner/command_async.py
@@ -8,7 +8,7 @@ queue with messages.
 
 from queue import Queue
 
-from ansible_runner import run_command_async  # type: ignore[import]
+from ansible_runner import run_command_async
 
 from .command_base import CommandBase
 

--- a/src/ansible_navigator/tm_tokenize/reg.py
+++ b/src/ansible_navigator/tm_tokenize/reg.py
@@ -6,7 +6,7 @@ from typing import Match
 from typing import Optional
 from typing import Tuple
 
-import onigurumacffi  # type: ignore[import]
+import onigurumacffi
 
 from .region import Region
 

--- a/src/ansible_navigator/utils.py
+++ b/src/ansible_navigator/utils.py
@@ -491,7 +491,7 @@ def templar(string: str, template_vars: Mapping) -> Tuple[List[str], Any]:
         logger.debug("error was: %s", str(exc))
         logger.debug("attempted on %s", result)
 
-    result = unescape_moustaches(result)
+    result = unescape_moustaches(result)  # type: ignore[assignment, arg-type]
     return errors, result
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,10 @@ flake8-docstrings
 flake8-quotes
 libtmux
 lxml
+mypy
 pre-commit
+pylint
 pytest-cov
 pytest-mock
 pytest-xdist
+sphinx

--- a/tests/integration/actions/run_unicode/base.py
+++ b/tests/integration/actions/run_unicode/base.py
@@ -62,7 +62,7 @@ class BaseClass:
     def test(
         self,
         request: pytest.FixtureRequest,
-        tmux_session: pytest.FixtureRequest,
+        tmux_session: TmuxSession,
         step: UiTestStep,
     ):
         # pylint: disable=too-many-branches

--- a/tests/unit/test_yaml.py
+++ b/tests/unit/test_yaml.py
@@ -23,12 +23,12 @@ def _aliases_allowed(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureReq
     :param request: The request for this fixture from a test
     :returns: The original request parameter
     """
-    if request.param:
+    if request.param:  # type: ignore[attr-defined] # github.com/pytest-dev/pytest/issues/8073
         monkeypatch.setattr(
             "ansible_navigator._yaml.HumanDumper.ignore_aliases",
             Dumper.ignore_aliases,
         )
-    return request.param
+    return request.param  # type: ignore[attr-defined]
 
 
 @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ setenv =
   SKIP = cspell, flake8-rule-candidates
 
 [testenv:lint-candidates]
-description = All enforced standards and docstring, spelling and mypy using 3.10
+description = All enforced standards including docstring and spelling checks
 install_command = pip install {opts} {packages}
 commands =
   pre-commit run {posargs: \

--- a/tox.ini
+++ b/tox.ini
@@ -72,12 +72,8 @@ setenv =
   # NOTE: Although stage=manual hooks are included in the above
   # NOTE: pre-commit run, some may not be enforced and should be included
   # NOTE: in the skip list below.
-  # NOTE: Running some of the MyPy checks is disabled here but they may
-  # NOTE: be reconfigured in the pre-commit configuration file. So the
-  # NOTE: value of the `SKIP` env var must not be updated separately
-  # NOTE: from changing the pre-commit setup.
   {[testenv]setenv}
-  SKIP = cspell, flake8-rule-candidates, mypy-py310
+  SKIP = cspell, flake8-rule-candidates
 
 [testenv:lint-candidates]
 description = All enforced standards and docstring, spelling and mypy using 3.10


### PR DESCRIPTION
In an attempt to make the `mypy` configuration cleaner with improved documentation and explanations, cover use cases outside of `tox`, and avoid different results between environments:

- Move all `mypy` config out of pre-commit to `mypy.ini` except the python-version
- Remove all in code import import statement
  - The exception here is sphinx.spelling, b/c I could only exempt all of sphinx if in `mypy.ini`
- Add and note specific ignore imports in `mypy.ini`
- Add packages dependencies as needed in `pre-commit.yaml`
- Removed the `txt-report`, and the dependency on `lxml`
- Added `sphinx`, `pylint` and `mypy` to `test-requirements.txt` so it is a complete list of developer requirements for those using tool direct IDE extensions
- Although `mypy` will install it's own dependencies, they are still listed in the `.pre-commit-config.yaml` because `pre-commit.ci` won't do it
- Added `pre-commit` checks for `mypy` with 3.6 - 3.11
  - This was done not necessarily because navigator really needs it but more instead to eliminate the possibility of different developers getting different results when running `mypy` directly or running `mypy` with an interpreter different than CI.  By checking all version navigator support, this should catch any inconsistencies or differences.
  - This will also eliminate the question why 3.6 and 3.10 and not 3.8?
  - Once cached, `mypy` runs quickly so this should not take long locally.
  - Since 3.11 was running clean and is in late alpha, it was added. This should prevent any surprises later this year


This should allow for:
- Running `mypy` at the command line outside of `tox` with any 3.6-3.11 interpreter and check for 3.6-3.11 issues
- Using the `vscode` `mypy` extension
- Running `mypy` with a 3.6 interpreter and check 3.6 and 3.10
- Running `mypy` with a 3.10 interpreter and check for 3.6 and 3.10


No "code" changes were, rather a couple new ignore statements were added because the necessary changes were going to pretty wide and extend back into the actions.

The vscode settings for the mypy extension that seemed to work well were:

```
    "mypy.runUsingActiveInterpreter": true, #runs mypy from the venv
    "mypy.targets": []  #uses the files in the mypy.ini
```
Which provide feedback like this with the extension enabled:

![image](https://user-images.githubusercontent.com/18386516/154812804-89bcfcfa-2688-4f25-ace5-7abb5e48d788.png)

https://marketplace.visualstudio.com/items?itemName=matangover.mypy