### PR TITLE
[meta][pylint] ignore too-few-public-methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ skip_glob = ["tests/fixtures/common/collections*"] # Skip ansible content due to
     disable = [
       "duplicate-code",
       "fixme",
+      "too-few-public-methods",
       "unsubscriptable-object",
     ]
     enable = [

--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -39,7 +39,6 @@ PROCESSES = (multiprocessing.cpu_count() - 1) or 1
 
 
 class CollectionCatalog:
-    # pylint: disable=too-few-public-methods
     """A collection cataloger."""
 
     def __init__(self, directories: List[str]):

--- a/share/ansible_navigator/utils/image_introspect.py
+++ b/share/ansible_navigator/utils/image_introspect.py
@@ -20,7 +20,6 @@ PROCESSES = (multiprocessing.cpu_count() - 1) or 1
 
 
 class Command(SimpleNamespace):
-    # pylint: disable=too-few-public-methods
     """Abstraction for a details about a shell command."""
 
     id: str

--- a/src/ansible_navigator/actions/back.py
+++ b/src/ansible_navigator/actions/back.py
@@ -15,7 +15,6 @@ from . import _actions as actions
 class Action:
     """``:back`` command implementation."""
 
-    # pylint: disable=too-few-public-methods
 
     KEGEX = r"^\^\[|\x1b|back$"
 

--- a/src/ansible_navigator/actions/back.py
+++ b/src/ansible_navigator/actions/back.py
@@ -15,7 +15,6 @@ from . import _actions as actions
 class Action:
     """``:back`` command implementation."""
 
-
     KEGEX = r"^\^\[|\x1b|back$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/actions/filter.py
+++ b/src/ansible_navigator/actions/filter.py
@@ -11,7 +11,6 @@ from . import _actions as actions
 class Action:
     """``:filter`` command implementation."""
 
-
     KEGEX = r"^f(ilter)?(\s(?P<regex>.*))?$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/actions/filter.py
+++ b/src/ansible_navigator/actions/filter.py
@@ -11,7 +11,6 @@ from . import _actions as actions
 class Action:
     """``:filter`` command implementation."""
 
-    # pylint: disable=too-few-public-methods
 
     KEGEX = r"^f(ilter)?(\s(?P<regex>.*))?$"
 

--- a/src/ansible_navigator/actions/open_file.py
+++ b/src/ansible_navigator/actions/open_file.py
@@ -42,7 +42,6 @@ class SuspendCurses:
 class Action:
     """``:open`` command implementation."""
 
-    # pylint: disable=too-few-public-methods
 
     KEGEX = r"^o(?:pen)?(\s(?P<something>.*))?$"
 

--- a/src/ansible_navigator/actions/open_file.py
+++ b/src/ansible_navigator/actions/open_file.py
@@ -42,7 +42,6 @@ class SuspendCurses:
 class Action:
     """``:open`` command implementation."""
 
-
     KEGEX = r"^o(?:pen)?(\s(?P<something>.*))?$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/actions/quit.py
+++ b/src/ansible_navigator/actions/quit.py
@@ -11,7 +11,6 @@ from . import _actions as actions
 class Action:
     """``:quit`` command implementation."""
 
-    # pylint: disable=too-few-public-methods
 
     KEGEX = r"q(?:uit)?(?P<exclamation>!)?$"
 

--- a/src/ansible_navigator/actions/quit.py
+++ b/src/ansible_navigator/actions/quit.py
@@ -11,7 +11,6 @@ from . import _actions as actions
 class Action:
     """``:quit`` command implementation."""
 
-
     KEGEX = r"q(?:uit)?(?P<exclamation>!)?$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/actions/refresh.py
+++ b/src/ansible_navigator/actions/refresh.py
@@ -11,7 +11,6 @@ from . import _actions as actions
 class Action:
     """Screen refresh implementation."""
 
-
     KEGEX = r"^KEY_F\(5\)$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/actions/refresh.py
+++ b/src/ansible_navigator/actions/refresh.py
@@ -11,7 +11,6 @@ from . import _actions as actions
 class Action:
     """Screen refresh implementation."""
 
-    # pylint: disable=too-few-public-methods
 
     KEGEX = r"^KEY_F\(5\)$"
 

--- a/src/ansible_navigator/actions/rerun.py
+++ b/src/ansible_navigator/actions/rerun.py
@@ -12,7 +12,6 @@ from . import _actions as actions
 class Action:
     """``:rerun`` command implementation."""
 
-
     KEGEX = r"^rr|rerun?$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/actions/rerun.py
+++ b/src/ansible_navigator/actions/rerun.py
@@ -12,7 +12,6 @@ from . import _actions as actions
 class Action:
     """``:rerun`` command implementation."""
 
-    # pylint: disable=too-few-public-methods
 
     KEGEX = r"^rr|rerun?$"
 

--- a/src/ansible_navigator/actions/save.py
+++ b/src/ansible_navigator/actions/save.py
@@ -11,7 +11,6 @@ from . import _actions as actions
 class Action:
     """``:save`` command implementation."""
 
-    # pylint: disable=too-few-public-methods
 
     KEGEX = r"^s(?:ave)?\s(?P<filename>.*)$"
 

--- a/src/ansible_navigator/actions/save.py
+++ b/src/ansible_navigator/actions/save.py
@@ -11,7 +11,6 @@ from . import _actions as actions
 class Action:
     """``:save`` command implementation."""
 
-
     KEGEX = r"^s(?:ave)?\s(?P<filename>.*)$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/actions/select.py
+++ b/src/ansible_navigator/actions/select.py
@@ -16,7 +16,6 @@ from . import _actions as actions
 class Action:
     """Menu selection implementation."""
 
-    # pylint: disable=too-few-public-methods
 
     KEGEX = r"^\d+$"
 

--- a/src/ansible_navigator/actions/select.py
+++ b/src/ansible_navigator/actions/select.py
@@ -16,7 +16,6 @@ from . import _actions as actions
 class Action:
     """Menu selection implementation."""
 
-
     KEGEX = r"^\d+$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/actions/serialize_json.py
+++ b/src/ansible_navigator/actions/serialize_json.py
@@ -11,7 +11,6 @@ from . import _actions as actions
 class Action:
     """``:json`` command implementation."""
 
-    # pylint: disable=too-few-public-methods
 
     KEGEX = r"^j(?:son)?$"
 

--- a/src/ansible_navigator/actions/serialize_json.py
+++ b/src/ansible_navigator/actions/serialize_json.py
@@ -11,7 +11,6 @@ from . import _actions as actions
 class Action:
     """``:json`` command implementation."""
 
-
     KEGEX = r"^j(?:son)?$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/actions/serialize_yaml.py
+++ b/src/ansible_navigator/actions/serialize_yaml.py
@@ -11,7 +11,6 @@ from . import _actions as actions
 class Action:
     """``:yaml`` command implementation."""
 
-    # pylint: disable=too-few-public-methods
 
     KEGEX = r"^y(?:aml)?$"
 

--- a/src/ansible_navigator/actions/serialize_yaml.py
+++ b/src/ansible_navigator/actions/serialize_yaml.py
@@ -11,7 +11,6 @@ from . import _actions as actions
 class Action:
     """``:yaml`` command implementation."""
 
-
     KEGEX = r"^y(?:aml)?$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/actions/write_file.py
+++ b/src/ansible_navigator/actions/write_file.py
@@ -16,7 +16,6 @@ from . import _actions as actions
 class Action:
     """``:write`` command implementation."""
 
-
     KEGEX = r"^w(?:rite)?(?P<force>!)?\s+(?P<append>>>)?\s*(?P<filename>.+)$"
 
     def __init__(self, args: ApplicationConfiguration):

--- a/src/ansible_navigator/actions/write_file.py
+++ b/src/ansible_navigator/actions/write_file.py
@@ -16,7 +16,6 @@ from . import _actions as actions
 class Action:
     """``:write`` command implementation."""
 
-    # pylint: disable=too-few-public-methods
 
     KEGEX = r"^w(?:rite)?(?P<force>!)?\s+(?P<append>>>)?\s*(?P<filename>.+)$"
 

--- a/src/ansible_navigator/command_runner/command_runner.py
+++ b/src/ansible_navigator/command_runner/command_runner.py
@@ -13,7 +13,6 @@ PROCESSES = (multiprocessing.cpu_count() - 1) or 1
 
 
 class Command(SimpleNamespace):
-    # pylint: disable=too-few-public-methods
     """command obj"""
 
     id: str

--- a/src/ansible_navigator/configuration_subsystem/configurator.py
+++ b/src/ansible_navigator/configuration_subsystem/configurator.py
@@ -21,7 +21,6 @@ from .parser import Parser
 
 
 class Configurator:
-    # pylint: disable=too-few-public-methods
     """the configuration class"""
 
     def __init__(

--- a/src/ansible_navigator/configuration_subsystem/definitions.py
+++ b/src/ansible_navigator/configuration_subsystem/definitions.py
@@ -127,7 +127,6 @@ class SettingsEntry:
 
 
 class SubCommand(SimpleNamespace):
-    # pylint: disable=too-few-public-methods
     """An object to hold a subcommand"""
 
     name: str

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -81,7 +81,6 @@ def generate_share_directory():
 
 
 class Internals(SimpleNamespace):
-    # pylint: disable=too-few-public-methods
     """a place to hold object that need to be carried
     from application initiation to the rest of the app
     """

--- a/src/ansible_navigator/configuration_subsystem/parser.py
+++ b/src/ansible_navigator/configuration_subsystem/parser.py
@@ -18,7 +18,6 @@ from .definitions import Constants as C
 class Parser:
     """Build the args"""
 
-    # pylint: disable=too-few-public-methods
     def __init__(self, config: ApplicationConfiguration):
         """Initialize the command line interface parameter parser.
 

--- a/src/ansible_navigator/image_manager/puller.py
+++ b/src/ansible_navigator/image_manager/puller.py
@@ -11,7 +11,6 @@ from ..utils import LogMessage
 
 
 class ImageAssessment(SimpleNamespace):
-    # pylint: disable=too-few-public-methods
     """report the findings"""
 
     messages: List[LogMessage]

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -42,7 +42,6 @@ CURSES_STYLES = {
 class ColorSchema:
     """A storage mechanism for the schema (theme)."""
 
-    # pylint: disable=too-few-public-methods
 
     def __init__(self, schema: Dict[str, Union[str, List, Dict]]):
         """Initialize the ColorSchema class.

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -42,7 +42,6 @@ CURSES_STYLES = {
 class ColorSchema:
     """A storage mechanism for the schema (theme)."""
 
-
     def __init__(self, schema: Dict[str, Union[str, List, Dict]]):
         """Initialize the ColorSchema class.
 

--- a/src/ansible_navigator/ui_framework/curses_window.py
+++ b/src/ansible_navigator/ui_framework/curses_window.py
@@ -43,7 +43,6 @@ COLOR_MAP = {
 
 
 class CursesWindow:
-    # pylint: disable=too-few-public-methods
     # pylint: disable=too-many-instance-attributes
     """abstraction for a curses window"""
 

--- a/src/ansible_navigator/ui_framework/form_handler_information.py
+++ b/src/ansible_navigator/ui_framework/form_handler_information.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
 
 
 class FormHandlerInformation(CursesWindow):
-    # pylint: disable=too-few-public-methods
     """handle form button"""
 
     def __init__(self, screen, ui_config):

--- a/src/ansible_navigator/ui_framework/form_handler_working.py
+++ b/src/ansible_navigator/ui_framework/form_handler_working.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
 
 
 class FormHandlerWorking(CursesWindow):
-    # pylint: disable=too-few-public-methods
     """handle form button"""
 
     def __init__(self, screen, ui_config):

--- a/src/ansible_navigator/ui_framework/form_presenter.py
+++ b/src/ansible_navigator/ui_framework/form_presenter.py
@@ -39,7 +39,6 @@ class FormPresenter(CursesWindow):
     """present the form to the user"""
 
     # pylint: disable=too-many-instance-attributes
-    # pylint: disable=too-few-public-methods
     def __init__(self, form, screen, ui_config):
         """Initialize the form presenter.
 

--- a/src/ansible_navigator/ui_framework/menu_builder.py
+++ b/src/ansible_navigator/ui_framework/menu_builder.py
@@ -19,7 +19,6 @@ from .utils import distribute
 
 
 class MenuBuilder:
-    # pylint: disable=too-few-public-methods
     """build a menu from list of dicts"""
 
     def __init__(

--- a/src/ansible_navigator/ui_framework/sentinels.py
+++ b/src/ansible_navigator/ui_framework/sentinels.py
@@ -18,7 +18,6 @@ class Singleton(type):
 
 
 class Unknown(metaclass=Singleton):
-    # pylint: disable=too-few-public-methods
     """something that should eventually be known"""
 
     def __repr__(self):
@@ -29,7 +28,6 @@ unknown = Unknown()
 
 
 class Nonexistent(metaclass=Singleton):
-    # pylint: disable=too-few-public-methods
     """something that does not exist"""
 
     def __repr__(self):

--- a/tests/integration/actions/collections/base.py
+++ b/tests/integration/actions/collections/base.py
@@ -15,7 +15,6 @@ from ..._tmux_session import TmuxSession
 
 
 class BaseClass:
-    # pylint: disable=too-few-public-methods
     """Base class for interactive collections tests."""
 
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/collections/test_direct_interactive_ee.py
+++ b/tests/integration/actions/collections/test_direct_interactive_ee.py
@@ -26,7 +26,6 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment", testdata)
 class Test(BaseClass):
-    # pylint: disable=too-few-public-methods
     """Run the tests for collections from CLI, interactive, with an EE."""
 
     TEST_FOR_MODE = "interactive"

--- a/tests/integration/actions/collections/test_direct_interactive_ee_with_volmount.py
+++ b/tests/integration/actions/collections/test_direct_interactive_ee_with_volmount.py
@@ -18,7 +18,6 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment", testdata)
 class Test(BaseClass):
-    # pylint: disable=too-few-public-methods
     """Run the tests for collections from CLI, interactive, with an EE."""
 
     TEST_FOR_MODE = "interactive"

--- a/tests/integration/actions/collections/test_direct_interactive_noee.py
+++ b/tests/integration/actions/collections/test_direct_interactive_noee.py
@@ -26,7 +26,6 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment", testdata)
 class Test(BaseClass):
-    # pylint: disable=too-few-public-methods
     """Run the tests for collections from CLI, interactive, without an EE."""
 
     TEST_FOR_MODE = "interactive"

--- a/tests/integration/actions/collections/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/collections/test_welcome_interactive_ee.py
@@ -27,7 +27,6 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment", testdata)
 class Test(BaseClass):
-    # pylint: disable=too-few-public-methods
     """Run the tests for collections from welcome, interactive, with an EE."""
 
     TEST_FOR_MODE = "interactive"

--- a/tests/integration/actions/collections/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/collections/test_welcome_interactive_noee.py
@@ -27,7 +27,6 @@ testdata = [
 
 @pytest.mark.parametrize("index, user_input, comment", testdata)
 class Test(BaseClass):
-    # pylint: disable=too-few-public-methods
     """Run the tests for collections from welcome, interactive, without an EE."""
 
     TEST_FOR_MODE = "interactive"


### PR DESCRIPTION
Change:
- Add too-few-public-methods to the list of ignores
- Remove now-needless disables of this lint check

This check isn't very helpful; there are many cases a class might not have
many or any public methods, such as subclassing a class for the purpose of
type-safety and wanting a runtime representation of it (i.e., not using
NewType).

Test Plan:
- pre-commit run -a pylint

Signed-off-by: Rick Elrod <rick@elrod.me>

-------------

After this, these are the most ignored lint checks:

```
rick@mba ansible-navigator % grep 'pylint: *disable=' src tests docs share -R | cut -d# -f2 | cut -d= -f2 | sort | uniq -c | sort -nr
  33 unused-argument
  22 too-many-branches
  21 too-many-arguments
  13 too-many-instance-attributes
  11 protected-access
  10 too-many-locals
   8 preferred-module
   7 too-many-statements
   6 cyclic-import
   5 invalid-name
   4 broad-except
   2 too-many-nested-blocks
   2 no-self-use
   2 attribute-defined-outside-init
   1 unused-import
   1 too-many-return-statements
   1 too-many-public-methods
   1 too-many-ancestors
   1 super-init-not-called
   1 redefined-builtin
   1 no-else-return
   1 import-outside-toplevel
   1 import-error
   1 expression-not-assigned
   1 dangerous-default-value
```