### PR TITLE
Move mypy configuration to mypy.ini

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,19 +154,25 @@ repos:
       # NOTE: CI automations run both checks. Whenever the versions are
       # NOTE: updated in this config, a symmetric action must be performed
       # NOTE: in `tox.ini` as well.
-      - id: mypy
+      - &_base-mypy-setup-map
+        id: mypy
         alias: mypy-py310
         name: MyPy, for Python 3.10
-        additional_dependencies: &_mypy_deps
-          - types-dataclasses # Needed for checking py3.6 with a later interpreter
+        additional_dependencies:
+          - lxml == 4.6.4 # needed for `--txt-report`
           - types-docutils
           - types-PyYAML
         args:
           - --python-version=3.10
         pass_filenames: false
-      - id: mypy
+      - <<: *_base-mypy-setup-map
+        alias: mypy-py36
         name: MyPy, for Python 3.6
-        additional_dependencies: *_mypy_deps
+        additional_dependencies:
+          - lxml == 4.6.4 # needed for `--txt-report`
+          - types-dataclasses # Needed for checking py3.6 with a later interpreter
+          - types-docutils
+          - types-PyYAML
         args:
           - --python-version=3.6
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,72 +143,27 @@ repos:
   - repo: https://github.com/pre-commit/mirrors-mypy.git
     rev: v0.931
     hooks:
-      # NOTE: Here MyPy is executed twice -- once for the highest and once
-      # NOTE: for the lowest supported version. They are hardcoded in the
-      # NOTE: hook invocations below. Whenever one of these versions needs
-      # NOTE: to be updated, the values in the `alias` and `name` fields
-      # NOTE: should be adjusted along with the `--python-version` CLI
-      # NOTE: option.
-      # NOTE: The external developer environment is configured to only run
-      # NOTE: the check with the lowest version on the tox side while the
-      # NOTE: CI automations run both checks. Whenever the versions are
-      # NOTE: updated in this config, a symmetric action must be performed
-      # NOTE: in `tox.ini` as well.
-      - &_base-mypy-setup-map
-        id: mypy
+      # NOTE: The latest version dependencies should include all dependancies for all interpreter
+      # NOTE: versions so the configuration doesn' grow out of control.
+      # NOTE: As new interpreters are added or removed, the dependency list should be auditted
+      # NOTE: For version specific dependendcies, please note the interpreter version.
+      # NOTE: These are ordered from latest version to earliest for no particular reason
+      # NOTE: other than a way to keep them organized.
+      - id: mypy
         alias: mypy-py310
         name: MyPy, for Python 3.10
-        additional_dependencies:
-          - lxml == 4.6.4 # needed for `--txt-report`
-          - types-docutils
+        additional_dependencies: &_mypy_deps
           - types-PyYAML
+          - types-dataclasses # Needed for checking py3.6 with a later interpreter
+          - types-docutils
         args:
-          # FIXME: get rid of missing imports ignore
-          - --ignore-missing-imports
-          - --install-types
-          - --namespace-packages
-          - --non-interactive
-          - --pretty
           - --python-version=3.10
-          - --show-column-numbers
-          - --show-error-codes
-          - --show-error-context
-          #- --strict
-          #- --strict-optional
-          - --txt-report
-          - .tox/.tmp/.mypy/
-          - docs/
-          - share/
-          - src/
-          - tests/
         pass_filenames: false
-      - <<: *_base-mypy-setup-map
-        alias: mypy-py36
+      - id: mypy
         name: MyPy, for Python 3.6
-        additional_dependencies:
-          - lxml == 4.6.4 # needed for `--txt-report`
-          - types-dataclasses
-          - types-docutils
-          - types-PyYAML
+        additional_dependencies: *_mypy_deps
         args:
-          # FIXME: get rid of missing imports ignore
-          - --ignore-missing-imports
-          - --install-types
-          - --namespace-packages
-          - --non-interactive
-          - --pretty
           - --python-version=3.6
-          - --show-column-numbers
-          - --show-error-codes
-          - --show-error-context
-          #- --strict
-          #- --strict-optional
-          - --txt-report
-          - .tox/.tmp/.mypy/
-          - docs/
-          - share/
-          - src/
-          - tests/
 
   - repo: https://github.com/pycqa/pylint.git
     rev: v2.12.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -158,9 +158,9 @@ repos:
         alias: mypy-py310
         name: MyPy, for Python 3.10
         additional_dependencies: &_mypy_deps
-          - types-PyYAML
           - types-dataclasses # Needed for checking py3.6 with a later interpreter
           - types-docutils
+          - types-PyYAML
         args:
           - --python-version=3.10
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,12 +143,17 @@ repos:
   - repo: https://github.com/pre-commit/mirrors-mypy.git
     rev: v0.931
     hooks:
-      # NOTE: The latest version dependencies should include all dependancies for all interpreter
-      # NOTE: versions so the configuration doesn' grow out of control.
-      # NOTE: As new interpreters are added or removed, the dependency list should be auditted
-      # NOTE: For version specific dependendcies, please note the interpreter version.
-      # NOTE: These are ordered from latest version to earliest for no particular reason
-      # NOTE: other than a way to keep them organized.
+      # NOTE: Here MyPy is executed twice -- once for the highest and once
+      # NOTE: for the lowest supported version. They are hardcoded in the
+      # NOTE: hook invocations below. Whenever one of these versions needs
+      # NOTE: to be updated, the values in the `alias` and `name` fields
+      # NOTE: should be adjusted along with the `--python-version` CLI
+      # NOTE: option.
+      # NOTE: The external developer environment is configured to only run
+      # NOTE: the check with the lowest version on the tox side while the
+      # NOTE: CI automations run both checks. Whenever the versions are
+      # NOTE: updated in this config, a symmetric action must be performed
+      # NOTE: in `tox.ini` as well.
       - id: mypy
         alias: mypy-py310
         name: MyPy, for Python 3.10

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -13,6 +13,8 @@ ignorePaths:
   - docs/requirements.in
   # Ignore licenses
   - licenses/*
+  # The mypy configuration file
+  - mypy.ini
   # The shared file for tool configuration
   - pyproject.toml
   # The setup file

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,9 +1,9 @@
 [mypy]
 files =
-  docs,
-  share,
-  src,
-  tests
+  docs/,
+  share/,
+  src/,
+  tests/
 # FIXME: get rid of missing imports ignore
 ignore_missing_imports = true
 install_types = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,9 @@
 [mypy]
-files = docs,share,src,tests
+files =
+  docs,
+  share,
+  src,
+  tests,
 ignore_missing_imports = true
 install_types = true
 namespace_packages = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,7 +3,7 @@ files =
   docs,
   share,
   src,
-  tests
+  tests,
 # FIXME: get rid of missing imports ignore
 ignore_missing_imports = true
 install_types = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,7 +3,8 @@ files =
   docs,
   share,
   src,
-  tests,
+  tests
+# FIXME: get rid of missing imports ignore
 ignore_missing_imports = true
 install_types = true
 namespace_packages = true
@@ -12,5 +13,6 @@ pretty = true
 show_column_numbers = true
 show_error_codes = true
 show_error_context = true
+txt_report = .tox/.tmp/.mypy/
 # strict = true
 # strict_optional = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,12 @@
+[mypy]
+files = docs,share,src,tests
+ignore_missing_imports = true
+install_types = true
+namespace_packages = true
+non_interactive = true
+pretty = true
+show_column_numbers = true
+show_error_codes = true
+show_error_context = true
+# strict = true
+# strict_optional = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,7 +3,7 @@ files =
   docs,
   share,
   src,
-  tests,
+  tests
 # FIXME: get rid of missing imports ignore
 ignore_missing_imports = true
 install_types = true


### PR DESCRIPTION
This PR moves the mypy configuration out of the `.pre-commit-config.yaml` into `mypy.ini`

- Added entry to not spell check the `mypy.ini` file with cspell.

More PRs to follow related to the configuration.



Related #977
