### PR TITLE
Add pytest to mypy dependencies in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -161,6 +161,7 @@ repos:
         additional_dependencies:
           - jinja2
           - lxml == 4.6.4 # needed for `--txt-report`
+          - pytest
           - types-docutils
           - types-PyYAML
         args:
@@ -172,6 +173,7 @@ repos:
         additional_dependencies:
           - jinja2
           - lxml == 4.6.4 # needed for `--txt-report`
+          - pytest
           - types-dataclasses # Needed for checking py3.6 with a later interpreter
           - types-docutils
           - types-PyYAML

--- a/tests/integration/actions/run_unicode/base.py
+++ b/tests/integration/actions/run_unicode/base.py
@@ -62,7 +62,7 @@ class BaseClass:
     def test(
         self,
         request: pytest.FixtureRequest,
-        tmux_session: pytest.FixtureRequest,
+        tmux_session: TmuxSession,
         step: UiTestStep,
     ):
         # pylint: disable=too-many-branches

--- a/tests/unit/test_yaml.py
+++ b/tests/unit/test_yaml.py
@@ -23,12 +23,12 @@ def _aliases_allowed(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureReq
     :param request: The request for this fixture from a test
     :returns: The original request parameter
     """
-    if request.param:
+    if request.param:  # type: ignore[attr-defined] # github.com/pytest-dev/pytest/issues/8073
         monkeypatch.setattr(
             "ansible_navigator._yaml.HumanDumper.ignore_aliases",
             Dumper.ignore_aliases,
         )
-    return request.param
+    return request.param  # type: ignore[attr-defined]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Ongoing work to remove ignore-imports. from the mypy configuration.

One type fix and one ignore with explanation.