### PR TITLE
Add sphinx to mypy deps in pre-commit and test-requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,6 +160,7 @@ repos:
         name: MyPy, for Python 3.10
         additional_dependencies:
           - lxml == 4.6.4 # needed for `--txt-report`
+          - shpinx
           - types-docutils
           - types-PyYAML
         args:
@@ -170,6 +171,7 @@ repos:
         name: MyPy, for Python 3.6
         additional_dependencies:
           - lxml == 4.6.4 # needed for `--txt-report`
+          - sphinx
           - types-dataclasses # Needed for checking py3.6 with a later interpreter
           - types-docutils
           - types-PyYAML

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,7 +160,6 @@ repos:
         name: MyPy, for Python 3.10
         additional_dependencies:
           - jinja2
-          - lxml == 4.6.4 # needed for `--txt-report`
           - shpinx
           - types-docutils
           - types-PyYAML
@@ -172,7 +171,6 @@ repos:
         name: MyPy, for Python 3.6
         additional_dependencies:
           - jinja2
-          - lxml == 4.6.4 # needed for `--txt-report`
           - sphinx
           - types-dataclasses # Needed for checking py3.6 with a later interpreter
           - types-docutils

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,8 +160,8 @@ repos:
         name: MyPy, for Python 3.10
         additional_dependencies:
           - jinja2
-          - shpinx
           - pytest
+          - sphinx
           - types-docutils
           - types-PyYAML
         args:
@@ -172,8 +172,8 @@ repos:
         name: MyPy, for Python 3.6
         additional_dependencies:
           - jinja2
-          - sphinx
           - pytest
+          - sphinx
           - types-dataclasses # Needed for checking py3.6 with a later interpreter
           - types-docutils
           - types-PyYAML

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,7 +141,7 @@ extensions = [
 
 # Conditional third-party extensions:
 try:
-    import sphinxcontrib.spelling as _sphinxcontrib_spelling
+    import sphinxcontrib.spelling as _sphinxcontrib_spelling  # type: ignore[import]
 except ImportError:
     extensions.append("spelling_stub_ext")
 else:

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,6 +13,5 @@ pretty = true
 show_column_numbers = true
 show_error_codes = true
 show_error_context = true
-txt_report = .tox/.tmp/.mypy/
 # strict = true
 # strict_optional = true

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ flake8-docstrings
 flake8-quotes
 libtmux
 lxml
+sphinx
 pre-commit
 pytest-cov
 pytest-mock

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,8 +4,8 @@ flake8-docstrings
 flake8-quotes
 libtmux
 lxml
-sphinx
 pre-commit
 pytest-cov
 pytest-mock
 pytest-xdist
+sphinx


### PR DESCRIPTION
Ongoing effort to remove ignore-imports from mypy.

- Added as a dependency in the precommit entries for python3.6 and 3.10
- Added to test-requirements so mypy can be used from the command line
- One type ignore b/c sphinx spelling is not typed.