### PR TITLE
Remove mypy txt report

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,7 +160,6 @@ repos:
         name: MyPy, for Python 3.10
         additional_dependencies:
           - jinja2
-          - lxml == 4.6.4 # needed for `--txt-report`
           - pytest
           - types-docutils
           - types-PyYAML
@@ -172,7 +171,6 @@ repos:
         name: MyPy, for Python 3.6
         additional_dependencies:
           - jinja2
-          - lxml == 4.6.4 # needed for `--txt-report`
           - pytest
           - types-dataclasses # Needed for checking py3.6 with a later interpreter
           - types-docutils

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,6 +13,5 @@ pretty = true
 show_column_numbers = true
 show_error_codes = true
 show_error_context = true
-txt_report = .tox/.tmp/.mypy/
 # strict = true
 # strict_optional = true


### PR DESCRIPTION
- Eliminates the need for lxml pinned to a version incompatible with sphinx
- I don't think anyone was using this, was added early on in #111 