### PR TITLE
Add libtmux to mypy dependancies and exempt from ignore-import errors.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,6 +160,7 @@ repos:
         name: MyPy, for Python 3.10
         additional_dependencies:
           - jinja2
+          - libtmux
           - pytest
           - sphinx
           - types-docutils
@@ -172,6 +173,7 @@ repos:
         name: MyPy, for Python 3.6
         additional_dependencies:
           - jinja2
+          - libtmux
           - pytest
           - sphinx
           - types-dataclasses # Needed for checking py3.6 with a later interpreter

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,3 +15,7 @@ show_error_codes = true
 show_error_context = true
 # strict = true
 # strict_optional = true
+
+[mypy-libtmux]
+# No type hints as of version 0.10.3
+ignore_missing_imports = True


### PR DESCRIPTION
Ongoing work to remove `ignore_imports` from the mypy config.

`libtmux` is not typed and therefore has a package level ignore in the `mypy.ini`