### PR TITLE
Remove docs dependency on setuptools_scm

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -165,6 +165,7 @@ repos:
           - sphinx
           - types-docutils
           - types-PyYAML
+          - types-setuptools
         args:
           - --python-version=3.10
         pass_filenames: false
@@ -179,6 +180,7 @@ repos:
           - types-dataclasses # Needed for checking py3.6 with a later interpreter
           - types-docutils
           - types-PyYAML
+          - types-setuptools
         args:
           - --python-version=3.6
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ copyright = author  # pylint:disable=redefined-builtin
 NAVIGATOR_VERSION = version("ansible_navigator")
 
 # The short X.Y version
-version = ".".join(NAVIGATOR_VERSION.split(".")[:2])
+major_minor_version = ".".join(NAVIGATOR_VERSION.split(".")[:2])
 
 # The full version, including alpha/beta/rc tags
 release = NAVIGATOR_VERSION
@@ -274,5 +274,5 @@ myst_substitutions = {
     "project": project,
     "release": release,
     "release_l": f"`v{release}`",
-    "version": version,
+    "version": major_minor_version,
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,8 @@ copyright = author  # pylint:disable=redefined-builtin
 
 NAVIGATOR_VERSION = get_version("ansible_navigator")
 
-# The short X.Y.Z version
+# The short X.Y version
+# including .Z, resulting in the X.Y.Z version
 version = ".".join(NAVIGATOR_VERSION.split(".")[:3])
 
 # The full version, including alpha/beta/rc tags

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,17 +3,16 @@
 # Ref: https://www.sphinx-doc.org/en/master/usage/configuration.html
 """Configuration file for the Sphinx docs."""
 
-from functools import partial
+import re
 from pathlib import Path
 from sys import path
 
-from setuptools_scm import get_version
+from ansible_navigator import _version
 
 
 # -- Path setup --------------------------------------------------------------
 
 PROJECT_ROOT_DIR = Path(__file__).parents[1].resolve()
-get_scm_version = partial(get_version, root=PROJECT_ROOT_DIR)
 
 # Make in-tree extension importable in non-tox setups/envs, like RTD.
 # Refs:
@@ -36,22 +35,49 @@ project = "Ansible Navigator"
 author = f"{project} project contributors"
 copyright = author  # pylint:disable=redefined-builtin
 
-# fmt: off
-# The short X.Y version
-version = ".".join(
-    get_scm_version(
-        local_scheme="no-local-version",
-    ).split(".")[:3],
+NAVIGATOR_VERSION = _version.__version__
+
+# Regular expression taken from
+# https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+SEMVER_RE = re.compile(
+    r"""
+    ^
+        (?P<major>0|[1-9]\d*)
+        \.
+        (?P<minor>0|[1-9]\d*)
+        \.
+        (?P<patch>0|[1-9]\d*)
+        (?:
+            -
+            (?P<prerelease>
+                (?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)
+                (?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*
+            )
+        )?
+        (?:
+            \+
+            (?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)
+        )?
+    $
+    """,
+    flags=re.X,
 )
 
+parsed_version = SEMVER_RE.match(NAVIGATOR_VERSION)
+if parsed_version is None:
+    raise ValueError(f"Malformed version. Ensure it is semver compliant: {NAVIGATOR_VERSION}")
+version_dictionary = parsed_version.groupdict()
+
+# The short X.Y version
+version = f"{version_dictionary['major']}.{version_dictionary['minor']}"
+
 # The full version, including alpha/beta/rc tags
-release = get_scm_version()
+release = NAVIGATOR_VERSION
 
 rst_epilog = f"""
 .. |project| replace:: {project}
 .. |release_l| replace:: ``v{release}``
 """
-
 
 # -- General configuration ---------------------------------------------------
 
@@ -277,8 +303,8 @@ myst_enable_extensions = [
     "substitution",  # replace common ASCII shortcuts into their symbols
 ]
 myst_substitutions = {
-  "project": project,
-  "release": release,
-  "release_l": f"`v{release}`",
-  "version": version,
+    "project": project,
+    "release": release,
+    "release_l": f"`v{release}`",
+    "version": version,
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,7 +187,7 @@ html_context = {
     "github_user": github_repo_org,
     "github_repo": github_repo_name,
     "github_version": "main/docs/",
-    "current_version": version,
+    "current_version": major_minor_version,
     "latest_version": "latest",
     "available_versions": ("latest",),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,12 +3,10 @@
 # Ref: https://www.sphinx-doc.org/en/master/usage/configuration.html
 """Configuration file for the Sphinx docs."""
 
-import re
 
+from importlib.metadata import version
 from pathlib import Path
 from sys import path
-
-from ansible_navigator import _version
 
 
 # -- Path setup --------------------------------------------------------------
@@ -36,41 +34,10 @@ project = "Ansible Navigator"
 author = f"{project} project contributors"
 copyright = author  # pylint:disable=redefined-builtin
 
-NAVIGATOR_VERSION = _version.__version__
-
-# Regular expression taken from
-# https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-SEMVER_RE = re.compile(
-    r"""
-    ^
-        (?P<major>0|[1-9]\d*)
-        \.
-        (?P<minor>0|[1-9]\d*)
-        \.
-        (?P<patch>0|[1-9]\d*)
-        (?:
-            -
-            (?P<prerelease>
-                (?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)
-                (?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*
-            )
-        )?
-        (?:
-            \+
-            (?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)
-        )?
-    $
-    """,
-    flags=re.X,
-)
-
-parsed_version = SEMVER_RE.match(NAVIGATOR_VERSION)
-if parsed_version is None:
-    raise ValueError(f"Malformed version. Ensure it is semver compliant: {NAVIGATOR_VERSION}")
-version_dictionary = parsed_version.groupdict()
+NAVIGATOR_VERSION = version("ansible_navigator")
 
 # The short X.Y version
-version = f"{version_dictionary['major']}.{version_dictionary['minor']}"
+version = ".".join(NAVIGATOR_VERSION.split(".")[:2])
 
 # The full version, including alpha/beta/rc tags
 release = NAVIGATOR_VERSION

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@
 """Configuration file for the Sphinx docs."""
 
 
-from importlib.metadata import version
+from importlib.metadata import version as get_version
 from pathlib import Path
 from sys import path
 
@@ -34,10 +34,10 @@ project = "Ansible Navigator"
 author = f"{project} project contributors"
 copyright = author  # pylint:disable=redefined-builtin
 
-NAVIGATOR_VERSION = version("ansible_navigator")
+NAVIGATOR_VERSION = get_version("ansible_navigator")
 
-# The short X.Y version
-major_minor_version = ".".join(NAVIGATOR_VERSION.split(".")[:2])
+# The short X.Y.Z version
+version = ".".join(NAVIGATOR_VERSION.split(".")[:3])
 
 # The full version, including alpha/beta/rc tags
 release = NAVIGATOR_VERSION
@@ -187,7 +187,7 @@ html_context = {
     "github_user": github_repo_org,
     "github_repo": github_repo_name,
     "github_version": "main/docs/",
-    "current_version": major_minor_version,
+    "current_version": version,
     "latest_version": "latest",
     "available_versions": ("latest",),
 }
@@ -274,5 +274,5 @@ myst_substitutions = {
     "project": project,
     "release": release,
     "release_l": f"`v{release}`",
-    "version": major_minor_version,
+    "version": version,
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,7 @@
 """Configuration file for the Sphinx docs."""
 
 import re
+
 from pathlib import Path
 from sys import path
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@
     name = "Contributor-facing changes"
     showcontent = true
 
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
 
 [tool.black]
 line-length = 100
@@ -95,3 +97,5 @@ skip_glob = ["tests/fixtures/common/collections*"] # Skip ansible content due to
 
     [tool.pylint.format]
     max-line-length = 100
+
+[tool.setuptools_scm]

--- a/src/ansible_navigator/_version.py
+++ b/src/ansible_navigator/_version.py
@@ -15,5 +15,5 @@
    application version, although keeping the major in sync is probably
    not a bad idea to minimize the amount of stale docs in the user's cache
 """
-__version__ = "1.1.0-alpha.1"
+__version__ = "1.1.0a1"
 __version_collection_doc_cache__ = "1.0"

--- a/src/ansible_navigator/_version.py
+++ b/src/ansible_navigator/_version.py
@@ -15,5 +15,5 @@
    application version, although keeping the major in sync is probably
    not a bad idea to minimize the amount of stale docs in the user's cache
 """
-__version__ = "1.1.0a1"
+__version__ = "1.1.0-alpha.1"
 __version_collection_doc_cache__ = "1.0"


### PR DESCRIPTION
Part of ongoing work to remove `ignore_imports` for mypy.

In this case, rather than account for setuptools_scm in the mypy.ini as untyped (https://github.com/pypa/setuptools_scm/issues/501), simply remove the dependency on it entirely.
