### PR TITLE
Transition from __version__ to version

### DIFF
--- a/src/ansible_navigator/__init__.py
+++ b/src/ansible_navigator/__init__.py
@@ -9,6 +9,6 @@ try:
     from ._version import __version__
 except ImportError:
     try:
-        from ._version import version
+        from ._version import version  # type: ignore[attr-defined]
     except ImportError:
         __version__ = "source"

--- a/src/ansible_navigator/__init__.py
+++ b/src/ansible_navigator/__init__.py
@@ -1,2 +1,14 @@
-"""The ansible-navigator application."""
-from ._version import __version__  # noqa: F401
+"""The ansible-navigator application.
+
+This is a transitional configuration during the migration
+from the hardcoded __version__ in _version to
+version being populated during the build.
+"""
+
+try:
+    from ._version import __version__
+except ImportError:
+    try:
+        from ._version import version
+    except ImportError:
+        __version__ = "source"

--- a/src/ansible_navigator/__init__.py
+++ b/src/ansible_navigator/__init__.py
@@ -8,7 +8,4 @@ version being populated during the build.
 try:
     from ._version import __version__
 except ImportError:
-    try:
-        from ._version import version  # type: ignore[attr-defined]
-    except ImportError:
-        __version__ = "source"
+    __version__ = "source"

--- a/src/ansible_navigator/_version.py
+++ b/src/ansible_navigator/_version.py
@@ -16,4 +16,5 @@
    not a bad idea to minimize the amount of stale docs in the user's cache
 """
 __version__ = "1.1.0a1"
+version = __version__
 __version_collection_doc_cache__ = "1.0"

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -9,7 +9,7 @@ from typing import List
 from typing import Tuple
 from typing import Union
 
-from .._version import __version__ as VERSION
+from .. import __version__ as VERSION
 from ..utils import ExitMessage
 from ..utils import LogMessage
 from ..utils import abs_user_path

--- a/src/ansible_navigator/configuration_subsystem/parser.py
+++ b/src/ansible_navigator/configuration_subsystem/parser.py
@@ -9,7 +9,7 @@ from typing import Dict
 from typing import Tuple
 from typing import Union
 
-from .._version import __version__
+from .. import __version__
 from ..utils import oxfordcomma
 from .definitions import ApplicationConfiguration
 from .definitions import Constants as C


### PR DESCRIPTION
This will allow the `__version__` entry in the `._version` file eventually be `version`, and account for running from source when the `._version` file doesn't exist at all.

Another small step toward removing the hard coded version from the repo and letting setuptools_scm generate it during build.

(This will get cleaned up in 3-4 PRs)
