### PR TITLE
Ignore PRs from any GitHub apps in Chronographer

### DIFF
--- a/.github/chronographer.yml
+++ b/.github/chronographer.yml
@@ -2,10 +2,6 @@
 enforce_name:
   suffix: .md
 exclude:
-  bots:
-  - dependabot-preview
-  - dependabot
-  - patchback
   humans:
   - pyup-bot
 ...


### PR DESCRIPTION
When the list in the config is explicit, then only those bots get ignored but now PRs from any GitHub Apps will not require change notes.