### PR TITLE
Limit use of `_version.py` to one location

### DIFF
--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -28,6 +28,7 @@ from .utils import ExitPrefix
 from .utils import LogMessage
 from .utils import clear_screen
 
+
 try:
     from ._version import __version__
 except ImportError:

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -28,6 +28,11 @@ from .utils import ExitPrefix
 from .utils import LogMessage
 from .utils import clear_screen
 
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = None
+
 
 APP_NAME = "ansible-navigator"
 PKG_NAME = "ansible_navigator"
@@ -110,6 +115,8 @@ def main():
     exit_messages: List[ExitMessage] = []
 
     args = deepcopy(NavigatorConfiguration)
+    if __version__:
+        args.application_version = __version__
     messages.extend(args.internals.initialization_messages)
     exit_messages.extend(args.internals.initialization_exit_messages)
 

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -32,7 +32,7 @@ from .utils import clear_screen
 try:
     from ._version import __version__
 except ImportError:
-    __version__ = None
+    __version__ = ""
 
 
 APP_NAME = "ansible-navigator"
@@ -116,7 +116,7 @@ def main():
     exit_messages: List[ExitMessage] = []
 
     args = deepcopy(NavigatorConfiguration)
-    if isinstance(__version__, str):
+    if __version__:
         args.application_version = __version__
     messages.extend(args.internals.initialization_messages)
     exit_messages.extend(args.internals.initialization_exit_messages)

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -115,7 +115,7 @@ def main():
     exit_messages: List[ExitMessage] = []
 
     args = deepcopy(NavigatorConfiguration)
-    if __version__:
+    if isinstance(__version__, str):
         args.application_version = __version__
     messages.extend(args.internals.initialization_messages)
     exit_messages.extend(args.internals.initialization_exit_messages)

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -9,7 +9,6 @@ from typing import List
 from typing import Tuple
 from typing import Union
 
-from .._version import __version__ as VERSION
 from ..utils import ExitMessage
 from ..utils import LogMessage
 from ..utils import abs_user_path
@@ -166,7 +165,7 @@ navigator_subcommands = [
 
 NavigatorConfiguration = ApplicationConfiguration(
     application_name=APP_NAME,
-    application_version=VERSION,
+    application_version=C.NOT_SET,
     internals=Internals(),
     post_processor=NavigatorPostProcessor(),
     subcommands=navigator_subcommands,

--- a/src/ansible_navigator/configuration_subsystem/parser.py
+++ b/src/ansible_navigator/configuration_subsystem/parser.py
@@ -9,7 +9,6 @@ from typing import Dict
 from typing import Tuple
 from typing import Union
 
-from .._version import __version__
 from ..utils import oxfordcomma
 from .definitions import ApplicationConfiguration
 from .definitions import Constants as C
@@ -88,10 +87,14 @@ class Parser:
         )
 
     def _configure_base(self) -> None:
+        if isinstance(self._config.application_version, C):
+            version = self._config.application_version.value
+        else:
+            version = self._config.application_version
         self._base_parser.add_argument(
             "--version",
             action="version",
-            version="%(prog)s " + __version__,
+            version="%(prog)s " + version,
         )
 
         for entry in self._config.entries:

--- a/tests/unit/configuration_subsystem/test_previous_cli.py
+++ b/tests/unit/configuration_subsystem/test_previous_cli.py
@@ -269,6 +269,7 @@ def test_apply_cli_subset_none():
     """Ensure subset none works for apply CLI"""
     test_config = ApplicationConfiguration(
         application_name="test_application",
+        application_version="1.0",
         internals=Internals(),
         post_processor=None,
         subcommands=[

--- a/tests/unit/configuration_subsystem/test_sample_configurations.py
+++ b/tests/unit/configuration_subsystem/test_sample_configurations.py
@@ -48,6 +48,7 @@ def test_no_subcommand():
     """Ensure a configuration without no ``subparser`` entry fails"""
     test_config = ApplicationConfiguration(
         application_name="test_config1",
+        application_version="1.0",
         internals=Internals(),
         post_processor=None,
         subcommands=[
@@ -63,6 +64,7 @@ def test_many_subcommand():
     """Ensure a configuration without a ``subparser`` entry fails"""
     test_config = ApplicationConfiguration(
         application_name="test_config1",
+        application_version="1.0",
         internals=Internals(),
         post_processor=None,
         subcommands=[
@@ -117,6 +119,7 @@ def test_custom_nargs_for_positional():
     """Ensure a ``nargs`` for a positional are carried forward"""
     test_config = ApplicationConfiguration(
         application_name="test_config1",
+        application_version="1.0",
         post_processor=None,
         subcommands=[
             SubCommand(name="subcommand1", description="subcommand1"),


### PR DESCRIPTION
Rather than importing `_version` from multiple locations, simply  populate the `NavigatorConfiguration.application_version` and use that.

In the case a `_version.py` file is not available, simple use the default value of `Constants.NOT_SET`