### PR TITLE
Reorder import of key_value_store

### DIFF
--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -14,7 +14,6 @@ from collections import OrderedDict
 from datetime import datetime
 from json.decoder import JSONDecodeError
 from pathlib import Path
-from typing import TYPE_CHECKING
 from typing import Dict
 from typing import Generator
 from typing import List

--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -14,7 +14,8 @@ from collections import OrderedDict
 from datetime import datetime
 from json.decoder import JSONDecodeError
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
+from typing import Dict
 from typing import Generator
 from typing import List
 from typing import Tuple

--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -31,7 +31,9 @@ except ImportError:
     from yaml import SafeLoader  # type: ignore
 
 try:
-    from key_value_store import KeyValueStore  # type: ignore[import] # Not present unless in an EE
+    from key_value_store import (
+        KeyValueStore,  # type: ignore[import] # Not present unless in an EE
+    )
 except ImportError:
     from ansible_navigator.utils.key_value_store import KeyValueStore
 

--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 from datetime import datetime
 from json.decoder import JSONDecodeError
 from pathlib import Path
-from typing import Dict
+from typing import TYPE_CHECKING, Dict
 from typing import Generator
 from typing import List
 from typing import Tuple
@@ -30,10 +30,13 @@ try:
 except ImportError:
     from yaml import SafeLoader  # type: ignore
 
-try:
-    from key_value_store import KeyValueStore
-except ImportError:
+if TYPE_CHECKING:
     from ansible_navigator.utils.key_value_store import KeyValueStore
+else:
+    try:
+        from key_value_store import KeyValueStore
+    except ImportError:
+        from ansible_navigator.utils.key_value_store import KeyValueStore
 
 
 # pylint: enable=import-error

--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -31,8 +31,8 @@ except ImportError:
     from yaml import SafeLoader  # type: ignore
 
 try:
-    from key_value_store import (
-        KeyValueStore,  # type: ignore[import] # Not present unless in an EE
+    from key_value_store import (  # type: ignore[import] # Not present unless in an EE
+        KeyValueStore,
     )
 except ImportError:
     from ansible_navigator.utils.key_value_store import KeyValueStore

--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -31,13 +31,11 @@ try:
 except ImportError:
     from yaml import SafeLoader  # type: ignore
 
-if TYPE_CHECKING:
+
+try:
+    from key_value_store import KeyValueStore  # type: ignore[import] # Not present unless in an EE
+except ImportError:
     from ansible_navigator.utils.key_value_store import KeyValueStore
-else:
-    try:
-        from key_value_store import KeyValueStore
-    except ImportError:
-        from ansible_navigator.utils.key_value_store import KeyValueStore
 
 
 # pylint: enable=import-error

--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -14,6 +14,7 @@ from collections import OrderedDict
 from datetime import datetime
 from json.decoder import JSONDecodeError
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Dict
 from typing import Generator
 from typing import List
@@ -30,15 +31,17 @@ try:
 except ImportError:
     from yaml import SafeLoader  # type: ignore
 
+# Import from the source tree whenever possible. When running
+# in an execution environment, and therefore not type checking
+# import from the key_value_store which was injected in the path.
+# The TYPE_CHECKING conditional prevents mypy from attempting the
+# import and cause an import error.
 try:
-    from key_value_store import (  # type: ignore[import] # Not present unless in an EE
-        KeyValueStore,
-    )
-except ImportError:
     from ansible_navigator.utils.key_value_store import KeyValueStore
+except ImportError:
+    if not TYPE_CHECKING:
+        from key_value_store import KeyValueStore
 
-
-# pylint: enable=import-error
 
 PROCESSES = (multiprocessing.cpu_count() - 1) or 1
 

--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -35,7 +35,7 @@ except ImportError:
 # in an execution environment, and therefore not type checking
 # import from the key_value_store which was injected in the path.
 # The TYPE_CHECKING conditional prevents mypy from attempting the
-# import and cause an import error.
+# import and causing an import error.
 try:
     from ansible_navigator.utils.key_value_store import KeyValueStore
 except ImportError:

--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -30,7 +30,6 @@ try:
 except ImportError:
     from yaml import SafeLoader  # type: ignore
 
-
 try:
     from key_value_store import KeyValueStore  # type: ignore[import] # Not present unless in an EE
 except ImportError:


### PR DESCRIPTION
The file only exists when running in an EE, not during type checking.

Not previously caught as we still ignore import errors, this is another small fix on the path to remove that.