### PR TITLE
Centralize json dump and dumps

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,6 +104,7 @@ nitpick_ignore = [
     ("py:class", "Form"),
     ("py:class", "Grammar"),
     ("py:class", "Grammars"),
+    ("py:class", "IO"),
     ("py:class", "Match"),
     ("py:class", "multiprocessing.context.BaseContext.Queue"),
     ("py:class", "NavigatorPostProcessor"),

--- a/src/ansible_navigator/actions/open_file.py
+++ b/src/ansible_navigator/actions/open_file.py
@@ -1,6 +1,5 @@
 """``:open`` command implementation."""
 import curses
-import json
 import logging
 import os
 import tempfile
@@ -16,6 +15,7 @@ from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
 from ..ui_framework import Menu
 from ..utils import remove_dbl_un
+from ..utils.serialize import json_dump
 from . import _actions as actions
 
 
@@ -111,7 +111,7 @@ class Action:
                 with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as temp_file:
                     filename = temp_file.name
                     with open(filename, "w", encoding="utf-8") as fh:
-                        json.dump(obj, fh, indent=4, sort_keys=True)
+                        json_dump(obj, fh)
             else:
                 with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as temp_file:
                     filename = temp_file.name

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -37,6 +37,7 @@ from ..utils import abs_user_path
 from ..utils import human_time
 from ..utils import remove_ansi
 from ..utils import round_half_up
+from ..utils.serialize import json_dump
 from . import _actions as actions
 from . import run_action
 
@@ -860,7 +861,7 @@ class Action(ActionBase):
                         "status": status,
                         "status_color": status_color,
                     }
-                    json.dump(artifact, fh, indent=4)
+                    json_dump(artifact, fh)
                     self._logger.info("Saved artifact as %s", filename)
 
             except (IOError, OSError) as exc:

--- a/src/ansible_navigator/actions/write_file.py
+++ b/src/ansible_navigator/actions/write_file.py
@@ -1,5 +1,4 @@
 """``:write`` command implementation."""
-import json
 import logging
 import os
 import re
@@ -9,6 +8,7 @@ from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..ui_framework import Interaction
 from ..utils import remove_dbl_un
+from ..utils.serialize import json_dump
 from . import _actions as actions
 
 
@@ -86,7 +86,7 @@ class Action:
             human_dump(obj=obj, filename=filename, file_mode=file_mode)
         elif write_as == "json":
             with open(os.path.abspath(filename), file_mode, encoding="utf-8") as fh:
-                json.dump(obj, fh, indent=4, sort_keys=True)
+                json_dump(obj, fh)
                 fh.write("\n")
 
         self._logger.info("Wrote to '%s' with mode '%s' as '%s'", filename, file_mode, write_as)

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -2,7 +2,6 @@
 """the main UI renderer
 """
 import curses
-import json
 import logging
 import re
 
@@ -23,6 +22,7 @@ from typing import Union
 
 from .._yaml import human_dump
 from ..utils import templar
+from ..utils.serialize import json_dumps
 from .colorize import Colorize
 from .colorize import rgb_to_ansi
 from .curses_defs import CursesLine
@@ -504,7 +504,7 @@ class UserInterface(CursesWindow):
         if self.serialization_format() == "source.yaml":
             string = human_dump(obj)
         elif self.serialization_format() == "source.json":
-            string = json.dumps(obj, indent=4, sort_keys=True, ensure_ascii=False)
+            string = json_dumps(obj)
         else:
             string = obj
 

--- a/src/ansible_navigator/utils/serialize.py
+++ b/src/ansible_navigator/utils/serialize.py
@@ -1,0 +1,36 @@
+"""Abstractions for common serialization formats."""
+
+from functools import lru_cache
+import json
+from typing import Any
+from typing import IO
+from typing import NamedTuple
+
+
+class JsonParams(NamedTuple):
+    """The parameters for json dump and dumps."""
+
+    indent: int = 4
+    sort_keys: bool = True
+    ensure_ascii: bool = False
+
+
+def json_dump(dumpable: Any, file_handle: IO, params: NamedTuple = JsonParams()) -> None:
+    """Serialize and write the dumpable to a file.
+
+    :param dumpable: The object to serialize
+    :param file_handle: The file handle to write to
+    :param params: Parameters to override the defaults
+    """
+    json.dump(dumpable, file_handle, **params._asdict())
+
+
+def json_dumps(dumpable: Any, params: NamedTuple = JsonParams()) -> str:
+    """Serialize the dumpable to json.
+
+    :param dumpable: The object to serialize
+    :param params: Parameters to override the defaults
+    :returns: The object serialized
+    """
+    string = json.dumps(dumpable, **params._asdict())
+    return string

--- a/src/ansible_navigator/utils/serialize.py
+++ b/src/ansible_navigator/utils/serialize.py
@@ -1,8 +1,9 @@
 """Abstractions for common serialization formats."""
 
 import json
-from typing import Any
+
 from typing import IO
+from typing import Any
 from typing import NamedTuple
 
 

--- a/src/ansible_navigator/utils/serialize.py
+++ b/src/ansible_navigator/utils/serialize.py
@@ -1,6 +1,5 @@
 """Abstractions for common serialization formats."""
 
-from functools import lru_cache
 import json
 from typing import Any
 from typing import IO


### PR DESCRIPTION
Centralizes the json dumping into one location, to prevent issues like the below and will allow for a different encoder in one place.

Fixes #1003 


(yaml can be moved into this file as well to centralize all serializers)