### PR TITLE
Align the RTD config file to the schema, upgrade to python 3.10 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,21 +1,23 @@
 # https://docs.readthedocs.io/en/stable/config-file/v2.html
-
 ---
-
 version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.10"
+
+formats: all
+
+python:
+  install:
+    - method: pip
+      path: .
+    - requirements: docs/requirements.in
+  system_packages: false
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: dirhtml
   configuration: docs/conf.py
   fail_on_warning: true
-
-formats: all
-
-python:
-  version: 3.8
-  install:
-  - method: pip
-    path: .
-  - requirements: docs/requirements.in
-  system_packages: false


### PR DESCRIPTION
This aligns the RTD config to the spec of their json schema file.

Formatting changes to align with the RH yaml extension/LS

Additionally upgrade the interpreter version to 3.10.

Also alphabetized the entries, with the exception of the version which was relevant to the comment up to.