### PR TITLE
Add toml support to prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,9 @@ repos:
             .*\.md|
             .*\.yml
           )$
+        additional_dependencies:
+          - prettier
+          - prettier-plugin-toml
 
   - repo: https://github.com/psf/black.git
     rev: 22.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,50 +1,3 @@
-[tool.towncrier]
-  directory = "docs/changelog-fragments.d/"
-  filename = "CHANGELOG.md"
-  issue_format = "{{issue}}`{issue}`"
-  start_string = "<!-- towncrier release notes start -->\n\n"
-  template = "docs/changelog-fragments.d/.CHANGELOG-TEMPLATE.md.j2"
-  title_format = "## [{version}] - {project_date}"
-  underlines = ["##", "###", "####", "#####"]
-
-  [[tool.towncrier.section]]
-    path = ""
-
-  [[tool.towncrier.type]]
-    directory = "bugfix"
-    name = "Bugfixes"
-    showcontent = true
-
-  [[tool.towncrier.type]]
-    directory = "feature"
-    name = "Features"
-    showcontent = true
-
-  [[tool.towncrier.type]]
-    directory = "deprecation"
-    name = "Deprecations (removal in next major release)"
-    showcontent = true
-
-  [[tool.towncrier.type]]
-    directory = "breaking"
-    name = "Backward incompatible changes"
-    showcontent = true
-
-  [[tool.towncrier.type]]
-    directory = "doc"
-    name = "Documentation"
-    showcontent = true
-
-  [[tool.towncrier.type]]
-    directory = "misc"
-    name = "Miscellaneous"
-    showcontent = true
-
-  [[tool.towncrier.type]]
-    directory = "internal"
-    name = "Contributor-facing changes"
-    showcontent = true
-
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
@@ -56,16 +9,18 @@ requires = [
   "setuptools_scm_git_archive >= 1.1",
 ]
 
+[tool]
+
 [tool.black]
 line-length = 100
 
-[tool.coverage.run]
-    branch = true
-    source_pkgs = ["ansible_navigator"]
-    source = ["share"]
-
 [tool.coverage.report]
-    show_missing = true
+show_missing = true
+
+[tool.coverage.run]
+branch = true
+source_pkgs = ["ansible_navigator"]
+source = ["share"]
 
 [tool.isort]
 force_single_line = true # Force from .. import to be 1 per line, minimizing changes at time of implementation
@@ -77,36 +32,84 @@ profile = "black" # Avoid conflict with black
 skip_glob = ["tests/fixtures/common/collections*"] # Skip ansible content due to ansible-test sanity ruleset
 
 [tool.pylint]
-    [tool.pylint.imports]
-    preferred-modules = [
+
+[tool.pylint.format]
+max-line-length = 100
+
+[tool.pylint.imports]
+preferred-modules = [
       # NOTE: The unittest replacements below help keep
       # NOTE: the tests pytest ecosystem-oriented.
       "unittest:pytest",
       "unittest.mock:pytest-mock",
     ]
 
-    [tool.pylint.master]
-    ignore = [
+[tool.pylint.master]
+ignore = [
       "_version.py", # built by setuptools_scm
       "tm_tokenize", # tm_tokenize is virtually vendored and shouldn't be linted as such
     ]
-    # pylint defaults + fh for with open .. as (f|fh)
-    good-names = "i,j,k,ex,Run,_,f,fh"
-    jobs = 0
+# pylint defaults + fh for with open .. as (f|fh)
+good-names = "i,j,k,ex,Run,_,f,fh"
+jobs = 0
 
-    [tool.pylint.messages_control]
-    disable = [
+[tool.pylint.messages_control]
+disable = [
       "duplicate-code",
       "fixme",
       "too-few-public-methods",
       "unsubscriptable-object",
     ]
-    enable = [
+enable = [
       "useless-suppression",  # Identify unneeded pylint disable statements
     ]
 
-    [tool.pylint.format]
-    max-line-length = 100
-
 [tool.setuptools_scm]
 write_to = "src/ansible_navigator/_version.py"
+
+[tool.towncrier]
+directory = "docs/changelog-fragments.d/"
+filename = "CHANGELOG.md"
+issue_format = "{{issue}}`{issue}`"
+start_string = "<!-- towncrier release notes start -->\n\n"
+template = "docs/changelog-fragments.d/.CHANGELOG-TEMPLATE.md.j2"
+title_format = "## [{version}] - {project_date}"
+underlines = ["##", "###", "####", "#####"]
+
+[[tool.towncrier.section]]
+path = ""
+
+[[tool.towncrier.type]]
+directory = "bugfix"
+name = "Bugfixes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "Features"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecation"
+name = "Deprecations (removal in next major release)"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Backward incompatible changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "doc"
+name = "Documentation"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "misc"
+name = "Miscellaneous"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "internal"
+name = "Contributor-facing changes"
+showcontent = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ build-backend = "setuptools.build_meta"
 requires = [
   # Essentials
   "setuptools >= 45",
-
   # Plugins
   "setuptools_scm[toml] >= 6.2",
   "setuptools_scm_git_archive >= 1.1",
@@ -27,9 +26,11 @@ force_single_line = true # Force from .. import to be 1 per line, minimizing cha
 known_first_party = "ansible_navigator, key_value_store" # No effect at implementation, here anticipating future benefit
 lines_after_imports = 2 # Ensures consistency for cases when there's variable vs function/class definitions after imports
 lines_between_types = 1 # Separate import/from with 1 line, minimizing changes at time of implementation
-no_lines_before = "LOCALFOLDER"  # Keeps local imports bundled with first-party
+no_lines_before = "LOCALFOLDER" # Keeps local imports bundled with first-party
 profile = "black" # Avoid conflict with black
-skip_glob = ["tests/fixtures/common/collections*"] # Skip ansible content due to ansible-test sanity ruleset
+skip_glob = [
+  "tests/fixtures/common/collections*"
+] # Skip ansible content due to ansible-test sanity ruleset
 
 [tool.pylint]
 
@@ -38,31 +39,33 @@ max-line-length = 100
 
 [tool.pylint.imports]
 preferred-modules = [
-      # NOTE: The unittest replacements below help keep
-      # NOTE: the tests pytest ecosystem-oriented.
-      "unittest:pytest",
-      "unittest.mock:pytest-mock",
-    ]
+  # NOTE: The unittest replacements below help keep
+  # NOTE: the tests pytest ecosystem-oriented.
+  "unittest:pytest",
+  "unittest.mock:pytest-mock",
+]
 
 [tool.pylint.master]
 ignore = [
-      "_version.py", # built by setuptools_scm
-      "tm_tokenize", # tm_tokenize is virtually vendored and shouldn't be linted as such
-    ]
+  "_version.py", # built by setuptools_scm
+  "tm_tokenize", # tm_tokenize is virtually vendored and shouldn't be linted as such
+
+]
 # pylint defaults + fh for with open .. as (f|fh)
 good-names = "i,j,k,ex,Run,_,f,fh"
 jobs = 0
 
 [tool.pylint.messages_control]
 disable = [
-      "duplicate-code",
-      "fixme",
-      "too-few-public-methods",
-      "unsubscriptable-object",
-    ]
+  "duplicate-code",
+  "fixme",
+  "too-few-public-methods",
+  "unsubscriptable-object",
+]
 enable = [
-      "useless-suppression",  # Identify unneeded pylint disable statements
-    ]
+  "useless-suppression", # Identify unneeded pylint disable statements
+
+]
 
 [tool.setuptools_scm]
 write_to = "src/ansible_navigator/_version.py"


### PR DESCRIPTION
The pyproject.toml file was fist sorted using: https://pypi.org/project/toml-sort/

Some comments had to be restored after that, but it was a good start.

The remaining change were made by the toml plugin for prettier.

Works well with: https://marketplace.visualstudio.com/items?itemName=bodil.prettier-toml

Related: https://github.com/ansible-community/devtools/issues/31