### PR TITLE
Add yml to prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,7 @@ repos:
             tests/fixtures/integration/actions/.*\.json|
             share/ansible_navigator/grammar/.*\.json|
             share/ansible_navigator/themes/.*\.json|
-            .*\.md|
-            .*\.yml
+            .*\.md
           )$
 
   - repo: https://github.com/psf/black.git


### PR DESCRIPTION
The only change here was the removal of the yml exclusion for prettier.

Other changes made by the pre-commit hook.