### PR TITLE
Remove ignore missing imports for mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -189,6 +189,7 @@ repos:
         alias: mypy-py36
         name: MyPy, for Python 3.6
         additional_dependencies:
+          - importlib_resources # Needed for checking py3.6 with a later interpreter
           - jinja2
           - libtmux
           - pytest

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,8 +4,6 @@ files =
   share/,
   src/,
   tests/
-# FIXME: get rid of missing imports ignore
-ignore_missing_imports = true
 install_types = true
 namespace_packages = true
 non_interactive = true
@@ -18,4 +16,10 @@ show_error_context = true
 
 [mypy-libtmux]
 # No type hints as of version 0.10.3
+ignore_missing_imports = True
+
+[mypy-setuptools_scm]
+# No type hints as of version 6.4.2
+# See docs/conf.py for an explanation of why the recommencted
+# use of importlib.metadata is not possible.
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,6 +20,6 @@ ignore_missing_imports = True
 
 [mypy-setuptools_scm]
 # No type hints as of version 6.4.2
-# See docs/conf.py for an explanation of why the recommencted
+# See docs/conf.py for an explanation of why the recommended
 # use of importlib.metadata is not possible.
 ignore_missing_imports = True


### PR DESCRIPTION
This removes the `ignore_missing_imports` for mypy, and accommodates `setuptools_scm` which is required now for doc/conf.py.