### PR TITLE
Centralize mypy `ignore[import]` statements

### DIFF
--- a/docs/_ext/single_sourced_data.py
+++ b/docs/_ext/single_sourced_data.py
@@ -92,7 +92,7 @@ def _nodes_from_rst(
         ),
         node=node,
     )
-    return node.children  # type: ignore
+    return node.children
 
 
 def _rst_generate_row(row: Tuple) -> List:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,7 +143,7 @@ extensions = [
 
 # Conditional third-party extensions:
 try:
-    import sphinxcontrib.spelling as _sphinxcontrib_spelling  # type: ignore[import]
+    import sphinxcontrib.spelling as _sphinxcontrib_spelling
 except ImportError:
     extensions.append("spelling_stub_ext")
 else:

--- a/mypy.ini
+++ b/mypy.ini
@@ -14,12 +14,29 @@ show_error_context = true
 # strict = true
 # strict_optional = true
 
+[mypy-ansible.*]
+# No type hints as of version 2.12
+ignore_missing_imports = true
+
+[mypy-ansible_runner]
+# No type hints as of version 2.1.2
+ignore_missing_imports = true
+
 [mypy-libtmux]
 # No type hints as of version 0.10.3
-ignore_missing_imports = True
+ignore_missing_imports = true
+
+[mypy-onigurumacffi]
+# No type hints as of version 1.1.0
+ignore_missing_imports = true
 
 [mypy-setuptools_scm]
 # No type hints as of version 6.4.2
 # See docs/conf.py for an explanation of why the recommended
 # use of importlib.metadata is not possible.
-ignore_missing_imports = True
+ignore_missing_imports = true
+
+[mypy-sphinxcontrib.*]
+# Covers sphinxcontrib.spelling in docs/conf.py
+# Not type hints as of version 7.3.2
+ignore_missing_imports = true

--- a/share/ansible_navigator/utils/catalog_collections.py
+++ b/share/ansible_navigator/utils/catalog_collections.py
@@ -22,14 +22,14 @@ from typing import Tuple
 
 import yaml
 
-from ansible.utils.plugin_docs import get_docstring  # type: ignore
+from ansible.utils.plugin_docs import get_docstring
 from yaml.error import YAMLError
 
 
 try:
     from yaml import CSafeLoader as SafeLoader
 except ImportError:
-    from yaml import SafeLoader  # type: ignore
+    from yaml import SafeLoader  # type: ignore[misc]
 
 # Import from the source tree whenever possible. When running
 # in an execution environment, and therefore not type checking
@@ -242,7 +242,7 @@ def worker(pending_queue: multiprocessing.Queue, completed_queue: multiprocessin
     # pylint: disable=import-outside-toplevel
 
     # load the fragment_loader _after_ the path is set
-    from ansible.plugins.loader import fragment_loader  # type: ignore
+    from ansible.plugins.loader import fragment_loader
 
     while True:
         entry = pending_queue.get()

--- a/src/ansible_navigator/runner/ansible_config.py
+++ b/src/ansible_navigator/runner/ansible_config.py
@@ -5,7 +5,7 @@ to run the ansible-config command
 from typing import Optional
 from typing import Tuple
 
-from ansible_runner import get_ansible_config  # type: ignore[import]
+from ansible_runner import get_ansible_config
 
 from .base import Base
 

--- a/src/ansible_navigator/runner/ansible_doc.py
+++ b/src/ansible_navigator/runner/ansible_doc.py
@@ -8,7 +8,7 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
-from ansible_runner import get_plugin_docs  # type: ignore[import]
+from ansible_runner import get_plugin_docs
 
 from .base import Base
 

--- a/src/ansible_navigator/runner/ansible_inventory.py
+++ b/src/ansible_navigator/runner/ansible_inventory.py
@@ -6,7 +6,7 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
-from ansible_runner import get_inventory  # type: ignore[import]
+from ansible_runner import get_inventory
 
 from .base import Base
 

--- a/src/ansible_navigator/runner/base.py
+++ b/src/ansible_navigator/runner/base.py
@@ -17,7 +17,7 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-from ansible_runner import Runner  # type: ignore[import]
+from ansible_runner import Runner
 
 
 class Base:

--- a/src/ansible_navigator/runner/command.py
+++ b/src/ansible_navigator/runner/command.py
@@ -3,7 +3,7 @@ run a command in a synchronous manner
 """
 from typing import Tuple
 
-from ansible_runner import run_command  # type: ignore[import]
+from ansible_runner import run_command
 
 from .command_base import CommandBase
 

--- a/src/ansible_navigator/runner/command_async.py
+++ b/src/ansible_navigator/runner/command_async.py
@@ -8,7 +8,7 @@ queue with messages.
 
 from queue import Queue
 
-from ansible_runner import run_command_async  # type: ignore[import]
+from ansible_runner import run_command_async
 
 from .command_base import CommandBase
 

--- a/src/ansible_navigator/tm_tokenize/reg.py
+++ b/src/ansible_navigator/tm_tokenize/reg.py
@@ -6,7 +6,7 @@ from typing import Match
 from typing import Optional
 from typing import Tuple
 
-import onigurumacffi  # type: ignore[import]
+import onigurumacffi
 
 from .region import Region
 


### PR DESCRIPTION
Centralize the mypy ignore import statements into the mypy.ini file.

This will make it easier to maintain, explain and audit the 3rd packages that are not typed.

One type was clarified as well, to ensure it doesn't get researched as an import error in the future.