### PR TITLE
Fix color resolution issue

### DIFF
--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -74,7 +74,7 @@ class ColorSchema:
                 if color:
                     foreground = color.get("settings", {}).get("foreground", None)
                     # Without decoration support, continue resolving to a until we find a
-                    # forground color or ultimately return None. This currently completely
+                    # foreground color or ultimately return None. This currently completely
                     # ignores font styles.
                     # e.g. color={'scope': 'strong', 'settings': {'fontStyle': 'bold'}}
                     if foreground is not None:

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -47,6 +47,7 @@ class ColorSchema:
 
         :param schema: The color scheme, theme to use
         """
+        self._logger = logging.getLogger(__name__)
         self._schema = schema
 
     @functools.lru_cache(maxsize=None)
@@ -72,7 +73,13 @@ class ColorSchema:
                 )
                 if color:
                     foreground = color.get("settings", {}).get("foreground", None)
-                    return hex_to_rgb(foreground)
+                    # Without decoration support, continue resolving to a until we find a
+                    # forground color or ultimately return None. This currently completely
+                    # ignores font styles.
+                    # e.g. color={'scope': 'strong', 'settings': {'fontStyle': 'bold'}}
+                    if foreground is not None:
+                        return hex_to_rgb(foreground)
+                    self._logger.debug("Color resolution continued: %s", color)
         return None
 
 

--- a/tests/unit/ui_framework/test_colorize.py
+++ b/tests/unit/ui_framework/test_colorize.py
@@ -46,6 +46,24 @@ def test_basic_success_yaml():
     assert "".join(line_part.chars for line_part in result[1]) == sample.splitlines()[1]
 
 
+def test_basic_success_log():
+    """Ensure the log string is returned as 1 line, with 5 parts.
+
+    Also ensure the parts can be reassembled to match the string.
+    """
+    sample = "1 ERROR text 42"
+
+    result = Colorize(grammar_dir=GRAMMAR_DIR, theme_path=THEME_PATH).render(
+        doc=sample,
+        scope="text.log",
+    )
+    assert len(result) == 1
+    first_line = result[0]
+    line_parts = tuple(p.chars for p in first_line)
+    assert line_parts == ("1", " ", "ERROR", " text ", "42")
+    assert "".join(line_parts) == sample
+
+
 def test_basic_success_no_color():
     """Ensure scope ``no_color`` return just lines."""
     sample = json.dumps({"test": "data"})


### PR DESCRIPTION
https://github.com/ansible/ansible-navigator/commit/c92f3b81f3b01910b7d37b43f476f5a10f296def#diff-3d34285d5669d838670a1586c158a7bd0b1087b93a5e1f4a625288dda34cb28fL159

Originally, if the color was `None` we simply returned `None` and continued resolution past font style, until  color was found.

When the conditional was removed, and an intermediate fontstyle was found in the scope:

` color={'scope': 'strong', 'settings': {'fontStyle': 'bold'}}`

The foregound color was `None` and the following occurred:

```
  File "/Users/rick/dev/ansible/ansible-navigator/src/ansible_navigator/ui_framework/colorize.py", line 178, in hex_to_rgb
    value = value.lstrip("#")
AttributeError: 'NoneType' object has no attribute 'lstrip'
```

The fix is to continue resolution until a scope entry with a foreground color is found, or return `None`.

Test created served as a reproducer prior to the fix.