### PR TITLE
Prefer `thing.get(key)` over `thing[key]` in ui.py

### DIFF
--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -716,7 +716,7 @@ class UserInterface(CursesWindow):
         :return: True if a match else False
         """
         for key in columns:
-            if self._search_value(self.menu_filter(), obj[key]):
+            if self._search_value(self.menu_filter(), obj.get(key)):
                 return True
         return False
 


### PR DESCRIPTION
This change is being broken out of #957 to reduce what is found in that PR. 

In preparation for the UI taking a list of dataclasses in addition to a list of dictionaries, we need to make sure we are not assuming the objects in the list are subscriptable and instead use a get method against them.

Although not an ideal long term stance, any dataclass provided to the UI will need to support a `get()`.

Rather than add a `super()._getattribute__` this felt like a cleaner approach:

```
@dataclass
class Data:
    a: int
    b: int

    def __getitem__(self, key):
        return super().__getattribute__(key)

    def get(self, attr):
        return getattr(self, attr)

t1 = Data(1, 2)

t1["a"]  # calls __getitem__

t1.get("a") # call get
```
