### PR TITLE
Define `CursesLine` and `CursesLines` as NewType (`:settings` related)

### DIFF
--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -19,6 +19,7 @@ from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..runner import Command
 from ..steps import Step
+from ..ui_framework import CursesLine
 from ..ui_framework import CursesLinePart
 from ..ui_framework import CursesLines
 from ..ui_framework import Interaction
@@ -52,23 +53,15 @@ def content_heading(obj: Any, screen_w: int) -> Union[CursesLines, None]:
     :param screen_w: The current screen width
     :return: The heading
     """
-    heading = []
     string = f"{obj['full_name'].upper()}: {obj['__description']}"
     string = string + (" " * (screen_w - len(string) + 1))
-
-    heading.append(
-        tuple(
-            [
-                CursesLinePart(
-                    column=0,
-                    string=string,
-                    color=2,
-                    decoration=curses.A_UNDERLINE,
-                ),
-            ],
-        ),
+    line_part = CursesLinePart(
+        column=0,
+        string=string,
+        color=2,
+        decoration=curses.A_UNDERLINE,
     )
-    return tuple(heading)
+    return CursesLines((CursesLine((line_part,)),))
 
 
 def filter_content_keys(obj: Dict[Any, Any]) -> Dict[Any, Any]:

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -19,6 +19,7 @@ from ..configuration_subsystem import ApplicationConfiguration
 from ..runner import AnsibleConfig
 from ..runner import Command
 from ..steps import Step
+from ..ui_framework import CursesLine
 from ..ui_framework import CursesLinePart
 from ..ui_framework import CursesLines
 from ..ui_framework import Interaction
@@ -51,7 +52,6 @@ def content_heading(obj: Any, screen_w: int) -> Union[CursesLines, None]:
     :param screen_w: The current screen width
     :return: The heading
     """
-    heading = []
     string = obj["option"].replace("_", " ")
     if obj["__default"] is False:
         string += f" (current: {obj['__current_value']})  (default: {obj['default']})"
@@ -62,19 +62,13 @@ def content_heading(obj: Any, screen_w: int) -> Union[CursesLines, None]:
 
     string = string + (" " * (screen_w - len(string) + 1))
 
-    heading.append(
-        tuple(
-            [
-                CursesLinePart(
-                    column=0,
-                    string=string,
-                    color=color,
-                    decoration=curses.A_UNDERLINE,
-                ),
-            ],
-        ),
+    line_part = CursesLinePart(
+        column=0,
+        string=string,
+        color=color,
+        decoration=curses.A_UNDERLINE,
     )
-    return tuple(heading)
+    return CursesLines((CursesLine((line_part,)),))
 
 
 def filter_content_keys(obj: Dict[Any, Any]) -> Dict[Any, Any]:

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -19,6 +19,7 @@ from ..configuration_subsystem import ApplicationConfiguration
 from ..configuration_subsystem import Constants as C
 from ..runner import AnsibleDoc
 from ..runner import Command
+from ..ui_framework import CursesLine
 from ..ui_framework import CursesLinePart
 from ..ui_framework import CursesLines
 from ..ui_framework import Interaction
@@ -53,18 +54,14 @@ class Action(ActionBase):
         empty_str = " " * (screen_w - len(plugin_str) + 1)
         heading_str = (plugin_str + empty_str).upper()
 
-        heading = (
-            (
-                CursesLinePart(
-                    column=0,
-                    string=heading_str,
-                    color=0,
-                    decoration=curses.A_UNDERLINE | curses.A_BOLD,
-                ),
-            ),
+        line_part = CursesLinePart(
+            column=0,
+            string=heading_str,
+            color=0,
+            decoration=curses.A_UNDERLINE | curses.A_BOLD,
         )
 
-        return heading
+        return CursesLines((CursesLine((line_part,)),))
 
     def run(self, interaction: Interaction, app: AppPublic) -> Union[Interaction, None]:
         """Execute the ``doc`` request for mode interactive.

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -16,6 +16,7 @@ from ..configuration_subsystem import ApplicationConfiguration
 from ..image_manager import inspect_all
 from ..runner import Command
 from ..steps import Step
+from ..ui_framework import CursesLine
 from ..ui_framework import CursesLinePart
 from ..ui_framework import CursesLines
 from ..ui_framework import Interaction
@@ -112,17 +113,13 @@ class Action(ActionBase):
 
         empty_str = " " * (screen_w - len(text) + 1)
         heading_str = (text + empty_str).upper()
-        heading = (
-            (
-                CursesLinePart(
-                    column=0,
-                    string=heading_str,
-                    color=color,
-                    decoration=curses.A_UNDERLINE | curses.A_BOLD,
-                ),
-            ),
+        line_part = CursesLinePart(
+            column=0,
+            string=heading_str,
+            color=color,
+            decoration=curses.A_UNDERLINE | curses.A_BOLD,
         )
-        return heading
+        return CursesLines((CursesLine((line_part,)),))
 
     def run(self, interaction: Interaction, app: AppPublic) -> Union[Interaction, None]:
         """Execute the ``images`` request for mode interactive.

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -19,6 +19,7 @@ from ..runner import AnsibleInventory
 from ..runner import Command
 from ..steps import Step
 from ..ui_framework import Color
+from ..ui_framework import CursesLine
 from ..ui_framework import CursesLinePart
 from ..ui_framework import CursesLines
 from ..ui_framework import Decoration
@@ -66,24 +67,17 @@ def content_heading(obj: Any, screen_w: int) -> Union[CursesLines, None]:
     :param screen_w: The current screen width
     :return: The heading
     """
-    heading = []
     host = obj["inventory_hostname"]
     operating_system = obj.get("ansible_network_os", obj.get("ansible_platform", ""))
     string = f"[{host}] {operating_system}"
     string = string + (" " * (screen_w - len(string) + 1))
-    heading.append(
-        tuple(
-            [
-                CursesLinePart(
-                    column=0,
-                    string=string,
-                    color=Color.BLACK,
-                    decoration=Decoration.UNDERLINE,
-                ),
-            ],
-        ),
+    line_part = CursesLinePart(
+        column=0,
+        string=string,
+        color=Color.BLACK,
+        decoration=Decoration.UNDERLINE,
     )
-    return tuple(heading)
+    return CursesLines((CursesLine((line_part,)),))
 
 
 def filter_content_keys(obj: Dict[Any, Any]) -> Dict[Any, Any]:

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -26,6 +26,7 @@ from ..app_public import AppPublic
 from ..configuration_subsystem import ApplicationConfiguration
 from ..runner import CommandAsync
 from ..steps import Step
+from ..ui_framework import CursesLine
 from ..ui_framework import CursesLinePart
 from ..ui_framework import CursesLines
 from ..ui_framework import Interaction
@@ -110,17 +111,17 @@ def content_heading(obj: Any, screen_w: int) -> Union[CursesLines, None]:
     """
 
     if isinstance(obj, dict) and "task" in obj:
-        heading = []
         detail = f"PLAY [{obj['play']}:{obj['__number']}] "
         stars = "*" * (screen_w - len(detail))
-        heading.append(
-            tuple([CursesLinePart(column=0, string=detail + stars, color=0, decoration=0)]),
+
+        line_1 = CursesLine(
+            (CursesLinePart(column=0, string=detail + stars, color=0, decoration=0),),
         )
 
         detail = f"TASK [{obj['task']}] "
         stars = "*" * (screen_w - len(detail))
-        heading.append(
-            tuple([CursesLinePart(column=0, string=detail + stars, color=0, decoration=0)]),
+        line_2 = CursesLine(
+            (CursesLinePart(column=0, string=detail + stars, color=0, decoration=0),),
         )
 
         if obj["__changed"] is True:
@@ -137,19 +138,11 @@ def content_heading(obj: Any, screen_w: int) -> Union[CursesLines, None]:
 
         string = f"{res}: [{obj['__host']}] {msg}"
         string = string + (" " * (screen_w - len(string) + 1))
-        heading.append(
-            tuple(
-                [
-                    CursesLinePart(
-                        column=0,
-                        string=string,
-                        color=color,
-                        decoration=curses.A_UNDERLINE,
-                    ),
-                ],
-            ),
+        line_3 = CursesLine(
+            (CursesLinePart(column=0, string=string, color=color, decoration=curses.A_UNDERLINE),),
         )
-        return tuple(heading)
+
+        return CursesLines((line_1, line_2, line_3))
     return None
 
 

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -105,7 +105,7 @@ class Colorize:
         :return: Lines ready to present using the TUI
         """
         lines = tuple(ansi_to_curses(line) for line in doc.splitlines())
-        return lines
+        return CursesLines(lines)
 
     @functools.lru_cache(maxsize=100)
     def render(self, doc: str, scope: str) -> List[List[SimpleLinePart]]:
@@ -346,4 +346,4 @@ def ansi_to_curses(line: str) -> CursesLine:
                 colno += len(part)
                 color = 0
                 style = 0
-    return tuple(printable)
+    return CursesLine(tuple(printable))

--- a/src/ansible_navigator/ui_framework/curses_defs.py
+++ b/src/ansible_navigator/ui_framework/curses_defs.py
@@ -3,6 +3,7 @@
 
 from dataclasses import dataclass
 from typing import NamedTuple
+from typing import NewType
 from typing import Optional
 from typing import Tuple
 
@@ -22,8 +23,11 @@ class CursesLinePart(NamedTuple):
     decoration: int
 
 
-CursesLine = Tuple[CursesLinePart, ...]
-CursesLines = Tuple[CursesLine, ...]
+CursesLine = NewType("CursesLine", Tuple[CursesLinePart, ...])
+"""One line of text ready for curses."""
+
+CursesLines = NewType("CursesLines", Tuple[CursesLine, ...])
+"""One or more lines of text ready for curses."""
 
 
 RgbTuple = Tuple[int, int, int]

--- a/src/ansible_navigator/ui_framework/form_handler_text.py
+++ b/src/ansible_navigator/ui_framework/form_handler_text.py
@@ -7,6 +7,7 @@ from curses import ascii as curses_ascii
 from curses.textpad import Textbox
 from typing import Tuple
 
+from .curses_defs import CursesLine
 from .curses_defs import CursesLinePart
 from .curses_window import CursesWindow
 from .sentinels import unknown
@@ -31,9 +32,8 @@ class FormHandlerText(CursesWindow, Textbox):
 
     def _paint_from_line_cache(self) -> None:
         """put the text from the line cache in the text input window"""
-        clp = CursesLinePart(0, self.input_line_cache[self.input_line_pointer], 0, 0)
-        cline = (clp,)
-        self._add_line(self.win, 0, cline)
+        line_part = CursesLinePart(0, self.input_line_cache[self.input_line_pointer], 0, 0)
+        self._add_line(self.win, 0, CursesLine((line_part,)))
         self.win.clrtoeol()
 
     def _adjust_line_pointer(self, amount: int) -> None:
@@ -86,8 +86,8 @@ class FormHandlerText(CursesWindow, Textbox):
         form_field = form_fields[idx]
 
         if form_field.response is not unknown:
-            clp = CursesLinePart(0, form_field.response, 0, 0)
-            self._add_line(self.win, 0, tuple([clp]))
+            line_part = CursesLinePart(0, form_field.response, 0, 0)
+            self._add_line(self.win, 0, CursesLine((line_part,)))
         else:
             self.win.move(0, 0)
 

--- a/src/ansible_navigator/ui_framework/form_presenter.py
+++ b/src/ansible_navigator/ui_framework/form_presenter.py
@@ -115,6 +115,8 @@ class FormPresenter(CursesWindow):
         ]
         for form_field in body_fields:
 
+            # pylint: disable=not-an-iterable
+            # https://github.com/PyCQA/pylint/issues/2296
             if isinstance(form_field, FieldInformation):
                 information_lines = self._generate_information(form_field)
                 for line in information_lines:
@@ -126,20 +128,26 @@ class FormPresenter(CursesWindow):
                 for line in message_lines:
                     lines.append((self._line_number, line))
                     self._line_number += 1
+            # pylint: enable=not-an-iterable
 
             elif isinstance(form_field, FieldText):
                 prompt = self._generate_prompt(form_field)
-                lines.append((self._line_number, prompt + self._generate_field_text(form_field)))
+                line = CursesLine((tuple(prompt + [self._generate_field_text(form_field)])))
+                lines.append((self._line_number, line))
                 self._line_number += 1
 
             elif isinstance(form_field, (FieldChecks, FieldRadio)):
                 prompt = self._generate_prompt(form_field)
                 option_lines = self._generate_field_options(form_field)
-                lines.append((self._line_number, prompt + tuple([option_lines[0]])))
+                # although option_lines[0] is a CursesLine, only it's first line part is needed
+                # because the prompt needs to be prepended to it
+                first_option_line_part = option_lines[0][0]
+                line = CursesLine((tuple(prompt + [first_option_line_part])))
+                lines.append((self._line_number, line))
                 self._line_number += 1
 
                 for option_line in option_lines[1:]:
-                    lines.append((self._line_number, tuple([option_line])))
+                    lines.append((self._line_number, CursesLine((option_line))))
                     self._line_number += 1
 
             error = self._generate_error(form_field)
@@ -170,19 +178,18 @@ class FormPresenter(CursesWindow):
                 color = 8
             else:
                 color = form_field.color
-            clp = CursesLinePart(far_right, string, color, 0)
-            line_parts.append(clp)
+            line_part = CursesLinePart(far_right, string, color, 0)
+            line_parts.append(line_part)
             far_right -= 1
-        return tuple(line_parts)
+        return CursesLine(tuple(line_parts))
 
     def _generate_error(self, form_field) -> Union[CursesLine, None]:
         if form_field.current_error:
-            clp = CursesLinePart(self._input_start, form_field.current_error, 9, 0)
-            return (clp,)
+            line_part = CursesLinePart(self._input_start, form_field.current_error, 9, 0)
+            return CursesLine((line_part,))
         return None
 
-    def _generate_field_options(self, form_field) -> CursesLine:
-        lines = []
+    def _generate_field_options(self, form_field) -> CursesLines:
         window = curses.newwin(
             len(form_field.options),
             self._field_win_width,
@@ -191,15 +198,16 @@ class FormPresenter(CursesWindow):
         )
         window.keypad(True)
         form_field.win = window
+        lines = []
         for option in form_field.options:
             option_code = option.ansi_code(form_field)
             color = 8 if option.disabled else 0
             text = f"{option_code} {str(option.text)}"
-            clp = CursesLinePart(self._input_start, text, color, 0)
-            lines.append((clp))
-        return tuple(lines)
+            line_part = CursesLinePart(self._input_start, text, color, 0)
+            lines.append(CursesLine((line_part,)))
+        return CursesLines(tuple(lines))
 
-    def _generate_field_text(self, form_field) -> CursesLine:
+    def _generate_field_text(self, form_field) -> CursesLinePart:
         window = curses.newwin(1, self._field_win_width, self._line_number, self._field_win_start)
         window.keypad(True)
         form_field.win = window
@@ -210,24 +218,25 @@ class FormPresenter(CursesWindow):
         else:
             text = str(form_field.value)
             color = 0
-        clp = CursesLinePart(self._input_start, text, color, 0)
-        return (clp,)
+        return CursesLinePart(self._input_start, text, color, 0)
 
     def _generate_horizontal_line(self) -> CursesLine:
-        clp = CursesLinePart(0, "\u2500" * self._form_width, 8, 0)
-        return (clp,)
+        line_part = CursesLinePart(0, "\u2500" * self._form_width, 8, 0)
+        return CursesLine((line_part,))
 
     @staticmethod
     def _generate_information(form_field) -> CursesLines:
-        lines = tuple((CursesLinePart(0, line, 0, 0),) for line in form_field.information)
-        return lines
+        lines = tuple(
+            CursesLine((CursesLinePart(0, line, 0, 0),)) for line in form_field.information
+        )
+        return CursesLines(lines)
 
     @staticmethod
     def _generate_messages(form_field) -> CursesLines:
-        lines = tuple((CursesLinePart(0, line, 0, 0),) for line in form_field.messages)
-        return lines
+        lines = tuple(CursesLine((CursesLinePart(0, line, 0, 0),)) for line in form_field.messages)
+        return CursesLines(lines)
 
-    def _generate_prompt(self, form_field) -> CursesLine:
+    def _generate_prompt(self, form_field) -> List[CursesLinePart]:
         prompt_start = self._prompt_end - len(form_field.full_prompt)
         if form_field.valid is True:
             color = 10
@@ -242,12 +251,11 @@ class FormPresenter(CursesWindow):
             0,
         )
         cl_separator = CursesLinePart(self._prompt_end, self._separator, color, 0)
-        line_parts = (cl_prompt, cl_default, cl_separator)
-        return line_parts
+        return [cl_prompt, cl_default, cl_separator]
 
     def _generate_title(self) -> CursesLine:
-        clp = CursesLinePart(0, self._form.title.upper(), self._form.title_color, 0)
-        return (clp,)
+        line_part = CursesLinePart(0, self._form.title.upper(), self._form.title_color, 0)
+        return CursesLine((line_part,))
 
     def present(self) -> "Form":
         """present the form to the user"""

--- a/src/ansible_navigator/ui_framework/menu_builder.py
+++ b/src/ansible_navigator/ui_framework/menu_builder.py
@@ -81,7 +81,7 @@ class MenuBuilder:
 
         menu_layout = tuple([col_starts, cols, adjusted_column_widths, header])
         menu_lines = self._menu_lines(dicts, menu_layout, indices)
-        return tuple([header]), menu_lines
+        return CursesLines(tuple([header])), menu_lines
 
     def _menu_header_line(self, menu_layout: Tuple[List, ...]) -> CursesLine:
         """Generate the menu header line
@@ -94,7 +94,10 @@ class MenuBuilder:
         :return: The menu header line
         """
         _column_starts, cols, _adjusted_column_widths = menu_layout
-        return tuple(self._menu_header_line_part(colno, menu_layout) for colno in range(len(cols)))
+        line_parts = tuple(
+            self._menu_header_line_part(colno, menu_layout) for colno in range(len(cols))
+        )
+        return CursesLine(line_parts)
 
     @staticmethod
     def _menu_header_line_part(colno: int, menu_layout: Tuple[List, ...]) -> CursesLinePart:
@@ -139,7 +142,7 @@ class MenuBuilder:
             * ``menu_layout[3]``: ``CursesLine``, the menu header, used to determine justification
         :return: The menu lines
         """
-        return tuple(self._menu_line(dicts[idx], menu_layout) for idx in indices)
+        return CursesLines(tuple(self._menu_line(dicts[idx], menu_layout) for idx in indices))
 
     def _menu_line(self, menu_entry: dict, menu_layout: Tuple[List, ...]) -> CursesLine:
         """Generate one the menu line
@@ -155,10 +158,11 @@ class MenuBuilder:
         """
         _column_starts, cols, _adjusted_column_widths, _header = menu_layout
         menu_line = (menu_entry.get(c) for c in cols)
-        return tuple(
+        line_parts = (
             self._menu_line_part(colno, coltext, menu_entry, menu_layout)
             for colno, coltext in enumerate(menu_line)
         )
+        return CursesLine(tuple(line_parts))
 
     def _menu_line_part(
         self,

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -283,7 +283,7 @@ class UserInterface(CursesWindow):
                     decoration=curses.A_REVERSE,
                 ),
             )
-        return tuple(footer)
+        return CursesLine(tuple(footer))
 
     def _scroll_bar(
         self,
@@ -316,7 +316,9 @@ class UserInterface(CursesWindow):
             self._add_line(
                 window=self._screen,
                 lineno=min(lineno, viewport_height + len_heading),
-                line=tuple([line_part]),
+                line=CursesLine(
+                    ((line_part,)),
+                ),
             )
 
     def _get_input_line(self) -> str:
@@ -328,7 +330,13 @@ class UserInterface(CursesWindow):
         form_field = FieldText(name="one_line", prompt="")
         clp = CursesLinePart(column=0, string=":", color=0, decoration=0)
         input_at = self._screen_height - 1  # screen y is zero based
-        self._add_line(window=self._screen, lineno=input_at, line=tuple([clp]))
+        self._add_line(
+            window=self._screen,
+            lineno=input_at,
+            line=CursesLine(
+                ((clp,)),
+            ),
+        )
         self._screen.refresh()
         self._one_line_input.win = curses.newwin(1, self._screen_width, input_at, 1)
         self._one_line_input.win.keypad(True)
@@ -369,7 +377,7 @@ class UserInterface(CursesWindow):
         :type await_input: bool
         :return: the key pressed
         """
-        heading = heading or ()
+        heading = heading or CursesLines(tuple())
         heading_len = len(heading)
         footer = self._footer(dict(**STANDARD_KEYS, **key_dict, **END_KEYS))
         footer_at = self._screen_height - 1  # screen is 0 based index
@@ -561,7 +569,7 @@ class UserInterface(CursesWindow):
         :params lines: The lines to transform
         :return: All lines colored
         """
-        return tuple(self._colored_line(line) for line in lines)
+        return CursesLines(tuple(self._colored_line(line) for line in lines))
 
     def _colored_line(self, line: List[SimpleLinePart]) -> CursesLine:
         """Color one line.
@@ -569,7 +577,9 @@ class UserInterface(CursesWindow):
         :param line: The line to color
         :returns: One line colored
         """
-        return tuple(self._colored_line_part(line_part) for line_part in line)
+        return CursesLine(
+            tuple(self._colored_line_part(line_part) for line_part in line),
+        )
 
     def _colored_line_part(self, line_part: SimpleLinePart) -> CursesLinePart:
         """Color one line part.
@@ -647,7 +657,7 @@ class UserInterface(CursesWindow):
             line_numbers = tuple(range(first_line_idx, last_line_idx + 1))
 
             entry = self._display(
-                lines=lines[first_line_idx : last_line_idx + 1],
+                lines=CursesLines(lines[first_line_idx : last_line_idx + 1]),
                 line_numbers=line_numbers,
                 heading=heading,
                 indent_heading=False,

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -328,13 +328,13 @@ class UserInterface(CursesWindow):
         """
         self.disable_refresh()
         form_field = FieldText(name="one_line", prompt="")
-        clp = CursesLinePart(column=0, string=":", color=0, decoration=0)
+        line_part = CursesLinePart(column=0, string=":", color=0, decoration=0)
         input_at = self._screen_height - 1  # screen y is zero based
         self._add_line(
             window=self._screen,
             lineno=input_at,
             line=CursesLine(
-                ((clp,)),
+                ((line_part,)),
             ),
         )
         self._screen.refresh()


### PR DESCRIPTION
Allows them to be used as if they were an instantiated class rather than referred to as an alias.
It cleans up the definitions and return values.

Minimal code change were made, limited to a var name change for consistency or the way the return value was generated.

TIL, Changed in version 3.10: NewType is now a class rather than a function. There is some additional runtime cost when calling NewType over a regular function. However, this cost will be reduced in 3.11.0.

https://docs.python.org/3/library/typing.html#newtype

