### PR TITLE
Remove docstring first check from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,6 @@ repos:
       - id: check-added-large-files
       - id: fix-byte-order-marker
       - id: check-case-conflict
-      - id: check-docstring-first
       - id: check-json
         exclude: |
           (?x)


### PR DESCRIPTION
It conflicts when the PEP257 attribute naming convention is used to document either a `TypeAlias` or `NewType`.

Related: https://github.com/pre-commit/pre-commit-hooks/issues/159

```String literals occurring immediately after a simple assignment at the top level of a module, class, or __init__ method are called "attribute docstrings".```
Ref: https://www.python.org/dev/peps/pep-0257/#id4

As seen here: https://results.pre-commit.ci/run/github/320052445/1646080610.D81bOX7LQLakCKvAoaxx_A

because of:

https://github.com/ansible/ansible-navigator/pull/1024/files#diff-876f32fdc126136789ecfd4484fd9e4950a5faf7fb8fa3cefcff7ac6f6b7ac50R27
