### PR TITLE
Building dataclass `TypedStep` into steps.py and building `TypedStep` unit tests (`:settings` related)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,6 +109,7 @@ pygments_style = "ansible"
 nitpicky = True
 nitpick_ignore = [
     ("py:class", "_Rule"),
+    ("py:class", "ansible_navigator.steps.T"),
     ("py:class", "ansible_navigator.tm_tokenize.fchainmap.TKey"),
     ("py:class", "ansible_navigator.tm_tokenize.fchainmap.TValue"),
     ("py:class", "ansible_navigator.tm_tokenize.utils.T"),
@@ -144,6 +145,7 @@ nitpick_ignore = [
     ("py:class", "Window"),
     ("py:class", "yaml.cyaml.CDumper"),
     ("py:class", "yaml.nodes.ScalarNode"),
+    ("py:obj", "ansible_navigator.steps.T"),
     ("py:obj", "ansible_navigator.tm_tokenize.fchainmap.TKey"),
     ("py:obj", "ansible_navigator.tm_tokenize.fchainmap.TValue"),
 ]

--- a/src/ansible_navigator/steps.py
+++ b/src/ansible_navigator/steps.py
@@ -19,7 +19,7 @@ class Step:
     # pylint: disable=too-many-arguments
     """One step in the flow of things.
 
-    This MappingStep below should be used for all new actions.
+    The ``TypedStep`` below should be used for all new actions.
     """
 
     def __init__(

--- a/src/ansible_navigator/steps.py
+++ b/src/ansible_navigator/steps.py
@@ -136,8 +136,7 @@ class StepType(Enum):
     CONTENT = "content"
 
 
-# pylint: disable=invalid-name
-T = TypeVar("T")
+T = TypeVar("T")  # pylint: disable=invalid-name
 
 
 @dataclass

--- a/src/ansible_navigator/steps.py
+++ b/src/ansible_navigator/steps.py
@@ -146,7 +146,7 @@ class TypedStep(Generic[T]):
     """One step in the flow of things.
 
     This should be used for new actions following the pattern of a
-    TypedDict for the user interface as seen in settings.
+    ``TypedDict`` for the user interface as seen in settings.
     """
 
     name: str
@@ -197,7 +197,7 @@ class TypedStep(Generic[T]):
     def selected(self) -> Optional[T]:
         """Return the selected item.
 
-        :return: the selected item
+        :return: The selected item
         """
         if self._index is None or not self._value:
             return None

--- a/src/ansible_navigator/steps.py
+++ b/src/ansible_navigator/steps.py
@@ -3,6 +3,7 @@
 from collections import deque
 from dataclasses import dataclass
 from dataclasses import field
+from enum import Enum
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -128,11 +129,19 @@ class Step:
             raise ValueError(f"wanted {want}, got {type(value)}")
 
 
-TValueType = TypeVar("TValueType")
+class StepType(Enum):
+    """Type of step, either menu or content."""
+
+    MENU = "menu"
+    CONTENT = "content"
+
+
+# pylint: disable=invalid-name
+T = TypeVar("T")
 
 
 @dataclass
-class TypedStep(Generic[TValueType]):
+class TypedStep(Generic[T]):
     # pylint: disable=too-many-instance-attributes
     """One step in the flow of things.
 
@@ -141,11 +150,11 @@ class TypedStep(Generic[TValueType]):
     """
 
     name: str
-    step_type: str
+    step_type: StepType
     _index_changed: bool = False
     _index: Optional[int] = None
     _value_changed: bool = False
-    _value: List[TValueType] = field(default_factory=list)
+    _value: List[T] = field(default_factory=list)
     columns: Optional[List[str]] = None
     select_func: Optional[Callable[[], "TypedStep"]] = None
     show_func: Optional[Callable[[], None]] = None
@@ -185,7 +194,7 @@ class TypedStep(Generic[TValueType]):
         self._index = index
 
     @property
-    def selected(self) -> Optional[TValueType]:
+    def selected(self) -> Optional[T]:
         """Return the selected item.
 
         :return: the selected item
@@ -195,7 +204,7 @@ class TypedStep(Generic[TValueType]):
         return self._value[self._index % len(self._value)]
 
     @property
-    def value(self) -> List[TValueType]:
+    def value(self) -> List[T]:
         """Return the value.
 
         :return: The value
@@ -203,7 +212,7 @@ class TypedStep(Generic[TValueType]):
         return self._value
 
     @value.setter
-    def value(self, value: List[TValueType]) -> None:
+    def value(self, value: List[T]) -> None:
         """Set the value and value changed if needed
 
         :param value: The value for this instance

--- a/tests/unit/test_typestep.py
+++ b/tests/unit/test_typestep.py
@@ -2,6 +2,7 @@
 
 from ansible_navigator.steps import TypedStep
 
+
 # Test variables
 
 # Select a test index for @property index test

--- a/tests/unit/test_typestep.py
+++ b/tests/unit/test_typestep.py
@@ -1,42 +1,61 @@
 """Tests for TypeStep class."""
 
+from dataclasses import dataclass
+
 from ansible_navigator.steps import TypedStep
 
 
-# Test variables
+# Test dataclass
+
+@dataclass
+class TSTestClass:
+    """A dataclass for testing TypedStep @property and @setter functions.
+
+    :attr attr_1: Test integer
+    :attr attr_2: Test string
+    """
+
+    attr_1: int
+    attr_2: str
+
 
 # Select a test index for @property index test
-TEST_INDEX = 1
+TEST_INDEX = 5
+
+# Dataclass objects contained in value attr for @value.setter test
+value_1 = TSTestClass(attr_1=1, attr_2="test element 1")
+value_2 = TSTestClass(attr_1=3, attr_2="test element 2")
 
 # TypedStep object for all tests
-TypedStepTest = TypedStep(name="test_menu", step_type="menu")
-
-# TypedStep objects contained in test_value list for @value.setter test
-TypedStep1 = TypedStep(name="test_element_one", step_type="menu")
-TypedStep2 = TypedStep(name="test_element_two", step_type="menu")
-test_value_list = [TypedStep1, TypedStep2]
+TypedStepTest1 = TypedStep[TSTestClass](name="test_menu", step_type="menu")
 
 
-def test_property_changed():
-    """Test for TypedStep @property changed() and setter."""
-    assert TypedStepTest.changed is False
-    TypedStepTest.changed = True
-    assert TypedStepTest.changed is True
+def test_property_setters():
+    """Test for TypedStep @properties and setters."""
+    # Test @changed.setter
+    assert TypedStepTest1.changed is False
+    TypedStepTest1.changed = True
+    assert TypedStepTest1.changed is True
 
+    # Reset
+    TypedStepTest1.changed = False
+    assert TypedStepTest1.changed is False
 
-def test_property_index():
-    """Test for TypedStep @property index() and setter."""
-    assert TypedStepTest.index is None
-    TypedStepTest.index = TEST_INDEX
-    assert TypedStepTest.index == TEST_INDEX
+    # Test @value.setter and @changed
+    TypedStepTest1.value = [value_1, value_2]
+    assert TypedStepTest1.value == [value_1, value_2]
+    assert TypedStepTest1.changed is True
 
+    # Reset
+    TypedStepTest1.changed = False
+    assert TypedStepTest1.changed is False
 
-def test_property_value():
-    """Test for TypedStep @property value() and setter."""
-    TypedStepTest.value = test_value_list
-    assert TypedStepTest.value == test_value_list
+    # Test @index and @index.setter and changed
+    TypedStepTest1.index = TEST_INDEX
+    assert TypedStepTest1.index == TEST_INDEX
+    assert TypedStepTest1.changed is True
 
 
 def test_property_selected():
     """Test for TypedStep @property selected()."""
-    assert TypedStepTest.selected == TypedStep2
+    assert TypedStepTest1.selected == value_2

--- a/tests/unit/test_typestep.py
+++ b/tests/unit/test_typestep.py
@@ -1,0 +1,41 @@
+"""Tests for TypeStep class."""
+
+from ansible_navigator.steps import TypedStep
+
+# Test variables
+
+# Select a test index for @property index test
+TEST_INDEX = 1
+
+# TypedStep object for all tests
+TypedStepTest = TypedStep(name="test_menu", step_type="menu")
+
+# TypedStep objects contained in test_value list for @value.setter test
+TypedStep1 = TypedStep(name="test_element_one", step_type="menu")
+TypedStep2 = TypedStep(name="test_element_two", step_type="menu")
+test_value_list = [TypedStep1, TypedStep2]
+
+
+def test_property_changed():
+    """Test for TypedStep @property changed() and setter."""
+    assert TypedStepTest.changed is False
+    TypedStepTest.changed = True
+    assert TypedStepTest.changed is True
+
+
+def test_property_index():
+    """Test for TypedStep @property index() and setter."""
+    assert TypedStepTest.index is None
+    TypedStepTest.index = TEST_INDEX
+    assert TypedStepTest.index == TEST_INDEX
+
+
+def test_property_value():
+    """Test for TypedStep @property value() and setter."""
+    TypedStepTest.value = test_value_list
+    assert TypedStepTest.value == test_value_list
+
+
+def test_property_selected():
+    """Test for TypedStep @property selected()."""
+    assert TypedStepTest.selected == TypedStep2

--- a/tests/unit/test_typestep.py
+++ b/tests/unit/test_typestep.py
@@ -30,6 +30,10 @@ value_2 = TSTestClass(attr_1=3, attr_2="test element 2")
 
 @pytest.fixture(name="test_step")
 def _test_step():
+    """Instantiate and set default attribute values for TypedStep test object.
+
+    :returns: Test fixture
+    """
     test_step = TypedStep[TSTestClass](name="test", step_type=StepType.MENU)
     test_step.value = [value_1, value_2]
     test_step.value = [value_1, value_2]  # produce it "unchanged"
@@ -41,7 +45,7 @@ def _test_step():
 def test_fixture(test_step):
     """Base test fixture test for the other tests.
 
-    :param test_step: test fixture
+    :param test_step: Test fixture
     """
     assert not test_step.changed
     assert test_step.index == 0
@@ -52,7 +56,7 @@ def test_fixture(test_step):
 def test_index(test_step):
     """Testing @property index and index.setter.
 
-    :param test_step: test fixture
+    :param test_step: Test fixture
     """
     test_step.index = 1
     assert test_step.index == 1
@@ -68,7 +72,7 @@ def test_index(test_step):
 def test_selected(test_step):
     """Testing @property selected.
 
-    :param test_step: test fixture
+    :param test_step: Test fixture
     """
     test_step.index = 1
     assert test_step.selected == value_2
@@ -79,7 +83,7 @@ def test_selected(test_step):
 def test_value(test_step):
     """Testing @property value and value.setter.
 
-    :param test_step: test fixture
+    :param test_step: Test fixture
     """
     assert not test_step.changed
     test_step.value = [value_2, value_2]

--- a/tests/unit/test_typestep.py
+++ b/tests/unit/test_typestep.py
@@ -2,10 +2,11 @@
 
 from dataclasses import dataclass
 
+import pytest
+
+from ansible_navigator.steps import StepType
 from ansible_navigator.steps import TypedStep
 
-
-# Test dataclass
 
 @dataclass
 class TSTestClass:
@@ -26,36 +27,64 @@ TEST_INDEX = 5
 value_1 = TSTestClass(attr_1=1, attr_2="test element 1")
 value_2 = TSTestClass(attr_1=3, attr_2="test element 2")
 
-# TypedStep object for all tests
-TypedStepTest1 = TypedStep[TSTestClass](name="test_menu", step_type="menu")
+
+@pytest.fixture(name="test_step")
+def _test_step():
+    test_step = TypedStep[TSTestClass](name="test", step_type=StepType.MENU)
+    test_step.value = [value_1, value_2]
+    test_step.value = [value_1, value_2]  # produce it "unchanged"
+    test_step.index = 0
+    test_step.index = 0  # produce it "unchanged"
+    return test_step
 
 
-def test_property_setters():
-    """Test for TypedStep @properties and setters."""
-    # Test @changed.setter
-    assert TypedStepTest1.changed is False
-    TypedStepTest1.changed = True
-    assert TypedStepTest1.changed is True
+def test_fixture(test_step):
+    """Base test fixture test for the other tests.
 
-    # Reset
-    TypedStepTest1.changed = False
-    assert TypedStepTest1.changed is False
-
-    # Test @value.setter and @changed
-    TypedStepTest1.value = [value_1, value_2]
-    assert TypedStepTest1.value == [value_1, value_2]
-    assert TypedStepTest1.changed is True
-
-    # Reset
-    TypedStepTest1.changed = False
-    assert TypedStepTest1.changed is False
-
-    # Test @index and @index.setter and changed
-    TypedStepTest1.index = TEST_INDEX
-    assert TypedStepTest1.index == TEST_INDEX
-    assert TypedStepTest1.changed is True
+    :param test_step: test fixture
+    """
+    assert not test_step.changed
+    assert test_step.index == 0
+    assert test_step.value == [value_1, value_2]
+    assert test_step.selected == value_1
 
 
-def test_property_selected():
-    """Test for TypedStep @property selected()."""
-    assert TypedStepTest1.selected == value_2
+def test_index(test_step):
+    """Testing @property index and index.setter.
+
+    :param test_step: test fixture
+    """
+    test_step.index = 1
+    assert test_step.index == 1
+    assert test_step.changed
+    test_step.index = 1
+    assert test_step.index == 1
+    assert not test_step.changed
+    test_step.index = 2
+    assert test_step.index == 2
+    assert test_step.changed
+
+
+def test_selected(test_step):
+    """Testing @property selected.
+
+    :param test_step: test fixture
+    """
+    test_step.index = 1
+    assert test_step.selected == value_2
+    test_step.index = 2
+    assert test_step.selected == value_1
+
+
+def test_value(test_step):
+    """Testing @property value and value.setter.
+
+    :param test_step: test fixture
+    """
+    assert not test_step.changed
+    test_step.value = [value_2, value_2]
+    assert test_step.value == [value_2, value_2]
+    assert test_step.changed
+    test_step.value = [value_2, value_2]
+    assert test_step.value == [value_2, value_2]
+    assert not test_step.changed


### PR DESCRIPTION
Introduces dataclass `TypedStep` into steps.py for use in :settings action and future actions. Existing actions may be refactored at a later date to use `TypedStep` instead of `Step`. 

Added unit tests to test`TypedStep` property and setter methods in tests/unit/test_typestep.py. Tests are not parameterized currently as the unit tests are only asserting initial and post-setter values for one TypedStep object.