### PR TITLE
Move pull_policy to pull.policy

### DIFF
--- a/docs/changelog-fragments.d/1029.breaking.md
+++ b/docs/changelog-fragments.d/1029.breaking.md
@@ -1,0 +1,12 @@
+Moved the configuration of ``pull-policy`` under the ``pull`` key
+in the settings file.
+
+Here is a sample:
+```yaml
+ansible-navigator
+  execution-environment:
+    pull:
+      policy: never
+```
+
+-- by {user}`cidrblock`

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -488,7 +488,7 @@ NavigatorConfiguration = ApplicationConfiguration(
             name="pull_policy",
             choices=["always", "missing", "never", "tag"],
             cli_parameters=CliParameters(short="--pp"),
-            settings_file_path_override="execution-environment.pull-policy",
+            settings_file_path_override="execution-environment.pull.policy",
             short_description=(
                 "Specify the image pull policy."
                 " always:Always pull the image,"

--- a/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
+++ b/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
@@ -41,10 +41,10 @@ ansible-navigator:
         KEY2: VALUE2
         KEY3: VALUE3
     image: test_image:latest
-    pull-policy: never
     pull:
       arguments:
         - "--tls-verify=false"
+      policy: never
     volume-mounts:
       - src: "/test1"
         dest: "/test1"


### PR DESCRIPTION
This moves pull policy under the pull key in the settings file.

This will result in the next release being a major as it is a breaking change.

Fixes #951 