### PR TITLE
Convert percentages, dataclass capable (`:settings` related)

### DIFF
--- a/src/ansible_navigator/ui_framework/content_defs.py
+++ b/src/ansible_navigator/ui_framework/content_defs.py
@@ -93,3 +93,18 @@ class ContentBase(Generic[T]):
         :returns: A dictionary created from self
         """
         return asdict(self)
+
+    def get(self, attribute: str):
+        """Allow this dataclass to be treated like a dictionary.
+
+        This is a work around until the UI fully supports dataclasses
+        at which time this can be removed.
+
+        Default is intentionally not implemented as a safeguard to enure
+        this is not more work than necessary to remove in the future
+        and will only return attributes in existence.
+
+        :param attribute: The attribute to get
+        :returns: The gotten attribute
+        """
+        return getattr(self, attribute)

--- a/src/ansible_navigator/ui_framework/utils.py
+++ b/src/ansible_navigator/ui_framework/utils.py
@@ -10,9 +10,11 @@ from typing import Dict
 from typing import List
 from typing import Union
 
+from .content_defs import ContentBase
+
 
 def convert_percentage(
-    content: Union[Dict[str, Any], Any],
+    content: Union[Dict[str, Any], ContentBase],
     columns: List[str],
     progress_bar_width: int,
 ) -> None:

--- a/src/ansible_navigator/ui_framework/utils.py
+++ b/src/ansible_navigator/ui_framework/utils.py
@@ -3,28 +3,48 @@
 import functools
 import re
 
+from dataclasses import is_dataclass
 from math import floor
+from typing import Any
+from typing import Dict
 from typing import List
+from typing import Union
 
 
-def convert_percentage(data_dict: dict, keys: List, progress_bar_width: int) -> None:
-    """convert a string % to a little progress bar
-    not recursive
-    80% = 80%|XXXXXXXX  |
+def convert_percentage(
+    content: Union[Dict[str, Any], Any],
+    columns: List[str],
+    progress_bar_width: int,
+) -> None:
+    """Convert an attribute or value to a progress bar formatted for the TUI in place.
 
-    :param data_dict: The dictionary to update
-    :param keys: The keys to convert in each dictionary
-    :param progress_bar_width: The width of the progress bar
+    :param content: The content for which the progress bar will be generated
+    :param columns: The menu columns, only make progress bars for columns
+    :param progress_bar_width: The target width of the progress bar
     """
-    for key in keys:
-        value = data_dict.get(key)
+    for column in columns:
+        value = content.get(column)
         if value and is_percent(str(value)):
-            if value == "100%":
-                data_dict[key] = "COMPLETE".center(progress_bar_width, " ")
-            else:
-                chars_in_progress_bar = floor(progress_bar_width / 100 * int(value[0:-1]))
-                data_dict["_" + key] = value
-                data_dict[key] = ("\u2587" * chars_in_progress_bar).ljust(progress_bar_width)
+            new_value = _string_to_progress(value, progress_bar_width)
+            if isinstance(content, dict):
+                content["_" + column] = value
+                content[column] = new_value
+            elif is_dataclass(content):
+                setattr(content, f"_{column}", value)
+                setattr(content, column, new_value)
+
+
+def _string_to_progress(value: str, progress_bar_width: int) -> str:
+    """Convert a string to a progress bar or text string indicating complete.
+
+    :param value: The percent string
+    :param progress_bar_width: The target width of the progress bar
+    :returns: The resulting progress bar or text string
+    """
+    if value == "100%":
+        return "COMPLETE".center(progress_bar_width, " ")
+    chars_in_progress_bar = floor(progress_bar_width / 100 * int(value[0:-1]))
+    return ("\u2587" * chars_in_progress_bar).ljust(progress_bar_width)
 
 
 @functools.lru_cache(maxsize=None)

--- a/tests/unit/ui_framework/test_progress_bar.py
+++ b/tests/unit/ui_framework/test_progress_bar.py
@@ -1,10 +1,11 @@
 """Test for the conversion of percent string to progress bars."""
 from dataclasses import dataclass
 
+from ansible_navigator.ui_framework.content_defs import ContentBase
 from ansible_navigator.ui_framework.utils import convert_percentage
 
 
-def test_dictionary_running():
+def test_dictionary_running() -> None:
     """Test the conversion of a string within a dictionary to a progress bar when not complete."""
     test_data = {"progress": "30%", "other": "test value"}
     convert_percentage(content=test_data, columns=["progress"], progress_bar_width=10)
@@ -12,7 +13,7 @@ def test_dictionary_running():
     assert test_data == expected
 
 
-def test_dictionary_complete():
+def test_dictionary_complete() -> None:
     """Test the conversion of a string within a dictionary to a progress bar when complete."""
     test_data = {"progress": "100%", "other": "test value"}
     convert_percentage(content=test_data, columns=["progress"], progress_bar_width=10)
@@ -21,7 +22,7 @@ def test_dictionary_complete():
 
 
 @dataclass
-class ContentTest:
+class ContentTest(ContentBase):
     """Test data for string conversion to a progress bar."""
 
     progress: str
@@ -44,7 +45,7 @@ class ContentTest:
         return getattr(self, attribute)
 
 
-def test_dataclass_running():
+def test_dataclass_running() -> None:
     """Test the conversion of a string within a dataclass to a progress bar when not complete."""
     test_data = ContentTest(progress="30%")
     convert_percentage(content=test_data, columns=["progress"], progress_bar_width=10)
@@ -53,7 +54,7 @@ def test_dataclass_running():
     assert test_data.other == "test_value"
 
 
-def test_dataclass_complete():
+def test_dataclass_complete() -> None:
     """Test the conversion of a string within a dataclass to a progress bar when not complete."""
     test_data = ContentTest(progress="100%")
     convert_percentage(content=test_data, columns=["progress"], progress_bar_width=10)

--- a/tests/unit/ui_framework/test_progress_bar.py
+++ b/tests/unit/ui_framework/test_progress_bar.py
@@ -1,0 +1,62 @@
+"""Test for the conversion of percent string to progress bars."""
+from dataclasses import dataclass
+
+from ansible_navigator.ui_framework.utils import convert_percentage
+
+
+def test_dictionary_running():
+    """Test the conversion of a string within a dictionary to a progress bar when not complete."""
+    test_data = {"progress": "30%", "other": "test value"}
+    convert_percentage(content=test_data, columns=["progress"], progress_bar_width=10)
+    expected = {"progress": "▇▇▇       ", "other": "test value", "_progress": "30%"}
+    assert test_data == expected
+
+
+def test_dictionary_complete():
+    """Test the conversion of a string within a dictionary to a progress bar when complete."""
+    test_data = {"progress": "100%", "other": "test value"}
+    convert_percentage(content=test_data, columns=["progress"], progress_bar_width=10)
+    expected = {"progress": " COMPLETE ", "other": "test value", "_progress": "100%"}
+    assert test_data == expected
+
+
+@dataclass
+class ContentTest:
+    """Test data for string conversion to a progress bar."""
+
+    progress: str
+    _progress: str = ""
+    other: str = "test_value"
+
+    def get(self, attribute: str):
+        """Allow this dataclass to be treated like a dictionary.
+
+        This is a work around until the UI fully supports dataclasses
+        at which time this can be removed.
+
+        Default is intentionally not implemented as a safeguard to enure
+        this is not more work than necessary to remove in the future
+        and will only return attributes in existence.
+
+        :param attribute: The attribute to get
+        :returns: The gotten attribute
+        """
+        return getattr(self, attribute)
+
+
+def test_dataclass_running():
+    """Test the conversion of a string within a dataclass to a progress bar when not complete."""
+    test_data = ContentTest(progress="30%")
+    convert_percentage(content=test_data, columns=["progress"], progress_bar_width=10)
+    assert test_data.progress == "▇▇▇       "
+    assert test_data._progress == "30%"  # pylint: disable=protected-access
+    assert test_data.other == "test_value"
+
+
+def test_dataclass_complete():
+    """Test the conversion of a string within a dataclass to a progress bar when not complete."""
+    test_data = ContentTest(progress="100%")
+    convert_percentage(content=test_data, columns=["progress"], progress_bar_width=10)
+    assert test_data.progress == " COMPLETE "
+    assert test_data._progress == "100%"  # pylint: disable=protected-access
+    assert test_data.other == "test_value"


### PR DESCRIPTION
Depends on #1014 

The `Any` here should be replaced with `ContentBase` when it merges.

This is a rewrite of the convert percentages function to account for the data being either a dictionary or dataclass.

New tests to confirm.