### PR TITLE
Allow prettier to format security.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,9 +8,8 @@ them to the main branch and making the next patch release in the stream.
 ## Reporting a Vulnerability
 
 We encourage responsible disclosure practices for security
-vulnerabilities. Please read our [policies for reporting bugs][bug
-reports policy] if you want to report a security issue that might affect
+vulnerabilities. Please read our [policies for reporting bugs]
+[bug reports policy] if you want to report a security issue that might affect
 Ansible.
 
-[bug reports policy]:
-https://docs.ansible.com/ansible/devel/community/reporting_bugs_and_features.html#reporting-a-bug
+[bug reports policy]: https://docs.ansible.com/ansible/devel/community/reporting_bugs_and_features.html#reporting-a-bug

--- a/.prettierignore
+++ b/.prettierignore
@@ -23,6 +23,5 @@ share/ansible_navigator/markdown/welcome.md
 
 # WIP
 docs/changelog-fragments.d/README.md
-.github/SECURITY.md
 CHANGELOG.md
 README.md


### PR DESCRIPTION
Controlling the line length was a manual step, but it should be fine moving forward.