### PR TITLE
cspell maintenance

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -1,12 +1,7 @@
 cliconf             # Ansible network cli abstraction plugin
 kegex               # An action's regex
 netcommon           # Ansible network collection, seen in tests and README
-pyproject           # Already in dictionary
 setuptools          # Used in _version.pyi
 Towncrier           # Changelog generator
 
-mkdir               # https://github.com/streetsidesoftware/cspell-dicts/pull/915
 mqueue              # https://github.com/ansible/ansible-runner/issues/984
-nxos                # https://github.com/streetsidesoftware/cspell-dicts/pull/919
-paramiko            # https://github.com/streetsidesoftware/cspell-dicts/pull/912
-SNMP                # https://github.com/streetsidesoftware/cspell-dicts/pull/919

--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -5,26 +5,8 @@ pyproject           # Already in dictionary
 setuptools          # Used in _version.pyi
 Towncrier           # Changelog generator
 
-_asdict             # https://github.com/streetsidesoftware/cspell-dicts/pull/912
-backport            # https://github.com/streetsidesoftware/cspell-dicts/pull/913
-curses              # https://github.com/streetsidesoftware/cspell-dicts/pull/912
-deque               # https://github.com/streetsidesoftware/cspell-dicts/pull/912
-libtmux             # https://github.com/streetsidesoftware/cspell-dicts/pull/912
-markdownlint        # https://github.com/streetsidesoftware/cspell-dicts/pull/916
 mkdir               # https://github.com/streetsidesoftware/cspell-dicts/pull/915
-mkdtemp             # https://github.com/streetsidesoftware/cspell-dicts/pull/918
 mqueue              # https://github.com/ansible/ansible-runner/issues/984
 nxos                # https://github.com/streetsidesoftware/cspell-dicts/pull/919
 paramiko            # https://github.com/streetsidesoftware/cspell-dicts/pull/912
-pexpect             # https://github.com/streetsidesoftware/cspell-dicts/pull/912
-podman              # https://github.com/streetsidesoftware/cspell-dicts/pull/899
-pycharm             # https://github.com/streetsidesoftware/cspell-dicts/pull/914
-pyyaml              # https://github.com/streetsidesoftware/cspell-dicts/pull/912
-rtype               # https://github.com/ansible/ansible-navigator/pull/939
 SNMP                # https://github.com/streetsidesoftware/cspell-dicts/pull/919
-snmpd               # https://github.com/streetsidesoftware/cspell-dicts/pull/918
-snmptrapd           # https://github.com/streetsidesoftware/cspell-dicts/pull/918
-ungrouped           # https://github.com/streetsidesoftware/cspell-dicts/pull/900
-unparsable          # https://github.com/streetsidesoftware/cspell-dicts/pull/900
-unpatched           # https://github.com/streetsidesoftware/cspell-dicts/pull/900
-zuul                # https://github.com/streetsidesoftware/cspell-dicts/pull/899

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -4,6 +4,7 @@ dictionaryDefinitions:
     addWords: true
 dictionaries:
   - words
+  - "!cpp"
 ignorePaths:
   # All dot files in the root
   - \.*

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -3,7 +3,13 @@ dictionaryDefinitions:
     path: .config/dictionary.txt
     addWords: true
 dictionaries:
+  - bash
+  - networking-terms
+  - python
   - words
+  - "!aws"
+  - "!backwards-compatibility"
+  - "!cryptocurrencies"
   - "!cpp"
 ignorePaths:
   # All dot files in the root


### PR DESCRIPTION
A couple updates for the unenforced cspell pre-commit hook:

1) Remove entries from the exception dicitonary that are now availble
2) Remove the use of the cpp dictionary, since it has a number of misspelled words 

```
definitition
definiton
definitons
defintion
defintions
defitions
```

https://raw.githubusercontent.com/streetsidesoftware/cspell-dicts/main/dictionaries/cpp/cpp.txt