### PR TITLE
Switch from `SimpleNamespace` to `dataclass` in command runner

### DIFF
--- a/src/ansible_navigator/command_runner/command_runner.py
+++ b/src/ansible_navigator/command_runner/command_runner.py
@@ -13,7 +13,7 @@ from typing import Union
 PROCESSES = (multiprocessing.cpu_count() - 1) or 1
 
 
-@dataclass
+@dataclass(frozen=False)  # updated with results after run
 class Command:
     """command obj"""
 

--- a/src/ansible_navigator/command_runner/command_runner.py
+++ b/src/ansible_navigator/command_runner/command_runner.py
@@ -2,8 +2,9 @@
 import multiprocessing
 import subprocess
 
+from dataclasses import dataclass
+from dataclasses import field
 from queue import Queue
-from types import SimpleNamespace
 from typing import Callable
 from typing import List
 from typing import Union
@@ -12,15 +13,16 @@ from typing import Union
 PROCESSES = (multiprocessing.cpu_count() - 1) or 1
 
 
-class Command(SimpleNamespace):
+@dataclass
+class Command:
     """command obj"""
 
-    id: str
+    identity: str
     command: str
     post_process: Callable
     stdout: str = ""
     stderr: str = ""
-    details: List = []
+    details: List = field(default_factory=list)
     errors: str = ""
 
 

--- a/src/ansible_navigator/command_runner/command_runner.py
+++ b/src/ansible_navigator/command_runner/command_runner.py
@@ -13,9 +13,13 @@ from typing import Union
 PROCESSES = (multiprocessing.cpu_count() - 1) or 1
 
 
-@dataclass(frozen=False)  # updated with results after run
+@dataclass(frozen=False)
 class Command:
-    """command obj"""
+    """Data structure for details of a command to be run.
+
+    A ``Command`` is updated after instantiated with details from either
+    ``stdout`` or ``stderr``.
+    """
 
     identity: str
     command: str

--- a/src/ansible_navigator/image_manager/inspector.py
+++ b/src/ansible_navigator/image_manager/inspector.py
@@ -90,5 +90,5 @@ def inspect_all(container_engine: str) -> Tuple[List, str]:
     images_inspect_class = ImagesInspect(container_engine=container_engine, ids=image_ids)
     inspects = cmd_runner.run_single_proccess(commands=images_inspect_class.commands)
     for inspect in inspects:
-        images[inspect.id]["inspect"] = {"details": inspect.details, "errors": inspect.errors}
+        images[inspect.identity]["inspect"] = {"details": inspect.details, "errors": inspect.errors}
     return list(images.values()), images_list.stderr

--- a/src/ansible_navigator/image_manager/inspector.py
+++ b/src/ansible_navigator/image_manager/inspector.py
@@ -27,7 +27,7 @@ class ImagesInspect:
         """generate commands"""
         return [
             Command(
-                id=image_id,
+                identity=image_id,
                 command=f"{self._container_engine} inspect {image_id}",
                 post_process=self.parse,
             )
@@ -57,7 +57,7 @@ class ImagesList:
         """generate command"""
         return [
             Command(
-                id="images",
+                identity="images",
                 command=f"{self._container_engine} images",
                 post_process=self.parse,
             ),

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/0.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/0.json
@@ -11,14 +11,15 @@
     },
     "output": [
         "  NAME                                                                                              TAG           EXECUTION ENVIRONMENT                      CREATED                   SIZE",
-        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      13 days ago               787 MB",
-        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      7 days ago                399 MB",
-        "2│ansible-automation-platform-21-ee-supported-rhel8                                                 latest                         True                      3 weeks ago               1.13 GB",
-        "3│ansible-builder                                                                                   latest                        False                      8 days ago                781 MB",
-        "4│creator-ee (primary)                                                                              v0.2.0                         True                      2 months ago              1.33 GB",
-        "5│ee-minimal-rhel8                                                                                  latest                         True                      3 weeks ago               399 MB",
-        "6│network_archive_ee                                                                                latest                         True                      7 days ago                484 MB",
-        "7│python-base                                                                                       latest                        False                      8 days ago                690 MB",
+        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      4 weeks ago               787 MB",
+        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      3 weeks ago               399 MB",
+        "2│ansible-automation-platform-21-ee-supported-rhel8                                                 latest                         True                      4 days ago                1.18 GB",
+        "3│ansible-builder                                                                                   latest                        False                      3 weeks ago               781 MB",
+        "4│ansible-navigator-demo-ee                                                                         0.6.0                          True                      6 months ago              1.35 GB",
+        "5│creator-ee (primary)                                                                              v0.2.0                         True                      3 months ago              1.33 GB",
+        "6│ee-minimal-rhel8                                                                                  latest                         True                      6 weeks ago               399 MB",
+        "7│network_archive_ee                                                                                latest                         True                      3 weeks ago               484 MB",
+        "8│python-base                                                                                       latest                        False                      3 weeks ago               690 MB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/1.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_ee.py/test/1.json
@@ -11,7 +11,7 @@
     },
     "output": [
         "  NAME                                                      TAG                EXECUTION ENVIRONMENT                                        CREATED                              SIZE",
-        "0│creator-ee (primary)                                      v0.2.0                              True                                        2 months ago                         1.33 GB",
+        "0│creator-ee (primary)                                      v0.2.0                              True                                        3 months ago                         1.33 GB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/0.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/0.json
@@ -11,14 +11,15 @@
     },
     "output": [
         "  NAME                                                                                              TAG           EXECUTION ENVIRONMENT                      CREATED                   SIZE",
-        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      13 days ago               787 MB",
-        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      7 days ago                399 MB",
-        "2│ansible-automation-platform-21-ee-supported-rhel8                                                 latest                         True                      3 weeks ago               1.13 GB",
-        "3│ansible-builder                                                                                   latest                        False                      8 days ago                781 MB",
-        "4│creator-ee (primary)                                                                              v0.2.0                         True                      2 months ago              1.33 GB",
-        "5│ee-minimal-rhel8                                                                                  latest                         True                      3 weeks ago               399 MB",
-        "6│network_archive_ee                                                                                latest                         True                      7 days ago                484 MB",
-        "7│python-base                                                                                       latest                        False                      8 days ago                690 MB",
+        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      4 weeks ago               787 MB",
+        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      3 weeks ago               399 MB",
+        "2│ansible-automation-platform-21-ee-supported-rhel8                                                 latest                         True                      4 days ago                1.18 GB",
+        "3│ansible-builder                                                                                   latest                        False                      3 weeks ago               781 MB",
+        "4│ansible-navigator-demo-ee                                                                         0.6.0                          True                      6 months ago              1.35 GB",
+        "5│creator-ee (primary)                                                                              v0.2.0                         True                      3 months ago              1.33 GB",
+        "6│ee-minimal-rhel8                                                                                  latest                         True                      6 weeks ago               399 MB",
+        "7│network_archive_ee                                                                                latest                         True                      3 weeks ago               484 MB",
+        "8│python-base                                                                                       latest                        False                      3 weeks ago               690 MB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/1.json
+++ b/tests/fixtures/integration/actions/images/test_direct_interactive_noee.py/test/1.json
@@ -11,7 +11,7 @@
     },
     "output": [
         "  NAME                                                      TAG                EXECUTION ENVIRONMENT                                        CREATED                              SIZE",
-        "0│creator-ee (primary)                                      v0.2.0                              True                                        2 months ago                         1.33 GB",
+        "0│creator-ee (primary)                                      v0.2.0                              True                                        3 months ago                         1.33 GB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/1.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/1.json
@@ -11,14 +11,15 @@
     },
     "output": [
         "  NAME                                                                                              TAG           EXECUTION ENVIRONMENT                      CREATED                   SIZE",
-        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      13 days ago               787 MB",
-        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      7 days ago                399 MB",
-        "2│ansible-automation-platform-21-ee-supported-rhel8                                                 latest                         True                      3 weeks ago               1.13 GB",
-        "3│ansible-builder                                                                                   latest                        False                      8 days ago                781 MB",
-        "4│creator-ee (primary)                                                                              v0.2.0                         True                      2 months ago              1.33 GB",
-        "5│ee-minimal-rhel8                                                                                  latest                         True                      3 weeks ago               399 MB",
-        "6│network_archive_ee                                                                                latest                         True                      7 days ago                484 MB",
-        "7│python-base                                                                                       latest                        False                      8 days ago                690 MB",
+        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      4 weeks ago               787 MB",
+        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      3 weeks ago               399 MB",
+        "2│ansible-automation-platform-21-ee-supported-rhel8                                                 latest                         True                      4 days ago                1.18 GB",
+        "3│ansible-builder                                                                                   latest                        False                      3 weeks ago               781 MB",
+        "4│ansible-navigator-demo-ee                                                                         0.6.0                          True                      6 months ago              1.35 GB",
+        "5│creator-ee (primary)                                                                              v0.2.0                         True                      3 months ago              1.33 GB",
+        "6│ee-minimal-rhel8                                                                                  latest                         True                      6 weeks ago               399 MB",
+        "7│network_archive_ee                                                                                latest                         True                      3 weeks ago               484 MB",
+        "8│python-base                                                                                       latest                        False                      3 weeks ago               690 MB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/2.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_ee.py/test/2.json
@@ -11,7 +11,7 @@
     },
     "output": [
         "  NAME                                                      TAG                EXECUTION ENVIRONMENT                                        CREATED                              SIZE",
-        "0│creator-ee (primary)                                      v0.2.0                              True                                        2 months ago                         1.33 GB",
+        "0│creator-ee (primary)                                      v0.2.0                              True                                        3 months ago                         1.33 GB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/1.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/1.json
@@ -11,14 +11,15 @@
     },
     "output": [
         "  NAME                                                                                              TAG           EXECUTION ENVIRONMENT                      CREATED                   SIZE",
-        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      13 days ago               787 MB",
-        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      7 days ago                399 MB",
-        "2│ansible-automation-platform-21-ee-supported-rhel8                                                 latest                         True                      3 weeks ago               1.13 GB",
-        "3│ansible-builder                                                                                   latest                        False                      8 days ago                781 MB",
-        "4│creator-ee (primary)                                                                              v0.2.0                         True                      2 months ago              1.33 GB",
-        "5│ee-minimal-rhel8                                                                                  latest                         True                      3 weeks ago               399 MB",
-        "6│network_archive_ee                                                                                latest                         True                      7 days ago                484 MB",
-        "7│python-base                                                                                       latest                        False                      8 days ago                690 MB",
+        "0│ansible-automation-platform-21-ee-29-rhel8                                                        latest                         True                      4 weeks ago               787 MB",
+        "1│ansible-automation-platform-21-ee-minimal-rhel8                                                   latest                         True                      3 weeks ago               399 MB",
+        "2│ansible-automation-platform-21-ee-supported-rhel8                                                 latest                         True                      4 days ago                1.18 GB",
+        "3│ansible-builder                                                                                   latest                        False                      3 weeks ago               781 MB",
+        "4│ansible-navigator-demo-ee                                                                         0.6.0                          True                      6 months ago              1.35 GB",
+        "5│creator-ee (primary)                                                                              v0.2.0                         True                      3 months ago              1.33 GB",
+        "6│ee-minimal-rhel8                                                                                  latest                         True                      6 weeks ago               399 MB",
+        "7│network_archive_ee                                                                                latest                         True                      3 weeks ago               484 MB",
+        "8│python-base                                                                                       latest                        False                      3 weeks ago               690 MB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }

--- a/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/2.json
+++ b/tests/fixtures/integration/actions/images/test_welcome_interactive_noee.py/test/2.json
@@ -11,7 +11,7 @@
     },
     "output": [
         "  NAME                                                      TAG                EXECUTION ENVIRONMENT                                        CREATED                              SIZE",
-        "0│creator-ee (primary)                                      v0.2.0                              True                                        2 months ago                         1.33 GB",
+        "0│creator-ee (primary)                                      v0.2.0                              True                                        3 months ago                         1.33 GB",
         "^f/PgUp page up                     ^b/PgDn page down                     ↑↓ scroll                     esc back                     [0-9] goto                     :help help"
     ]
 }


### PR DESCRIPTION
Just to ensure the data structure is not abused in the future.
