### PR TITLE
Switch from `SimpleNamespace` to `dataclass` in puller

### DIFF
--- a/src/ansible_navigator/image_manager/puller.py
+++ b/src/ansible_navigator/image_manager/puller.py
@@ -3,7 +3,7 @@ import logging
 import shlex
 import subprocess
 
-from types import SimpleNamespace
+from dataclasses import dataclass
 from typing import List
 from typing import Union
 
@@ -14,7 +14,8 @@ from ..utils.functions import LogMessage
 from ..utils.functions import shlex_join
 
 
-class ImageAssessment(SimpleNamespace):
+@dataclass
+class ImageAssessment:
     """report the findings"""
 
     messages: List[LogMessage]

--- a/src/ansible_navigator/image_manager/puller.py
+++ b/src/ansible_navigator/image_manager/puller.py
@@ -14,9 +14,13 @@ from ..utils.functions import LogMessage
 from ..utils.functions import shlex_join
 
 
-@dataclass
+@dataclass(frozen=False)
 class ImageAssessment:
-    """report the findings"""
+    """Data structure contianing the image assessment.
+
+    An ``ImageAssessment`` gets updated after instantiation
+    with the determination of whether or not a pull is required.
+    """
 
     messages: List[LogMessage]
     exit_messages: List[ExitMessage]

--- a/src/ansible_navigator/image_manager/puller.py
+++ b/src/ansible_navigator/image_manager/puller.py
@@ -16,7 +16,7 @@ from ..utils.functions import shlex_join
 
 @dataclass(frozen=False)
 class ImageAssessment:
-    """Data structure contianing the image assessment.
+    """Data structure containing the image assessment.
 
     An ``ImageAssessment`` gets updated after instantiation
     with the determination of whether or not a pull is required.


### PR DESCRIPTION
Just to ensure the data structure is not abused in the future.