### PR TITLE
Clear tmux screen in case subsequent tests produce the same output

### DIFF
--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -320,6 +320,11 @@ class TmuxSession:
                 self._fail_remaining = ["******** PREVIOUS TEST FAILURE ********"]
                 return showing
 
+        # Clear the screen in case subsequent tests produce the same output
+        # This ensures the pre_send capture will be different.
+        if mode == "shell":
+            self._pane.send_keys("clear")
+
         return showing
 
     def _get_cli_prompt(self):


### PR DESCRIPTION
Ran into some issues with tmux reporting a failure or pass when it was the opposite. this clears the screen to ensures things will be accurately represented. 