### PR TITLE
Normalize optional types

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -6,6 +6,7 @@ files =
   tests/
 install_types = true
 namespace_packages = true
+no_implicit_optional = true
 non_interactive = true
 pretty = true
 show_column_numbers = true

--- a/share/ansible_navigator/utils/image_introspect.py
+++ b/share/ansible_navigator/utils/image_introspect.py
@@ -11,6 +11,7 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Union
 
 
@@ -77,8 +78,8 @@ class CommandRunner:
 
     def __init__(self):
         """Initialize the command runner."""
-        self._completed_queue: Union[Queue, None] = None
-        self._pending_queue: Union[Queue, None] = None
+        self._completed_queue: Optional[Queue] = None
+        self._pending_queue: Optional[Queue] = None
 
     @staticmethod
     def run_single_proccess(command_classes: Any):

--- a/src/ansible_navigator/action_base.py
+++ b/src/ansible_navigator/action_base.py
@@ -3,6 +3,7 @@ import logging
 
 from copy import deepcopy
 from typing import List
+from typing import Optional
 from typing import Pattern
 from typing import Tuple
 from typing import Union
@@ -37,7 +38,7 @@ class ActionBase:
         self._calling_app: AppPublic
         self._interaction: Interaction
         self._name = name
-        self._previous_filter: Union[Pattern, None]
+        self._previous_filter: Optional[Pattern]
         self._previous_scroll: int
         self.stdout: List = []
         self.steps = Steps()

--- a/src/ansible_navigator/actions/__init__.py
+++ b/src/ansible_navigator/actions/__init__.py
@@ -14,7 +14,7 @@ is identified in the
 """
 from typing import Any
 from typing import Callable
-from typing import Union
+from typing import Optional
 
 from ..action_defs import RunStdoutReturn
 from ..app_public import AppPublic
@@ -38,7 +38,7 @@ run_action_stdout: Callable[
 
 run_action: Callable[
     [str, AppPublic, Interaction],
-    Union[None, Interaction],
+    Optional[Interaction],
 ] = actions.run_interactive_factory(__package__)
 
 

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
 from typing import Union
 
@@ -48,7 +49,7 @@ def color_menu(colno: int, colname: str, entry: Dict[str, Any]) -> Tuple[int, in
     return 2, 0
 
 
-def content_heading(obj: Any, screen_w: int) -> Union[CursesLines, None]:
+def content_heading(obj: Any, screen_w: int) -> Optional[CursesLines]:
     """Create a heading for collection content.
 
     :param obj: The content going to be shown
@@ -98,7 +99,7 @@ class Action(ActionBase):
         """Request calling app update, no collection update is required."""
         self._calling_app.update()
 
-    def run(self, interaction: Interaction, app: AppPublic) -> Union[Interaction, None]:
+    def run(self, interaction: Interaction, app: AppPublic) -> Optional[Interaction]:
         """Execute the ``collections`` request for mode interactive.
 
         :param interaction: The interaction from the user

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -45,7 +45,7 @@ def color_menu(colno: int, colname: str, entry: Dict[str, Any]) -> Tuple[int, in
     return 2, 0
 
 
-def content_heading(obj: Any, screen_w: int) -> Union[CursesLines, None]:
+def content_heading(obj: Any, screen_w: int) -> Optional[CursesLines]:
     """Create a heading for config content.
 
     :param obj: The content going to be shown
@@ -93,10 +93,10 @@ class Action(ActionBase):
         """
         super().__init__(args=args, logger_name=__name__, name="config")
 
-        self._config: Union[List[Any], None] = None
+        self._config: Optional[List[Any]] = None
         self._runner: Union[AnsibleConfig, Command]
 
-    def run(self, interaction: Interaction, app: AppPublic) -> Union[Interaction, None]:
+    def run(self, interaction: Interaction, app: AppPublic) -> Optional[Interaction]:
         """Execute the ``config`` request for mode interactive.
 
         :param interaction: The interaction from the user

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -63,7 +63,7 @@ class Action(ActionBase):
 
         return CursesLines((CursesLine((line_part,)),))
 
-    def run(self, interaction: Interaction, app: AppPublic) -> Union[Interaction, None]:
+    def run(self, interaction: Interaction, app: AppPublic) -> Optional[Interaction]:
         """Execute the ``doc`` request for mode interactive.
 
         :param interaction: The interaction from the user
@@ -142,7 +142,7 @@ class Action(ActionBase):
         _out, error, return_code = response
         return RunStdoutReturn(message=error, return_code=return_code)
 
-    def _run_runner(self) -> Union[None, dict, Tuple[str, str, int]]:
+    def _run_runner(self) -> Optional[Union[dict, Tuple[str, str, int]]]:
         # pylint: disable=too-many-branches
         # pylint: disable=no-else-return
         """Use the runner subsystem to retrieve the configuration.

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -7,8 +7,8 @@ from functools import partial
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
-from typing import Union
 
 from ..action_base import ActionBase
 from ..app_public import AppPublic
@@ -121,7 +121,7 @@ class Action(ActionBase):
         )
         return CursesLines((CursesLine((line_part,)),))
 
-    def run(self, interaction: Interaction, app: AppPublic) -> Union[Interaction, None]:
+    def run(self, interaction: Interaction, app: AppPublic) -> Optional[Interaction]:
         """Execute the ``images`` request for mode interactive.
 
         :param interaction: The interaction from the user
@@ -447,7 +447,7 @@ class Action(ActionBase):
             return False
         return True
 
-    def _parse(self, output) -> Union[Dict, None]:
+    def _parse(self, output) -> Optional[Dict]:
         """Load and process the ``json`` output from the image introspection process.
 
         :param output: The output from the image introspection process

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -8,6 +8,7 @@ import shutil
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
 from typing import Union
 
@@ -60,7 +61,7 @@ def color_menu(colno: int, colname: str, entry: Dict[str, Any]) -> Tuple[int, in
     return colors[colno % len(colors)], Decoration.NORMAL
 
 
-def content_heading(obj: Any, screen_w: int) -> Union[CursesLines, None]:
+def content_heading(obj: Any, screen_w: int) -> Optional[CursesLines]:
     """Create a heading for inventory content.
 
     :param obj: The content going to be shown
@@ -114,7 +115,7 @@ class Action(ActionBase):
 
         self.__inventory: Dict[Any, Any] = {}
         self._host_vars: Dict[str, Dict[Any, Any]]
-        self._inventories_mtime: Union[float, None]
+        self._inventories_mtime: Optional[float]
         self._inventories: List[str] = []
         self._inventory_error: str = ""
         self._runner: Union[Command, AnsibleInventory]
@@ -176,7 +177,7 @@ class Action(ActionBase):
         """Request calling app update, inventory update checked in ``run()``."""
         self._calling_app.update()
 
-    def run(self, interaction: Interaction, app: AppPublic) -> Union[Interaction, None]:
+    def run(self, interaction: Interaction, app: AppPublic) -> Optional[Interaction]:
         """Execute the ``inventory`` request for mode interactive.
 
         :param interaction: The interaction from the user
@@ -522,7 +523,7 @@ class Action(ActionBase):
     def _collect_inventory_details_automated(
         self,
         kwargs: Dict[str, Any],
-    ) -> Tuple[Union[None, str], Union[None, str], Union[None, int]]:
+    ) -> Tuple[Optional[str], Optional[str], Optional[int]]:
         """Use the runner subsystem to collect inventory details for mode stdout.
 
         :param kwargs: The arguments for the runner call
@@ -555,7 +556,7 @@ class Action(ActionBase):
 
     def _collect_inventory_details(
         self,
-    ) -> Tuple[Union[None, str], Union[None, str], Union[None, int]]:
+    ) -> Tuple[Optional[str], Optional[str], Optional[int]]:
         """Use the runner subsystem to collect inventory details for either mode.
 
         :returns: For mode interactive nothing. For mode stdout, the output, errors and return

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -19,7 +19,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
-from typing import Union
 
 from ..action_base import ActionBase
 from ..action_defs import RunStdoutReturn
@@ -103,7 +102,7 @@ def color_menu(_colno: int, colname: str, entry: Dict[str, Any]) -> Tuple[int, i
     return color, decoration
 
 
-def content_heading(obj: Any, screen_w: int) -> Union[CursesLines, None]:
+def content_heading(obj: Any, screen_w: int) -> Optional[CursesLines]:
     """create a heading for some piece of content showing
 
     :param obj: The content going to be shown
@@ -263,7 +262,7 @@ class Action(ActionBase):
             )
         return RunStdoutReturn(message="", return_code=return_code)
 
-    def run(self, interaction: Interaction, app: AppPublic) -> Union[Interaction, None]:
+    def run(self, interaction: Interaction, app: AppPublic) -> Optional[Interaction]:
         """run :run or :replay
 
         :param interaction: The interaction from the user

--- a/src/ansible_navigator/actions/template.py
+++ b/src/ansible_navigator/actions/template.py
@@ -5,7 +5,7 @@ Processor of a template request at the single line prompt. e.g. {{ }}
 import html
 
 from collections.abc import Mapping
-from typing import Union
+from typing import Optional
 
 from ..action_base import ActionBase
 from ..app_public import AppPublic
@@ -30,7 +30,7 @@ class Action(ActionBase):
         """
         super().__init__(args=args, logger_name=__name__, name="template")
 
-    def run(self, interaction: Interaction, app: AppPublic) -> Union[Interaction, None]:
+    def run(self, interaction: Interaction, app: AppPublic) -> Optional[Interaction]:
         """Execute the templating request for mode interactive.
 
         :param interaction: The interaction from the user

--- a/src/ansible_navigator/command_runner/command_runner.py
+++ b/src/ansible_navigator/command_runner/command_runner.py
@@ -7,7 +7,7 @@ from dataclasses import field
 from queue import Queue
 from typing import Callable
 from typing import List
-from typing import Union
+from typing import Optional
 
 
 PROCESSES = (multiprocessing.cpu_count() - 1) or 1
@@ -62,8 +62,8 @@ class CommandRunner:
 
     def __init__(self):
         """Initialize the command runner."""
-        self._completed_queue: Union[Queue, None] = None
-        self._pending_queue: Union[Queue, None] = None
+        self._completed_queue: Optional[Queue] = None
+        self._pending_queue: Optional[Queue] = None
 
     @staticmethod
     def run_single_proccess(commands: List[Command]):

--- a/src/ansible_navigator/configuration_subsystem/definitions.py
+++ b/src/ansible_navigator/configuration_subsystem/definitions.py
@@ -80,13 +80,13 @@ class SettingsEntry:
     #: The possible values for this entry
     choices: Iterable[Union[bool, str]] = field(default_factory=list)
     #: Argparse specific params
-    cli_parameters: Union[None, CliParameters] = None
+    cli_parameters: Optional[CliParameters] = None
     #: Post process in normal (alphabetical) order or wait until after first pass
     delay_post_process: bool = False
     #: Override the default, generated environment variable
-    environment_variable_override: Union[None, str] = None
+    environment_variable_override: Optional[str] = None
     #: Over the default settings file path, dot delimited representation in tree
-    settings_file_path_override: Union[None, str] = None
+    settings_file_path_override: Optional[str] = None
     #: Subcommand this should this be used for
     subcommands: Union[List[str], Constants] = Constants.ALL
     #: Does this hold the name of the active subcommand

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -5,6 +5,7 @@ import os
 
 from dataclasses import dataclass
 from typing import List
+from typing import Optional
 from typing import Tuple
 from typing import Union
 
@@ -89,7 +90,7 @@ class Internals:
     collection_doc_cache: Union[C, KeyValueStore] = C.NOT_SET
     initialization_exit_messages = initialization_exit_messages
     initialization_messages = initialization_messages
-    settings_file_path: Union[None, str] = None
+    settings_file_path: Optional[str] = None
     settings_source: C = C.NOT_SET
     share_directory: str = generate_share_directory()
 

--- a/src/ansible_navigator/configuration_subsystem/parser.py
+++ b/src/ansible_navigator/configuration_subsystem/parser.py
@@ -7,7 +7,6 @@ from argparse import _SubParsersAction
 from typing import Any
 from typing import Dict
 from typing import Tuple
-from typing import Union
 
 from ..utils.functions import oxfordcomma
 from .definitions import ApplicationConfiguration
@@ -30,7 +29,7 @@ class Parser:
         self._configure_subparsers()
 
     @staticmethod
-    def generate_argument(entry) -> Tuple[Any, Union[Any, str, None], Dict[str, Any]]:
+    def generate_argument(entry) -> Tuple[Any, Any, Dict[str, Any]]:
         """Generate an argparse argument"""
         kwargs = {}
         help_strings = [entry.short_description]

--- a/src/ansible_navigator/initialization.py
+++ b/src/ansible_navigator/initialization.py
@@ -30,7 +30,7 @@ def error_and_exit_early(exit_messages: List[ExitMessage]) -> NoReturn:
     sys.exit(1)
 
 
-def find_config() -> Tuple[List[LogMessage], List[ExitMessage], Union[None, str], C]:
+def find_config() -> Tuple[List[LogMessage], List[ExitMessage], Optional[str], C]:
     """
     Find a configuration file, logging each step.
     Return (log messages, path).

--- a/src/ansible_navigator/runner/base.py
+++ b/src/ansible_navigator/runner/base.py
@@ -15,7 +15,6 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Union
 
 from ansible_runner import Runner
 
@@ -161,7 +160,7 @@ class Base:
         """generate a tmp directory for artifacts"""
         return tempfile.mkdtemp(prefix="ansible-navigator_")
 
-    def _set_private_data_directory(self, provided: Union[str, None]) -> None:
+    def _set_private_data_directory(self, provided: Optional[str]) -> None:
         """Set the private data directory to the provided, the username, or a uuid"""
 
         if isinstance(provided, str):

--- a/src/ansible_navigator/ui_framework/curses_window.py
+++ b/src/ansible_navigator/ui_framework/curses_window.py
@@ -5,7 +5,7 @@ import json
 import logging
 
 from typing import TYPE_CHECKING
-from typing import Union
+from typing import Optional
 
 from .colorize import hex_to_rgb_curses
 from .curses_defs import CursesLine
@@ -84,7 +84,7 @@ class CursesWindow:
             curses.beep()
             self._screen.refresh()
 
-    def _color_pair_or_none(self, color: int) -> Union[None, int]:
+    def _color_pair_or_none(self, color: int) -> Optional[int]:
         """
         Returns 0 if colors are disabled.
         Otherwise returns the curses color pair by
@@ -109,7 +109,7 @@ class CursesWindow:
         window: Window,
         lineno: int,
         line: CursesLine,
-        prefix: Union[str, None] = None,
+        prefix: Optional[str] = None,
     ) -> None:
         """add a line to a window
 

--- a/src/ansible_navigator/ui_framework/field_button.py
+++ b/src/ansible_navigator/ui_framework/field_button.py
@@ -2,7 +2,7 @@
 """
 from dataclasses import dataclass
 from typing import Callable
-from typing import Union
+from typing import Optional
 
 from .curses_window import Window
 from .form_defs import FieldValidationStates
@@ -21,7 +21,7 @@ class FieldButton:
     color: int = 0
     window_handler = FormHandlerButton
     validator: Callable = FieldValidators.none
-    win: Union[Window, None] = None
+    win: Optional[Window] = None
 
     @property
     def full_prompt(self) -> str:

--- a/src/ansible_navigator/ui_framework/field_information.py
+++ b/src/ansible_navigator/ui_framework/field_information.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from typing import Callable
 from typing import List
+from typing import Optional
 from typing import Union
 
 from .curses_window import Window
@@ -22,7 +23,7 @@ class FieldInformation:
     window_handler = FormHandlerInformation
     valid: Union[bool, Unknown] = unknown
     validator: Callable = FieldValidators.null
-    win: Union[Window, None] = None
+    win: Optional[Window] = None
 
     @property
     def full_prompt(self) -> str:

--- a/src/ansible_navigator/ui_framework/field_text.py
+++ b/src/ansible_navigator/ui_framework/field_text.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from typing import Any
 from typing import Callable
+from typing import Optional
 from typing import Union
 
 from .curses_window import Window
@@ -26,7 +27,7 @@ class FieldText:
     valid: Union[bool, Unknown] = unknown
     validator: Callable = FieldValidators.none
     value: Any = unknown
-    win: Union[Window, None] = None
+    win: Optional[Window] = None
 
     @property
     def formatted_default(self) -> str:

--- a/src/ansible_navigator/ui_framework/field_working.py
+++ b/src/ansible_navigator/ui_framework/field_working.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from typing import Callable
 from typing import List
+from typing import Optional
 from typing import Union
 
 from .curses_window import Window
@@ -22,7 +23,7 @@ class FieldWorking:
     window_handler = FormHandlerWorking
     valid: Union[bool, Unknown] = unknown
     validator: Callable = FieldValidators.null
-    win: Union[Window, None] = None
+    win: Optional[Window] = None
 
     @property
     def full_prompt(self) -> str:

--- a/src/ansible_navigator/ui_framework/form_presenter.py
+++ b/src/ansible_navigator/ui_framework/form_presenter.py
@@ -5,8 +5,8 @@ import curses
 from curses import ascii as curses_ascii
 from typing import TYPE_CHECKING
 from typing import List
+from typing import Optional
 from typing import Tuple
-from typing import Union
 
 from .curses_defs import CursesLine
 from .curses_defs import CursesLinePart
@@ -183,7 +183,7 @@ class FormPresenter(CursesWindow):
             far_right -= 1
         return CursesLine(tuple(line_parts))
 
-    def _generate_error(self, form_field) -> Union[CursesLine, None]:
+    def _generate_error(self, form_field) -> Optional[CursesLine]:
         if form_field.current_error:
             line_part = CursesLinePart(self._input_start, form_field.current_error, 9, 0)
             return CursesLine((line_part,))

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -16,6 +16,7 @@ from typing import Dict
 from typing import List
 from typing import Match
 from typing import NamedTuple
+from typing import Optional
 from typing import Pattern
 from typing import Tuple
 from typing import Union
@@ -86,8 +87,8 @@ class Interaction(NamedTuple):
     name: str
     action: Action
     ui: Ui
-    content: Union[Content, None] = None
-    menu: Union[Menu, None] = None
+    content: Optional[Content] = None
+    menu: Optional[Menu] = None
 
 
 class UserInterface(CursesWindow):
@@ -120,7 +121,7 @@ class UserInterface(CursesWindow):
             grammar_dir=self._ui_config.grammar_dir,
             theme_path=self._ui_config.theme_path,
         )
-        self._content_heading: Callable[[Any, int], Union[CursesLines, None]]
+        self._content_heading: Callable[[Any, int], Optional[CursesLines]]
         self._default_colors = None
         self._default_pairs = None
         self._default_obj_serialization = "source.yaml"
@@ -128,7 +129,7 @@ class UserInterface(CursesWindow):
         self._hide_keys = True
         self._kegexes = kegexes
         self._logger = logging.getLogger(__name__)
-        self._menu_filter: Union[Pattern, None] = None
+        self._menu_filter: Optional[Pattern] = None
         self._menu_indices: Tuple[int, ...] = tuple()
 
         self._progress_bar_width = progress_bar_width
@@ -168,7 +169,7 @@ class UserInterface(CursesWindow):
         self._status = status
         self._status_color = status_color
 
-    def menu_filter(self, value: Union[str, None] = "") -> Union[Pattern, None]:
+    def menu_filter(self, value: Optional[str] = "") -> Optional[Pattern]:
         """Set or return the menu filter.
 
         :param value: None or the menu_filter regex to set
@@ -186,7 +187,7 @@ class UserInterface(CursesWindow):
                     self._logger.exception(exc)
         return self._menu_filter
 
-    def scroll(self, value: Union[int, None] = None) -> int:
+    def scroll(self, value: Optional[int] = None) -> int:
         """Set or return the current scroll
 
         :param value: the value to set the scroll to
@@ -199,7 +200,7 @@ class UserInterface(CursesWindow):
             self._scroll = value
         return self._scroll
 
-    def serialization_format(self, value: Union[str, None] = None, default: bool = False) -> str:
+    def serialization_format(self, value: Optional[str] = None, default: bool = False) -> str:
         """Set or return the current serialization format
 
         :param value: the value to set the serialization format to
@@ -356,7 +357,7 @@ class UserInterface(CursesWindow):
         self,
         lines: CursesLines,
         line_numbers: Tuple[int, ...],
-        heading: Union[CursesLines, None],
+        heading: Optional[CursesLines],
         indent_heading: int,
         key_dict: dict,
         await_input: bool,
@@ -602,7 +603,7 @@ class UserInterface(CursesWindow):
             decoration=0,
         )
 
-    def _filter_and_serialize(self, obj: Any) -> Tuple[Union[CursesLines, None], CursesLines]:
+    def _filter_and_serialize(self, obj: Any) -> Tuple[Optional[CursesLines], CursesLines]:
         """filter an obj and serialize
 
         :param obj: the obj to serialize
@@ -732,7 +733,7 @@ class UserInterface(CursesWindow):
 
     @staticmethod
     @lru_cache(maxsize=None)
-    def _search_value(regex: Pattern, value: str) -> Union[Match, None]:
+    def _search_value(regex: Pattern, value: str) -> Optional[Match]:
         """check a str against a regex
         lru_cache enabled because this is hit during resize
 
@@ -829,8 +830,8 @@ class UserInterface(CursesWindow):
         self,
         obj: Union[List, Dict, str, bool, int, float],
         serialization_format: str = "",
-        index: int = None,
-        columns: List = None,
+        index: Optional[int] = None,
+        columns: Optional[List] = None,
         await_input: bool = True,
         filter_content_keys: Callable = lambda x: x,
         color_menu_item: Callable = lambda *args, **kwargs: (0, 0),

--- a/src/ansible_navigator/ui_framework/validators.py
+++ b/src/ansible_navigator/ui_framework/validators.py
@@ -8,6 +8,7 @@ from random import randrange
 from typing import Any
 from typing import List
 from typing import NamedTuple
+from typing import Optional
 from typing import Union
 from urllib.parse import urlparse
 
@@ -208,7 +209,7 @@ class FormValidators:
     """Validators for a form"""
 
     @staticmethod
-    def all_true(response: Union[List, None] = None, hint: bool = False) -> Union[Validation, str]:
+    def all_true(response: Optional[List] = None, hint: bool = False) -> Union[Validation, str]:
         """validate all in list are true"""
         msg = "Please ensure all values are true"
         if hint:
@@ -220,7 +221,7 @@ class FormValidators:
 
     @staticmethod
     def no_validation(
-        response: Union[List, None] = None,
+        response: Optional[List] = None,
         hint: bool = False,
     ) -> Union[Validation, str]:
         """no validation"""

--- a/src/ansible_navigator/utils/functions.py
+++ b/src/ansible_navigator/utils/functions.py
@@ -210,7 +210,7 @@ def environment_variable_is_file_path(
     return messages, exit_messages, file_path
 
 
-def find_settings_file() -> Tuple[List[LogMessage], List[ExitMessage], Union[None, str]]:
+def find_settings_file() -> Tuple[List[LogMessage], List[ExitMessage], Optional[str]]:
     """find the settings file as
     ./ansible-navigator.(.yml,.yaml,.json)
     ~/.ansible-navigator.(.yml,.yaml,.json)
@@ -262,7 +262,7 @@ def flatten_list(data_list) -> List:
     return [data_list]
 
 
-def get_share_directory(app_name) -> Tuple[List[LogMessage], List[ExitMessage], Union[None, str]]:
+def get_share_directory(app_name) -> Tuple[List[LogMessage], List[ExitMessage], Optional[str]]:
     # pylint: disable=too-many-return-statements
     """
     returns datadir (e.g. /usr/share/ansible_nagivator) to use for the
@@ -513,7 +513,7 @@ def templar(string: str, template_vars: Mapping) -> Tuple[List[str], Any]:
     return errors, result
 
 
-def to_list(thing: Union[str, List, Tuple, Set, None]) -> List:
+def to_list(thing: Optional[Union[str, List, Tuple, Set]]) -> List:
     """convert something to a list if necessary"""
     if isinstance(thing, (list, tuple, set)):
         converted_value = list(thing)

--- a/src/ansible_navigator/utils/serialize.py
+++ b/src/ansible_navigator/utils/serialize.py
@@ -63,7 +63,7 @@ class YamlStyle(NamedTuple):
     allow_unicode: bool = True
 
 
-def human_dump(obj: Any, filename: str = None, file_mode: str = "w") -> Optional[str]:
+def human_dump(obj: Any, filename: Optional[str] = None, file_mode: str = "w") -> Optional[str]:
     """Serialize an object to yaml.
 
     This allows for the consistent representation across the application.

--- a/tests/integration/_interactions.py
+++ b/tests/integration/_interactions.py
@@ -5,6 +5,7 @@ import shlex
 from enum import Enum
 from typing import List
 from typing import NamedTuple
+from typing import Optional
 from typing import Union
 
 
@@ -20,12 +21,12 @@ class Command(NamedTuple):
 
     execution_environment: bool
     command: str = "ansible-navigator"
-    cmdline: Union[None, str] = None
+    cmdline: Optional[str] = None
     log_level: str = "debug"
     mode: str = "interactive"
     pass_environment_variables: List = []
     preclear: bool = False
-    subcommand: Union[None, str] = None
+    subcommand: Optional[str] = None
 
     def join(self):
         """create CLI command"""

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -7,6 +7,7 @@ import warnings
 
 from timeit import default_timer as timer
 from typing import List
+from typing import Optional
 from typing import Union
 
 import libtmux
@@ -196,7 +197,7 @@ class TmuxSession:
     def interaction(
         self,
         value,
-        search_within_response: Union[None, List, str] = None,
+        search_within_response: Optional[Union[List, str]] = None,
         ignore_within_response=None,
         timeout=300,
     ):

--- a/tests/integration/actions/exec/base.py
+++ b/tests/integration/actions/exec/base.py
@@ -5,7 +5,7 @@ import os
 
 from pathlib import Path
 from typing import Generator
-from typing import Union
+from typing import Optional
 
 import pytest
 
@@ -27,7 +27,7 @@ class BaseClass:
     update_fixtures = False
     pane_height = 25
     pane_width = 300
-    config_file: Union[Path, None] = None
+    config_file: Optional[Path] = None
 
     @pytest.fixture(scope="module", name="tmux_session")
     def fixture_tmux_session(

--- a/tests/unit/actions/test_run.py
+++ b/tests/unit/actions/test_run.py
@@ -9,7 +9,6 @@ from typing import Dict
 from typing import List
 from typing import NamedTuple
 from typing import Optional
-from typing import Union
 
 # pylint: disable=preferred-module  # FIXME: remove once migrated per GH-872
 from unittest.mock import mock_open
@@ -28,7 +27,7 @@ class ArtifactTstData(NamedTuple):
     """The artifact files test data object."""
 
     name: str
-    filename: Union[None, str]
+    filename: Optional[str]
     playbook: str
     expected: str
     help_playbook: bool = False


### PR DESCRIPTION
- Switch from `Union[None, xxx]` to `Optional[xxx]` where found
- Switch from `var: str = None` to `var: Optional[str] = None`

The first we will just need to keep any eye out for.
The second variation can be checked for with the `no-implicit-optional` flag, which was added to the mypy.ini file.

Fixes: #1048

The imperfect grep I used was: 
```
grep -REn --include \*.py "Union\[.*None.*\]" src
```