### PR TITLE
Add release drafting pipelines

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,2 @@
+# see https://github.com/ansible-community/devtools
+_extends: ansible-community/devtools

--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -1,0 +1,9 @@
+# See https://github.com/ansible-community/devtools/blob/main/.github/workflows/ack.yml
+name: ack
+on:
+  pull_request_target:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  ack:
+    uses: ansible-community/devtools/.github/workflows/ack.yml@main

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,13 @@
+---
+# See https://github.com/ansible-community/devtools/blob/main/.github/workflows/push.yml
+name: push
+on:
+  push:
+    branches:
+      - main
+      - "releases/**"
+      - "stable/**"
+
+jobs:
+  ack:
+    uses: ansible-community/devtools/.github/workflows/push.yml@main


### PR DESCRIPTION
This will help us see exactly what was merged into the main branch so we will know what version number we should use for next release.