### PR TITLE
Move playbook to playbook.path

### DIFF
--- a/docs/changelog-fragments.d/1100.breaking.md
+++ b/docs/changelog-fragments.d/1100.breaking.md
@@ -1,0 +1,3 @@
+Moved `ansible.playbook` to `ansible.playbook.path` in the settings file.
+
+-- by {user}`cidrblock`

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -433,7 +433,7 @@ NavigatorConfiguration = ApplicationConfiguration(
             name="playbook",
             cli_parameters=CliParameters(positional=True),
             short_description="Specify the playbook name",
-            settings_file_path_override="ansible.playbook",
+            settings_file_path_override="ansible.playbook.path",
             subcommands=["run"],
             value=SettingsEntryValue(),
         ),

--- a/src/ansible_navigator/configuration_subsystem/schema.py
+++ b/src/ansible_navigator/configuration_subsystem/schema.py
@@ -21,7 +21,15 @@ PARTIAL_SCHEMA: Dict = {
                             "items": {"type": "string"},
                             "type": "array",
                         },
-                        "playbook": {"type": "string"},
+                        "playbook": {
+                            "additionalProperties": False,
+                            "properties": {
+                                "path": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+
                     },
                     "type": "object",
                 },

--- a/src/ansible_navigator/configuration_subsystem/schema.py
+++ b/src/ansible_navigator/configuration_subsystem/schema.py
@@ -23,13 +23,8 @@ PARTIAL_SCHEMA: Dict = {
                         },
                         "playbook": {
                             "additionalProperties": False,
-                            "properties": {
-                                "path": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-
+                            "properties": {"path": {"type": "string"}},
+                        },
                     },
                     "type": "object",
                 },

--- a/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
+++ b/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
@@ -6,7 +6,8 @@ ansible-navigator:
     cmdline: "--forks 15"
     inventories:
       - /tmp/test_inventory.yml
-    playbook: /tmp/test_playbook.yml
+    playbook:
+      path: /tmp/test_playbook.yml
   ansible-builder:
     workdir: /tmp/
   ansible-runner:


### PR DESCRIPTION
This will enable help_playbook to be moved under ansible.playbook.help

More to follow this to get the settings file in order for 2.0