### PR TITLE
Move `ansible.config` to `ansible.config.path`

### DIFF
--- a/docs/changelog-fragments.d/1102.breaking.md
+++ b/docs/changelog-fragments.d/1102.breaking.md
@@ -1,0 +1,3 @@
+Moved `ansible.config` to `ansible.config.path` in the settings file.
+
+-- by {user}`cidrblock`

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -227,7 +227,7 @@ NavigatorConfiguration = ApplicationConfiguration(
             name="config",
             cli_parameters=CliParameters(short="-c", metavar="CONFIG_FILE"),
             environment_variable_override="ansible_config",
-            settings_file_path_override="ansible.config",
+            settings_file_path_override="ansible.config.path",
             short_description="Specify the path to the ansible configuration file",
             subcommands=["config"],
             value=SettingsEntryValue(),

--- a/src/ansible_navigator/configuration_subsystem/schema.py
+++ b/src/ansible_navigator/configuration_subsystem/schema.py
@@ -15,7 +15,8 @@ PARTIAL_SCHEMA: Dict = {
                             "type": "string",
                         },
                         "config": {
-                            "type": "string",
+                            "additionalProperties": False,
+                            "properties": {"path": {"type": "string"}},
                         },
                         "inventories": {
                             "items": {"type": "string"},

--- a/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
+++ b/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
@@ -2,7 +2,8 @@
 ---
 ansible-navigator:
   ansible:
-    config: /tmp/ansible.cfg
+    config:
+      path: /tmp/ansible.cfg
     cmdline: "--forks 15"
     inventories:
       - /tmp/test_inventory.yml


### PR DESCRIPTION
This move the ansible.config entry to ansible.config.path, making room to move help-config

Incremental work to get the help-* entries out of the root

Related #1100 