### PR TITLE
Move `ansible.invetories` to `ansible.inventory.paths`

### DIFF
--- a/docs/changelog-fragments.d/1103.breaking.md
+++ b/docs/changelog-fragments.d/1103.breaking.md
@@ -1,0 +1,3 @@
+Moved `ansible.inventories` to `ansible.inventory.paths` in the settings file.
+
+-- by {user}`cidrblock`

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -361,7 +361,7 @@ NavigatorConfiguration = ApplicationConfiguration(
             name="inventory",
             cli_parameters=CliParameters(action="append", nargs="+", short="-i"),
             environment_variable_override="ansible_navigator_inventories",
-            settings_file_path_override="ansible.inventories",
+            settings_file_path_override="ansible.inventory.paths",
             short_description="Specify an inventory file path or comma separated host list",
             subcommands=["inventory", "run"],
             value=SettingsEntryValue(),

--- a/src/ansible_navigator/configuration_subsystem/schema.py
+++ b/src/ansible_navigator/configuration_subsystem/schema.py
@@ -18,9 +18,14 @@ PARTIAL_SCHEMA: Dict = {
                             "additionalProperties": False,
                             "properties": {"path": {"type": "string"}},
                         },
-                        "inventories": {
-                            "items": {"type": "string"},
-                            "type": "array",
+                        "inventory": {
+                            "additionalProperties": False,
+                            "properties": {
+                                "paths": {
+                                    "items": {"type": "string"},
+                                    "type": "array",
+                                }
+                            },
                         },
                         "playbook": {
                             "additionalProperties": False,

--- a/src/ansible_navigator/configuration_subsystem/schema.py
+++ b/src/ansible_navigator/configuration_subsystem/schema.py
@@ -24,7 +24,7 @@ PARTIAL_SCHEMA: Dict = {
                                 "paths": {
                                     "items": {"type": "string"},
                                     "type": "array",
-                                }
+                                },
                             },
                         },
                         "playbook": {

--- a/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
+++ b/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
@@ -5,8 +5,9 @@ ansible-navigator:
     config:
       path: /tmp/ansible.cfg
     cmdline: "--forks 15"
-    inventories:
-      - /tmp/test_inventory.yml
+    inventory:
+      paths:
+        - /tmp/test_inventory.yml
     playbook:
       path: /tmp/test_playbook.yml
   ansible-builder:


### PR DESCRIPTION
This will make room to move help out of the root