### PR TITLE
Add the `--details` flag for `ansible-navigator images` for stdout

### DIFF
--- a/docs/changelog-fragments.d/1138.feature.md
+++ b/docs/changelog-fragments.d/1138.feature.md
@@ -1,0 +1,12 @@
+Added `--details` parameter to `ansible-navigator images` in mode `stdout`.
+This produces detailed information about the currently selected image.
+
+Here are some examples:
+
+```bash
+ansible-navigator images --details
+ansible-navigator images -d ansible_collections -d ansible_version
+ansible-navigator images -d python_version --eei network_archive_ee --pp never
+```
+
+-- by {user}`cidrblock`

--- a/src/ansible_navigator/configuration_subsystem/definitions.py
+++ b/src/ansible_navigator/configuration_subsystem/definitions.py
@@ -161,16 +161,22 @@ class SettingsEntry:
     def invalid_choice(self) -> str:
         """Generate an invalid choice message for this entry"""
         name = self.name.replace("_", "-")
-        if self.value.source is not Constants.NOT_SET:
-            choices = [str(choice).lower() for choice in self.choices]
-            msg = (
-                f"{name} must be one of "
-                + oxfordcomma(choices, "or")
-                + f", but set as '{self.value.current}' in "
-                + self.value.source.value
-            )
-            return msg
-        raise ValueError(f"Current source not set for {self.name}")
+        if self.value.source is Constants.NOT_SET:
+            raise ValueError(f"Current source not set for {self.name}")
+
+        choices = [str(choice).lower() for choice in self.choices]
+        current = self.value.current
+        if isinstance(current, list):
+            choices_str = oxfordcomma(choices, "and/or")
+            current = oxfordcomma(current, "and")
+            prefix = f"{name} must be one or more of"
+        else:
+            choices_str = oxfordcomma(choices, "or")
+            prefix = f"{name} must be one of"
+
+        source = self.value.source.value
+        msg = f"{prefix} {choices_str}, but set as {current} in {source}"
+        return msg
 
     @property
     def name_dashed(self) -> str:

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -375,6 +375,31 @@ NavigatorConfiguration = ApplicationConfiguration(
             value=SettingsEntryValue(default=False),
         ),
         SettingsEntry(
+            name="images_details",
+            choices=[
+                "ansible_collections",
+                "ansible_version",
+                "everything",
+                "os_release",
+                "python_packages",
+                "python_version",
+                "redhat_release",
+                "system_packages",
+            ],
+            cli_parameters=CliParameters(
+                action="append",
+                nargs="*",
+                short="-d",
+                long_override="--details",
+            ),
+            settings_file_path_override="images.details",
+            short_description=(
+                "Provide detailed information about the selected execution environment image"
+            ),
+            subcommands=["images"],
+            value=SettingsEntryValue(default=["everything"]),
+        ),
+        SettingsEntry(
             name="inventory",
             cli_parameters=CliParameters(action="append", nargs="*", short="-i"),
             environment_variable_override="ansible_inventory",

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -458,6 +458,31 @@ class NavigatorPostProcessor:
     help_inventory = partialmethod(_forced_stdout, subcommand="inventory")
     help_playbook = partialmethod(_forced_stdout, subcommand="run")
 
+    @_post_processor
+    def images_details(
+        self,
+        entry: SettingsEntry,
+        config: ApplicationConfiguration,
+    ) -> PostProcessorReturn:
+        # pylint: disable=unused-argument
+        """Post process execution_environment_image_details"""
+        messages: List[LogMessage] = []
+        exit_messages: List[ExitMessage] = []
+
+        entry.value.current = flatten_list(entry.value.current)
+        # In the case --default was provided, set it to everything
+        if not entry.value.current:
+            entry.value.current = entry.value.default
+
+        # Only force mode stdout if from the CLI so the values can be kept in settings
+        # or in an environment variable and used with only --mode stdout
+        if entry.value.source is C.USER_CLI:
+            mode = Mode.STDOUT
+            self._requested_mode.append(ModeChangeRequest(entry=entry.name, mode=mode))
+            message = message = f"`{entry.name} requesting mode {mode.value}"
+            messages.append(LogMessage(level=logging.DEBUG, message=message))
+        return messages, exit_messages
+
     @staticmethod
     @_post_processor
     def inventory(entry: SettingsEntry, config: ApplicationConfiguration) -> PostProcessorReturn:

--- a/src/ansible_navigator/configuration_subsystem/transform.py
+++ b/src/ansible_navigator/configuration_subsystem/transform.py
@@ -69,7 +69,12 @@ def to_schema(settings: ApplicationConfiguration) -> Dict[str, Any]:
                 subschema = subschema.get(part, {}).get("properties")
         subschema[dot_parts[-1]]["description"] = entry.short_description
         if entry.choices:
-            subschema[dot_parts[-1]]["enum"] = list(entry.choices)  # may be a tuple
+            if subschema[dot_parts[-1]].get("type") == "array":
+                # A list of items
+                subschema[dot_parts[-1]]["items"]["enum"] = entry.choices
+            else:
+                # A single item
+                subschema[dot_parts[-1]]["enum"] = entry.choices
         if entry.value.default is not Constants.NOT_SET:
             subschema[dot_parts[-1]]["default"] = entry.value.default
 

--- a/src/ansible_navigator/configuration_subsystem/transform.py
+++ b/src/ansible_navigator/configuration_subsystem/transform.py
@@ -70,7 +70,7 @@ def to_schema(settings: ApplicationConfiguration) -> Dict[str, Any]:
         subschema[dot_parts[-1]]["description"] = entry.short_description
         if entry.choices:
             # choice may be a tuple, so make a list
-            choices = entry.choices
+            choices = list(entry.choices)
             if subschema[dot_parts[-1]].get("type") == "array":
                 # A list of items
                 subschema[dot_parts[-1]]["items"]["enum"] = choices

--- a/src/ansible_navigator/configuration_subsystem/transform.py
+++ b/src/ansible_navigator/configuration_subsystem/transform.py
@@ -69,12 +69,14 @@ def to_schema(settings: ApplicationConfiguration) -> Dict[str, Any]:
                 subschema = subschema.get(part, {}).get("properties")
         subschema[dot_parts[-1]]["description"] = entry.short_description
         if entry.choices:
+            # choice may be a tuple, so make a list
+            choices = entry.choices
             if subschema[dot_parts[-1]].get("type") == "array":
                 # A list of items
-                subschema[dot_parts[-1]]["items"]["enum"] = entry.choices
+                subschema[dot_parts[-1]]["items"]["enum"] = choices
             else:
                 # A single item
-                subschema[dot_parts[-1]]["enum"] = entry.choices
+                subschema[dot_parts[-1]]["enum"] = choices
         if entry.value.default is not Constants.NOT_SET:
             subschema[dot_parts[-1]]["default"] = entry.value.default
 

--- a/src/ansible_navigator/package_data/settings-sample.template.yml
+++ b/src/ansible_navigator/package_data/settings-sample.template.yml
@@ -104,6 +104,11 @@ ansible-navigator:
         dest: "/tmp/directory"
         options: "Z"
   # {{ inventory-columns }}
+  images:
+    # {{ images.details }}
+    details:
+      - ansible_collections
+      - ansible_version
   inventory-columns:
     - ansible_network_os
     - ansible_network_cli_ssh_type

--- a/src/ansible_navigator/package_data/settings-schema.partial.json
+++ b/src/ansible_navigator/package_data/settings-schema.partial.json
@@ -217,6 +217,17 @@
           },
           "type": "object"
         },
+        "images": {
+          "additionalProperties": false,
+          "properties": {
+            "details": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          }
+        },
         "inventory-columns": {
           "items": {
             "type": "string"

--- a/tests/fixtures/integration/actions/images/test_stdout_tmux.py/test/1.json
+++ b/tests/fixtures/integration/actions/images/test_stdout_tmux.py/test/1.json
@@ -1,0 +1,30 @@
+{
+    "name": "test[print all details to stdout  clear && ansible-navigator images --details --ee True --ll debug --mode stdout  | grep '^[a-z]']",
+    "index": 1,
+    "comment": "print all details to stdout",
+    "additional_information": {
+        "present": [
+            "ansible_collections",
+            "ansible_version",
+            "image_name: quay.io/ansible/creator-ee",
+            "os_release",
+            "python_packages",
+            "python_version",
+            "redhat_release",
+            "system_packages"
+        ],
+        "absent": [],
+        "compared_fixture": false
+    },
+    "output": [
+        "ansible_collections:",
+        "ansible_version:",
+        "image_name: quay.io/ansible/creator-ee:v0.2.0",
+        "os_release:",
+        "python_packages:",
+        "python_version:",
+        "redhat_release:",
+        "system_packages:",
+        "(venv) bash-5.1$"
+    ]
+}

--- a/tests/fixtures/integration/actions/images/test_stdout_tmux.py/test/2.json
+++ b/tests/fixtures/integration/actions/images/test_stdout_tmux.py/test/2.json
@@ -1,0 +1,26 @@
+{
+    "name": "test[print all details to stdout  clear && ansible-navigator images -d ansible_collections -d ansible_version --ee True --ll debug --mode stdout  | grep '^[a-z]']",
+    "index": 2,
+    "comment": "print all details to stdout",
+    "additional_information": {
+        "present": [
+            "ansible_collections",
+            "ansible_version",
+            "image_name: quay.io/ansible/creator-ee"
+        ],
+        "absent": [
+            "os_release",
+            "python_packages",
+            "python_version",
+            "redhat_release",
+            "system_packages"
+        ],
+        "compared_fixture": false
+    },
+    "output": [
+        "ansible_collections:",
+        "ansible_version:",
+        "image_name: quay.io/ansible/creator-ee:v0.2.0",
+        "(venv) bash-5.1$"
+    ]
+}

--- a/tests/fixtures/integration/actions/images/test_stdout_tmux.py/test/3.json
+++ b/tests/fixtures/integration/actions/images/test_stdout_tmux.py/test/3.json
@@ -1,0 +1,21 @@
+{
+    "name": "test[print all details to stdout  clear && ansible-navigator images -d foo -d bar --ee True --ll debug --mode stdout]",
+    "index": 3,
+    "comment": "print all details to stdout",
+    "additional_information": {
+        "present": [
+            "must be one or more"
+        ],
+        "absent": [],
+        "compared_fixture": false
+    },
+    "output": [
+        "[ERROR]: Command provided: 'images -d foo -d bar --ee True --ll debug --mode stdout'",
+        "[ERROR]: images-details must be one or more of 'ansible_collections', 'ansible_version', 'everything', 'os_release', 'python_packages', 'python_version', 'redhat_release' and/or 'system_packages', but",
+        " set as 'foo' and 'bar' in Command line",
+        " [HINT]: Try again with '-d ansible_collections', '-d ansible_version', '-d everything', '-d os_release', '-d python_packages', '-d python_version', '-d redhat_release' or '-d system_packages'",
+        "[ERROR]: Configuration failed, using default log file location: /home/user/github/ansible-navigator/ansible-navigator.log. Log level set to debug",
+        " [HINT]: Review the hints and log file to see what went wrong: /home/user/github/ansible-navigator/ansible-navigator.log",
+        "(venv) bash-5.1$"
+    ]
+}

--- a/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
+++ b/tests/fixtures/unit/configuration_subsystem/ansible-navigator.yml
@@ -62,6 +62,10 @@ ansible-navigator:
         options: "Z"
     container-options:
       - "--net=host"
+  images:
+    details:
+      - ansible_version
+      - python_version
   inventory-columns:
     - ansible_network_os
     - ansible_network_cli_ssh_type

--- a/tests/integration/actions/images/test_stdout_tmux.py
+++ b/tests/integration/actions/images/test_stdout_tmux.py
@@ -32,6 +32,57 @@ stdout_tests = (
         ).join(),
         present=["repository: quay.io/ansible/creator-ee"],
     ),
+    ShellCommand(
+        comment="print all details to stdout",
+        user_input=StdoutCommand(
+            cmdline="--details",
+            mode="stdout",
+            execution_environment=True,
+            raw_append=" | grep '^[a-z]'",
+        ).join(),
+        present=[
+            "ansible_collections",
+            "ansible_version",
+            "image_name: quay.io/ansible/creator-ee",
+            "os_release",
+            "python_packages",
+            "python_version",
+            "redhat_release",
+            "system_packages",
+        ],
+    ),
+    ShellCommand(
+        comment="print all details to stdout",
+        user_input=StdoutCommand(
+            cmdline="-d ansible_collections -d ansible_version",
+            mode="stdout",
+            execution_environment=True,
+            raw_append=" | grep '^[a-z]'",
+        ).join(),
+        present=[
+            "ansible_collections",
+            "ansible_version",
+            "image_name: quay.io/ansible/creator-ee",
+        ],
+        absent=[
+            "os_release",
+            "python_packages",
+            "python_version",
+            "redhat_release",
+            "system_packages",
+        ],
+    ),
+    ShellCommand(
+        comment="print all details to stdout",
+        user_input=StdoutCommand(
+            cmdline="-d foo -d bar",
+            mode="stdout",
+            execution_environment=True,
+        ).join(),
+        present=[
+            "must be one or more of",
+        ],
+    ),
 )
 
 steps = add_indices(stdout_tests)

--- a/tests/unit/configuration_subsystem/data.py
+++ b/tests/unit/configuration_subsystem/data.py
@@ -233,6 +233,7 @@ ENV_VAR_DATA = [
     ("help_doc", "false", False),
     ("help_inventory", "false", False),
     ("help_playbook", "false", False),
+    ("images_details", "ansible_version,python_version", ["ansible_version", "python_version"]),
     ("inventory", "/tmp/test1.yaml,/tmp/test2.yml", ["/tmp/test1.yaml", "/tmp/test2.yml"]),
     ("inventory_column", "t1,t2,t3", ["t1", "t2", "t3"]),
     ("lint_config", "/tmp/ansible-lint-config.yml", "/tmp/ansible-lint-config.yml"),

--- a/tests/unit/configuration_subsystem/test_invalid_params.py
+++ b/tests/unit/configuration_subsystem/test_invalid_params.py
@@ -127,7 +127,7 @@ def test_poor_choices(_mocked_func, generate_config, entry):
     if entry.cli_parameters and entry.cli_parameters.action == "store_true":
         pass
     elif entry.cli_parameters:
-        look_for = "must be one of"
+        look_for = "must be one"
         # ansible-navigator choice error
         test(subcommand, entry.cli_parameters.short, look_for)
         test(


### PR DESCRIPTION
- Added tests
- Broke out the run_runner logic so it could be consumed by run_stdout
- Modified the check_choice function since `--details` can be a list, but has choices
- modified the `invalid choices` function so it could handle a list as well
- Added settings entry and post processor
- Modified the `to_schema` to place the enum inside of the item inside an array
- Updated the partial schema
- Updated the sample settings file
- Fixtures added as required