### PR TITLE
ui_framework init and curses_defs doc string fixes (D/DAR)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -71,9 +71,6 @@ per-file-ignores =
   src/ansible_navigator/tm_tokenize/state.py: D100, D101, D102
   src/ansible_navigator/tm_tokenize/tokenize.py: D100, D201, D400, D403, DAR101, DAR201
   src/ansible_navigator/tm_tokenize/utils.py: D100, D400, D403, DAR101, DAR201
-  src/ansible_navigator/ui_framework/__init__.py: D200, D400
-  src/ansible_navigator/ui_framework/colorize.py: D200, D205, D400, D403, DAR101, DAR201
-  src/ansible_navigator/ui_framework/curses_defs.py: D200, D400
   src/ansible_navigator/ui_framework/curses_window.py: D200, D202, D205, D209, D400, D401, D403, DAR101, DAR201
   src/ansible_navigator/ui_framework/field_button.py: D200, D205, D400, D403, DAR101, DAR201
   src/ansible_navigator/ui_framework/field_checks.py: D200, D204, D205, D400, D403, DAR101, DAR201

--- a/src/ansible_navigator/ui_framework/__init__.py
+++ b/src/ansible_navigator/ui_framework/__init__.py
@@ -1,5 +1,4 @@
-"""ui_framework
-"""
+"""Initialization file for the ui_framework."""
 
 from .curses_defs import CursesLine
 from .curses_defs import CursesLinePart

--- a/src/ansible_navigator/ui_framework/curses_defs.py
+++ b/src/ansible_navigator/ui_framework/curses_defs.py
@@ -1,5 +1,4 @@
-"""commonly used definitions
-"""
+"""Commonly used definitions."""
 
 from dataclasses import dataclass
 from typing import NamedTuple
@@ -9,7 +8,7 @@ from typing import Tuple
 
 
 class CursesLinePart(NamedTuple):
-    """One chunk of a line of text
+    """One chunk of a line of text.
 
     :param column: the column at which the text should start
     :param string: the text to be displayed


### PR DESCRIPTION
Removing .flake8 entries for src/ansible_navigator/ui_framework/__init__.py*curses_defs.py. 

Wanted to do more but need to jump out for the day and figured I would at least get it started. 