### PR TITLE
Optimize GHA execution

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,12 +36,6 @@ jobs:
             python-version: 3.9
           - tox_env: py310
             python-version: "3.10"
-          - tox_env: no-test-deps
-            python-version: 3.8
-          - tox_env: no-test-deps
-            python-version: 3.9
-          - tox_env: no-test-deps
-            python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v2
@@ -69,6 +63,10 @@ jobs:
           python3 -m tox
         env:
           TOXENV: ${{ matrix.tox_env }}
+      - name: tox -e no-test-deps
+        if: ${{ startsWith(matrix.tox_env, 'py') }}
+        continue-on-error: ${{ matrix.devel || false }}
+        run: python3 -m tox -e no-test-deps
       - name: Upload coverage data
         uses: codecov/codecov-action@v2
         with:


### PR DESCRIPTION
Reduce resource usage by running the no-test-deps env after normal unit (py) ones. Result is faster execution time.
