### PR TITLE
Minor tox.ini fixes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ small_test_ee = quay.io/ansible/python-base
 [tox]
 envlist =
   lint,
-  py38,
+  py,
   report,
   packaging,
   clean
@@ -32,14 +32,16 @@ allowlist_externals =
 deps =
   .[test]
 commands =
-  /bin/bash -c 'grep -iFInrq "UPDATE_FIXTURES = True" ./tests && exit 1 || exit 0'
-  /bin/bash -c 'podman pull -q {[base]default_ee} || docker pull -q {[base]default_ee}'
-  /bin/bash -c 'podman pull -q {[base]small_test_ee} || docker pull -q {[base]small_test_ee}'
+  sh -c 'grep -iFInrq "UPDATE_FIXTURES = True" ./tests && exit 1 || exit 0'
+  sh -c 'podman pull -q {[base]default_ee} || docker pull -q {[base]default_ee}'
+  sh -c 'podman pull -q {[base]small_test_ee} || docker pull -q {[base]small_test_ee}'
   # most coverage options are kept in pyproject.toml
-  /bin/bash -c 'py.test -vv -n `python -c "import multiprocessing; import os; print(int(os.environ.get(\"XDIST_CPU\") or multiprocessing.cpu_count()))"` --dist=loadfile --maxfail=15 --durations=100 --cov --cov-config=pyproject.toml --cov-report=xml:{toxworkdir}/coverage-{envname}.xml --showlocals {posargs}'
+  sh -c 'py.test -vv -n `python -c "import multiprocessing; import os; print(int(os.environ.get(\"XDIST_CPU\") or multiprocessing.cpu_count()))"` --dist=loadfile --maxfail=15 --durations=100 --cov --cov-config=pyproject.toml --cov-report=xml:{toxworkdir}/coverage-{envname}.xml --showlocals {posargs}'
 setenv =
-  TERM = xterm-256color
+  FORCE_COLOR = 1
   PIP_CONSTRAINT = {toxinidir}/requirements.txt
+  PRE_COMMIT_COLOR = always
+  TERM = xterm-256color
 passenv =
   CI
   GITHUB_*


### PR DESCRIPTION
- use default "py" to avoid forcing users to use py38
- correct external command to "sh" (error with tox4)
- ensure ANSI coloring works (tox4)
