### PR TITLE
Remove max size none for lru_cache

### DIFF
--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -53,7 +53,7 @@ class ColorSchema:
         self._logger = logging.getLogger(__name__)
         self._schema = schema
 
-    @functools.lru_cache(maxsize=None)
+    @functools.lru_cache
     def get_color_and_style(self, scope: str) -> Tuple[Optional[RgbTuple], Optional[str]]:
         """Get a color from the schema, traverse all to aggregate color and style.
 

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -53,7 +53,7 @@ class ColorSchema:
         self._logger = logging.getLogger(__name__)
         self._schema = schema
 
-    @functools.lru_cache
+    @functools.lru_cache(maxsize=128)
     def get_color_and_style(self, scope: str) -> Tuple[Optional[RgbTuple], Optional[str]]:
         """Get a color from the schema, traverse all to aggregate color and style.
 


### PR DESCRIPTION
Fixes:

```
************ Module ansible_navigator.ui_framework.colorize
src/ansible_navigator/ui_framework/colorize.py:56:5: W1517: 'lru_cache(maxsize=None)' will keep all method args alive indefinitely, including 'self' (cache-max-size-none)
```
https://github.com/ansible/ansible-navigator/pull/1199

We should not see a large number of style scope combinations, so will leave it at the default of 128.

Tested locally, did not see notice any rendering speed changes