### PR TITLE
Remove flake8-quotes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -37,6 +37,7 @@ extend-exclude =
 # IMPORTANT: avoid using ignore option, always use extend-ignore instead
 # Completely and unconditionally ignore the following errors:
 extend-ignore =
+  Q  # Safeguard neutering of flake8-quotes : https://github.com/zheller/flake8-quotes/issues/105
   E203,  # annoy black by allowing white space before : https://github.com/psf/black/issues/315
   F401,  # duplicate of pylint W0611 (unused-import)
   F821,  # duplicate of pylint E0602 (undefined-variable)
@@ -53,8 +54,6 @@ per-file-ignores =
   # If other ignores are added for a specific file in the section following this,
   # these will need to be added to that line as well.
 
-  # Q000: Allow single-quotes in _version.py because setuptools_scm will create it with them.
-  src/ansible_navigator/_version.py: Q000
   # S101: Allow the use of assert within the tests directory, since tests require it.
   tests/**.py: S101
 
@@ -194,11 +193,3 @@ per-file-ignores =
 
 # Count the number of occurrences of each error/warning code and print a report:
 statistics = true
-
-# flake8-quotes
-# https://github.com/zheller/flake8-quotes
-# keep at bottom of configuration because some IDEs
-# may see the single double quote in the inline-quotes
-# entry as an unterminated string and not properly
-# highlight the remainder of the file
-inline-quotes = "

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,7 +145,6 @@ repos:
         additional_dependencies:
           - flake8-2020 >= 1.6.0
           - flake8-isort >= 4.1.1
-          - flake8-quotes >= 3.3.1
       - id: flake8
         alias: flake8-rule-candidates
         name: Help improve our developer documentation. Try "tox -e lint-candidates" (optional)

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,6 @@ execnet==1.9.0
 filelock==3.6.0
 flake8==4.0.1
 flake8-docstrings==1.6.0
-flake8-quotes==3.3.1
 identify==2.4.12
 idna==3.3
 imagesize==1.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,6 @@ test =
     ansible-core
     darglint
     flake8-docstrings
-    flake8-quotes
     libtmux
     lxml
     pre-commit


### PR DESCRIPTION
This fixes a problem where presence of this plugin caused errors on other projects, as we did
not have custom configuration for it.

Related: https://github.com/zheller/flake8-quotes/issues/105