### PR TITLE
Allow compound words for python

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -49,3 +49,6 @@ ignoreRegExpList:
   - "curses\\.\\w+" # curses functions e.g. curses.doupdate
   - "monkeypatch\\.\\w+" # monkeypatch functions e.g. monkeypatch.setenv
   - "request\\.node\\.\\w+" # pytest request  e.g. request.node.nodeid
+languageSettings:
+  - languageId: python
+    allowCompoundWords: true


### PR DESCRIPTION
Related: https://github.com/ansible/ansible-navigator/issues/1221

Previously, compound words were enabled by default, cleanup can happen in the future