### PR TITLE
Default factory for ApplicationConfiguration

### DIFF
--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from dataclasses import dataclass
+from dataclasses import field
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -93,7 +94,7 @@ def generate_share_directory():
 class Internals:
     """Place to hold an object that needs to be used from app initiation through whole app."""
 
-    ansible_configuration: AnsibleConfiguration = AnsibleConfiguration()
+    ansible_configuration: AnsibleConfiguration = field(default_factory=AnsibleConfiguration)
     action_packages: Tuple[str] = ("ansible_navigator.actions",)
     collection_doc_cache: Union[C, KeyValueStore] = C.NOT_SET
     initializing: bool = False

--- a/src/ansible_navigator/configuration_subsystem/utils.py
+++ b/src/ansible_navigator/configuration_subsystem/utils.py
@@ -4,6 +4,7 @@ import logging
 from configparser import ConfigParser
 from configparser import ParsingError
 from dataclasses import dataclass
+from dataclasses import field
 from pathlib import Path
 from typing import Any
 from typing import Dict
@@ -90,7 +91,7 @@ class ParseAnsibleCfgResponse:
     """Log messages"""
     exit_messages: List[ExitMessage]
     """Exit messages"""
-    config: AnsibleConfiguration = AnsibleConfiguration()
+    config: AnsibleConfiguration = field(default_factory=AnsibleConfiguration)
     """An ansible configuration"""
 
 


### PR DESCRIPTION
Python 3.11 is raising a ValueError because of the mutable default value:

```
/usr/lib64/python3.11/dataclasses.py:816: in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
E   ValueError: mutable default <class 'ansible_navigator.configuration_subsystem.utils.AnsibleConfiguration'> for field ansible_configuration is not allowed: use default_factory
```

Switch to using default_factory.  
