### PR TITLE
Update runner warning exclusion

### DIFF
--- a/tests/unit/test_circular_imports.py
+++ b/tests/unit/test_circular_imports.py
@@ -88,14 +88,13 @@ def test_no_warnings(import_path: str) -> None:
         sys.executable,
         "-W",
         "error",
-        # NOTE: This exclusion is only necessary because ansible-runner still uses `distutils`
-        # NOTE: but this project already aims to target Python 3.10 as well.
+        # NOTE: This exclusion is only necessary because ansible-runner still uses `pipes`
+        # NOTE: but this project already aims to target Python 3.11 as well.
         # TODO: Remove this exclusion once the runner issue is addressed.
-        # Ref: https://github.com/ansible/ansible-runner/issues/969
+        # https://github.com/ansible/ansible-runner/issues/1101
         "-W",
-        "ignore:The distutils package is deprecated and slated for removal in Python 3.12."
-        " Use setuptools or check PEP 632 for potential alternatives:DeprecationWarning:"
-        "ansible_runner.config.runner",
+        "ignore: 'pipes' is deprecated and slated for removal in Python 3.13:DeprecationWarning:"
+        "ansible_runner.utils",
         "-c",
         f"import {import_path!s}",
     )


### PR DESCRIPTION
https://github.com/ansible/ansible-runner/issues/969  has been addressed

In py3.11 pipes throws a deprecation warning so https://github.com/ansible/ansible-runner/issues/1101 was raised and the exclusion updated.