### PR TITLE
Require later setuptools for python 3.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,12 +36,13 @@ packages = find:
 install_requires =
     ansible-builder >=1, <2
     ansible-runner >=2, <3
+    backports.zoneinfo; python_version < "3.9.0"
+    importlib-resources; python_version < "3.9.0"
     jinja2
     jsonschema
     onigurumacffi >=1.1.0, <2
     pyyaml
-    importlib-resources; python_version < "3.9.0"
-    backports.zoneinfo; python_version < "3.9.0"
+    setuptools >= 63.1.0; python_version >= '3.11'
     tzdata
 python_requires = >=3.8
 


### PR DESCRIPTION
Related: https://github.com/pypa/setuptools/pull/3276

Require a later version of setuptools for python 3.11 to avoid `sre_constants` deprecation warnings.

Additionally sort the list of requirements.