### PR TITLE
Implement PEP-563

### DIFF
--- a/src/ansible_navigator/configuration_subsystem/definitions.py
+++ b/src/ansible_navigator/configuration_subsystem/definitions.py
@@ -1,4 +1,6 @@
 """Configuration definitions."""
+from __future__ import annotations
+
 import copy
 import re
 
@@ -256,7 +258,7 @@ class ApplicationConfiguration:
 
     application_version: Union[Constants, str]
     entries: List[SettingsEntry]
-    internals: "Internals"
+    internals: Internals
     post_processor: "NavigatorPostProcessor"
     subcommands: List[SubCommand]
 

--- a/src/ansible_navigator/configuration_subsystem/definitions.py
+++ b/src/ansible_navigator/configuration_subsystem/definitions.py
@@ -259,7 +259,7 @@ class ApplicationConfiguration:
     application_version: Union[Constants, str]
     entries: List[SettingsEntry]
     internals: Internals
-    post_processor: "NavigatorPostProcessor"
+    post_processor: NavigatorPostProcessor
     subcommands: List[SubCommand]
 
     application_name: str = ""

--- a/src/ansible_navigator/content_defs.py
+++ b/src/ansible_navigator/content_defs.py
@@ -1,4 +1,5 @@
 """Definitions of UI content objects."""
+from __future__ import annotations
 
 from dataclasses import asdict
 from dataclasses import dataclass
@@ -26,7 +27,7 @@ class ContentView(Enum):
 
 
 T = TypeVar("T")
-DictType: "TypeAlias" = Dict[str, T]
+DictType: TypeAlias = Dict[str, T]
 
 
 class SerializationFormat(Enum):

--- a/src/ansible_navigator/tm_tokenize/compiler.py
+++ b/src/ansible_navigator/tm_tokenize/compiler.py
@@ -34,8 +34,8 @@ class Compiler:
         """
         self._root_scope = grammar.scope_name
         self._grammars = grammars
-        self._rule_to_grammar: Dict["_Rule", "Grammar"] = {}
-        self._c_rules: Dict[_Rule, "CompiledRule"] = {}
+        self._rule_to_grammar: Dict[_Rule, Grammar] = {}
+        self._c_rules: Dict[_Rule, CompiledRule] = {}
         root = self._compile_root(grammar)
         self.root_state = State.root(Entry(root.name, root, ("", 0)))
 
@@ -92,14 +92,14 @@ class Compiler:
                 raise AssertionError(f"unreachable {rule}")
         return ret_regs, tuple(ret_rules)
 
-    def _captures_ref(self, grammar: Grammar, captures: Captures) -> "Captures":
+    def _captures_ref(self, grammar: Grammar, captures: Captures) -> Captures:
         return tuple((n, self._visit_rule(grammar, r)) for n, r in captures)
 
-    def _compile_root(self, grammar: Grammar) -> "PatternRule":
+    def _compile_root(self, grammar: Grammar) -> PatternRule:
         regs, rules = self._patterns(grammar, grammar.patterns)
         return PatternRule((grammar.scope_name,), make_regset(*regs), rules)
 
-    def _compile_rule(self, grammar: Grammar, rule: _Rule) -> "CompiledRule":
+    def _compile_rule(self, grammar: Grammar, rule: _Rule) -> CompiledRule:
         assert rule.include is None, rule
         if rule.match is not None:
             captures_ref = self._captures_ref(grammar, rule.captures)
@@ -130,7 +130,7 @@ class Compiler:
             regs, rules = self._patterns(grammar, rule.patterns)
             return PatternRule(rule.name, make_regset(*regs), rules)
 
-    def compile_rule(self, rule: _Rule) -> "CompiledRule":
+    def compile_rule(self, rule: _Rule) -> CompiledRule:
         try:
             return self._c_rules[rule]
         except KeyError:

--- a/src/ansible_navigator/tm_tokenize/compiler.py
+++ b/src/ansible_navigator/tm_tokenize/compiler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 
 from typing import TYPE_CHECKING
@@ -24,7 +26,7 @@ if TYPE_CHECKING:
 
 
 class Compiler:
-    def __init__(self, grammar: "Grammar", grammars: "Grammars") -> None:
+    def __init__(self, grammar: Grammar, grammars: Grammars) -> None:
         """Initialize the grammar compiler.
 
         :param grammar: The grammar to compile, a text mate language file
@@ -37,7 +39,7 @@ class Compiler:
         root = self._compile_root(grammar)
         self.root_state = State.root(Entry(root.name, root, ("", 0)))
 
-    def _visit_rule(self, grammar: "Grammar", rule: "_Rule") -> "_Rule":
+    def _visit_rule(self, grammar: Grammar, rule: _Rule) -> "_Rule":
         self._rule_to_grammar[rule] = grammar
         return rule
 

--- a/src/ansible_navigator/tm_tokenize/compiler.py
+++ b/src/ansible_navigator/tm_tokenize/compiler.py
@@ -46,7 +46,7 @@ class Compiler:
     @functools.lru_cache(maxsize=None)
     def _include(
         self,
-        grammar: "Grammar",
+        grammar: Grammar,
         repository: FChainMap[str, "_Rule"],
         s: str,
     ) -> Tuple[List[str], Tuple["_Rule", ...]]:
@@ -68,7 +68,7 @@ class Compiler:
     @functools.lru_cache(maxsize=None)
     def _patterns(
         self,
-        grammar: "Grammar",
+        grammar: Grammar,
         rules: Tuple["_Rule", ...],
     ) -> Tuple[List[str], Tuple["_Rule", ...]]:
         ret_regs = []
@@ -92,14 +92,14 @@ class Compiler:
                 raise AssertionError(f"unreachable {rule}")
         return ret_regs, tuple(ret_rules)
 
-    def _captures_ref(self, grammar: "Grammar", captures: "Captures") -> "Captures":
+    def _captures_ref(self, grammar: Grammar, captures: Captures) -> "Captures":
         return tuple((n, self._visit_rule(grammar, r)) for n, r in captures)
 
-    def _compile_root(self, grammar: "Grammar") -> "PatternRule":
+    def _compile_root(self, grammar: Grammar) -> "PatternRule":
         regs, rules = self._patterns(grammar, grammar.patterns)
         return PatternRule((grammar.scope_name,), make_regset(*regs), rules)
 
-    def _compile_rule(self, grammar: "Grammar", rule: "_Rule") -> "CompiledRule":
+    def _compile_rule(self, grammar: Grammar, rule: _Rule) -> "CompiledRule":
         assert rule.include is None, rule
         if rule.match is not None:
             captures_ref = self._captures_ref(grammar, rule.captures)
@@ -130,7 +130,7 @@ class Compiler:
             regs, rules = self._patterns(grammar, rule.patterns)
             return PatternRule(rule.name, make_regset(*regs), rules)
 
-    def compile_rule(self, rule: "_Rule") -> "CompiledRule":
+    def compile_rule(self, rule: _Rule) -> "CompiledRule":
         try:
             return self._c_rules[rule]
         except KeyError:

--- a/src/ansible_navigator/tm_tokenize/compiler.py
+++ b/src/ansible_navigator/tm_tokenize/compiler.py
@@ -35,11 +35,11 @@ class Compiler:
         self._root_scope = grammar.scope_name
         self._grammars = grammars
         self._rule_to_grammar: Dict["_Rule", "Grammar"] = {}
-        self._c_rules: Dict["_Rule", "CompiledRule"] = {}
+        self._c_rules: Dict[_Rule, "CompiledRule"] = {}
         root = self._compile_root(grammar)
         self.root_state = State.root(Entry(root.name, root, ("", 0)))
 
-    def _visit_rule(self, grammar: Grammar, rule: _Rule) -> "_Rule":
+    def _visit_rule(self, grammar: Grammar, rule: _Rule) -> _Rule:
         self._rule_to_grammar[rule] = grammar
         return rule
 
@@ -47,9 +47,9 @@ class Compiler:
     def _include(
         self,
         grammar: Grammar,
-        repository: FChainMap[str, "_Rule"],
+        repository: FChainMap[str, _Rule],
         s: str,
-    ) -> Tuple[List[str], Tuple["_Rule", ...]]:
+    ) -> Tuple[List[str], Tuple[_Rule, ...]]:
         if s == "$self":
             return self._patterns(grammar, grammar.patterns)
         elif s == "$base":
@@ -69,10 +69,10 @@ class Compiler:
     def _patterns(
         self,
         grammar: Grammar,
-        rules: Tuple["_Rule", ...],
-    ) -> Tuple[List[str], Tuple["_Rule", ...]]:
+        rules: Tuple[_Rule, ...],
+    ) -> Tuple[List[str], Tuple[_Rule, ...]]:
         ret_regs = []
-        ret_rules: List["_Rule"] = []
+        ret_rules: List[_Rule] = []
         for rule in rules:
             if rule.include is not None:
                 tmp_regs, tmp_rules = self._include(grammar, rule.repository, rule.include)

--- a/src/ansible_navigator/tm_tokenize/reg.py
+++ b/src/ansible_navigator/tm_tokenize/reg.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import re
 
@@ -79,9 +81,9 @@ class _RegSet:
 def do_regset(
     idx: int,
     match: Optional[Match[str]],
-    rule: "CompiledRegsetRule",
-    compiler: "Compiler",
-    state: "State",
+    rule: CompiledRegsetRule,
+    compiler: Compiler,
+    state: State,
     pos: int,
 ) -> Optional[Tuple["State", int, bool, "Regions"]]:
     if match is None:

--- a/src/ansible_navigator/tm_tokenize/reg.py
+++ b/src/ansible_navigator/tm_tokenize/reg.py
@@ -85,7 +85,7 @@ def do_regset(
     compiler: Compiler,
     state: State,
     pos: int,
-) -> Optional[Tuple["State", int, bool, "Regions"]]:
+) -> Optional[Tuple[State, int, bool, Regions]]:
     if match is None:
         return None
 

--- a/src/ansible_navigator/tm_tokenize/rules.py
+++ b/src/ansible_navigator/tm_tokenize/rules.py
@@ -48,7 +48,7 @@ class CompiledRule(Protocol):
         compiler: Compiler,
         match: Match[str],
         state: State,
-    ) -> Tuple["State", bool, Regions]:
+    ) -> Tuple[State, bool, Regions]:
         ...
 
     def search(
@@ -152,7 +152,7 @@ class EndRule(NamedTuple):
         compiler: Compiler,
         match: Match[str],
         state: State,
-    ) -> Tuple["State", bool, "Regions"]:
+    ) -> Tuple[State, bool, Regions]:
         scope = state.cur.scope + self.name
         next_scope = scope + self.content_name
 
@@ -169,7 +169,7 @@ class EndRule(NamedTuple):
         state: State,
         pos: int,
         m: Match[str],
-    ) -> Tuple["State", int, bool, "Regions"]:
+    ) -> Tuple[State, int, bool, Regions]:
         ret = []
         if m.start() > pos:
             ret.append(Region(pos, m.start(), state.cur.scope))
@@ -218,7 +218,7 @@ class MatchRule(NamedTuple):
         compiler: Compiler,
         match: Match[str],
         state: State,
-    ) -> Tuple["State", bool, "Regions"]:
+    ) -> Tuple[State, bool, Regions]:
         scope = state.cur.scope + self.name
         return state, False, _captures(compiler, scope, match, self.captures)
 
@@ -245,7 +245,7 @@ class PatternRule(NamedTuple):
         compiler: Compiler,
         match: Match[str],
         state: State,
-    ) -> Tuple["State", bool, "Regions"]:
+    ) -> Tuple[State, bool, Regions]:
         raise AssertionError(f"unreachable {self}")
 
     def search(
@@ -374,7 +374,7 @@ class WhileRule(NamedTuple):
         compiler: Compiler,
         match: Match[str],
         state: State,
-    ) -> Tuple["State", bool, "Regions"]:
+    ) -> Tuple[State, bool, Regions]:
         scope = state.cur.scope + self.name
         next_scope = scope + self.content_name
 

--- a/src/ansible_navigator/tm_tokenize/rules.py
+++ b/src/ansible_navigator/tm_tokenize/rules.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from .compiler import Compiler
     from .region import Scope
 
-Captures = Tuple[Tuple[int, "_Rule"], ...]
+Captures = Tuple[Tuple[int, "_Rule"], ...]  # declared later
 
 
 def _split_name(s: Optional[str]) -> Tuple[str, ...]:
@@ -145,7 +145,7 @@ class EndRule(NamedTuple):
     end_captures: Captures
     end: str
     regset: _RegSet
-    u_rules: Tuple["_Rule", ...]
+    u_rules: Tuple[_Rule, ...]
 
     def start(
         self,
@@ -238,7 +238,7 @@ class MatchRule(NamedTuple):
 class PatternRule(NamedTuple):
     name: Tuple[str, ...]
     regset: _RegSet
-    u_rules: Tuple["_Rule", ...]
+    u_rules: Tuple[_Rule, ...]
 
     def start(
         self,
@@ -367,7 +367,7 @@ class WhileRule(NamedTuple):
     while_captures: Captures
     while_: str
     regset: _RegSet
-    u_rules: Tuple["_Rule", ...]
+    u_rules: Tuple[_Rule, ...]
 
     def start(
         self,

--- a/src/ansible_navigator/tm_tokenize/rules.py
+++ b/src/ansible_navigator/tm_tokenize/rules.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
@@ -43,16 +45,16 @@ class CompiledRule(Protocol):
 
     def start(
         self,
-        compiler: "Compiler",
+        compiler: Compiler,
         match: Match[str],
-        state: "State",
+        state: State,
     ) -> Tuple["State", bool, Regions]:
         ...
 
     def search(
         self,
-        compiler: "Compiler",
-        state: "State",
+        compiler: Compiler,
+        state: State,
         line: str,
         pos: int,
         first_line: bool,
@@ -142,14 +144,14 @@ class EndRule(NamedTuple):
     begin_captures: Captures
     end_captures: Captures
     end: str
-    regset: "_RegSet"
+    regset: _RegSet
     u_rules: Tuple["_Rule", ...]
 
     def start(
         self,
-        compiler: "Compiler",
+        compiler: Compiler,
         match: Match[str],
-        state: "State",
+        state: State,
     ) -> Tuple["State", bool, "Regions"]:
         scope = state.cur.scope + self.name
         next_scope = scope + self.content_name
@@ -163,8 +165,8 @@ class EndRule(NamedTuple):
 
     def _end_ret(
         self,
-        compiler: "Compiler",
-        state: "State",
+        compiler: Compiler,
+        state: State,
         pos: int,
         m: Match[str],
     ) -> Tuple["State", int, bool, "Regions"]:
@@ -185,8 +187,8 @@ class EndRule(NamedTuple):
 
     def search(
         self,
-        compiler: "Compiler",
-        state: "State",
+        compiler: Compiler,
+        state: State,
         line: str,
         pos: int,
         first_line: bool,
@@ -209,21 +211,21 @@ class EndRule(NamedTuple):
 @uniquely_constructed
 class MatchRule(NamedTuple):
     name: Tuple[str, ...]
-    captures: "Captures"
+    captures: Captures
 
     def start(
         self,
-        compiler: "Compiler",
+        compiler: Compiler,
         match: Match[str],
-        state: "State",
+        state: State,
     ) -> Tuple["State", bool, "Regions"]:
         scope = state.cur.scope + self.name
         return state, False, _captures(compiler, scope, match, self.captures)
 
     def search(
         self,
-        compiler: "Compiler",
-        state: "State",
+        compiler: Compiler,
+        state: State,
         line: str,
         pos: int,
         first_line: bool,
@@ -235,21 +237,21 @@ class MatchRule(NamedTuple):
 @uniquely_constructed
 class PatternRule(NamedTuple):
     name: Tuple[str, ...]
-    regset: "_RegSet"
+    regset: _RegSet
     u_rules: Tuple["_Rule", ...]
 
     def start(
         self,
-        compiler: "Compiler",
+        compiler: Compiler,
         match: Match[str],
-        state: "State",
+        state: State,
     ) -> Tuple["State", bool, "Regions"]:
         raise AssertionError(f"unreachable {self}")
 
     def search(
         self,
-        compiler: "Compiler",
-        state: "State",
+        compiler: Compiler,
+        state: State,
         line: str,
         pos: int,
         first_line: bool,
@@ -267,10 +269,10 @@ class Rule(NamedTuple):
     end: Optional[str]
     while_: Optional[str]
     content_name: Tuple[str, ...]
-    captures: "Captures"
-    begin_captures: "Captures"
-    end_captures: "Captures"
-    while_captures: "Captures"
+    captures: Captures
+    begin_captures: Captures
+    end_captures: Captures
+    while_captures: Captures
     include: Optional[str]
     patterns: Tuple[_Rule, ...]
     repository: FChainMap[str, _Rule]
@@ -361,17 +363,17 @@ class Rule(NamedTuple):
 class WhileRule(NamedTuple):
     name: Tuple[str, ...]
     content_name: Tuple[str, ...]
-    begin_captures: "Captures"
-    while_captures: "Captures"
+    begin_captures: Captures
+    while_captures: Captures
     while_: str
-    regset: "_RegSet"
+    regset: _RegSet
     u_rules: Tuple["_Rule", ...]
 
     def start(
         self,
-        compiler: "Compiler",
+        compiler: Compiler,
         match: Match[str],
-        state: "State",
+        state: State,
     ) -> Tuple["State", bool, "Regions"]:
         scope = state.cur.scope + self.name
         next_scope = scope + self.content_name
@@ -386,8 +388,8 @@ class WhileRule(NamedTuple):
 
     def continues(
         self,
-        compiler: "Compiler",
-        state: "State",
+        compiler: Compiler,
+        state: State,
         line: str,
         pos: int,
         first_line: bool,
@@ -402,8 +404,8 @@ class WhileRule(NamedTuple):
 
     def search(
         self,
-        compiler: "Compiler",
-        state: "State",
+        compiler: Compiler,
+        state: State,
         line: str,
         pos: int,
         first_line: bool,
@@ -414,10 +416,10 @@ class WhileRule(NamedTuple):
 
 
 def _captures(
-    compiler: "Compiler",
-    scope: "Scope",
+    compiler: Compiler,
+    scope: Scope,
     match: Match[str],
-    captures: "Captures",
+    captures: Captures,
 ) -> "Regions":
     ret: List[Region] = []
     pos, pos_end = match.span()
@@ -461,11 +463,11 @@ def _captures(
 
 
 def _inner_capture_parse(
-    compiler: "Compiler",
+    compiler: Compiler,
     start: int,
     s: str,
-    scope: "Scope",
-    rule: "CompiledRule",
+    scope: Scope,
+    rule: CompiledRule,
 ) -> "Regions":
     state = State.root(Entry(scope + rule.name, rule, (s, 0)))
     _, regions = tokenize(compiler, state, s, first_line=False)

--- a/src/ansible_navigator/tm_tokenize/state.py
+++ b/src/ansible_navigator/tm_tokenize/state.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 from typing import NamedTuple
 from typing import Tuple
@@ -13,24 +15,24 @@ class State(NamedTuple):
     while_stack: Tuple[Tuple["WhileRule", int], ...]
 
     @classmethod
-    def root(cls, entry: "Entry") -> "State":
+    def root(cls, entry: Entry) -> State:
         return cls((entry,), ())
 
     @property
-    def cur(self) -> "Entry":
+    def cur(self) -> Entry:
         return self.entries[-1]
 
-    def push(self, entry: "Entry") -> "State":
+    def push(self, entry: Entry) -> State:
         return self._replace(entries=(*self.entries, entry))
 
-    def pop(self) -> "State":
+    def pop(self) -> State:
         return self._replace(entries=self.entries[:-1])
 
-    def push_while(self, rule: "WhileRule", entry: "Entry") -> "State":
+    def push_while(self, rule: WhileRule, entry: Entry) -> State:
         entries = (*self.entries, entry)
         while_stack = (*self.while_stack, (rule, len(entries)))
         return self._replace(entries=entries, while_stack=while_stack)
 
-    def pop_while(self) -> "State":
+    def pop_while(self) -> State:
         entries, while_stack = self.entries[:-1], self.while_stack[:-1]
         return self._replace(entries=entries, while_stack=while_stack)

--- a/src/ansible_navigator/tm_tokenize/tokenize.py
+++ b/src/ansible_navigator/tm_tokenize/tokenize.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 from typing import List
 from typing import Tuple
@@ -12,7 +14,7 @@ if TYPE_CHECKING:
 
 
 def tokenize(
-    compiler: "Compiler",
+    compiler: Compiler,
     state: State,
     line: str,
     first_line: bool,

--- a/src/ansible_navigator/ui_framework/field_checks.py
+++ b/src/ansible_navigator/ui_framework/field_checks.py
@@ -1,4 +1,6 @@
 """Individual field check, the form field checks and radio check."""
+from __future__ import annotations
+
 import sys
 
 from dataclasses import dataclass
@@ -65,7 +67,7 @@ class FieldChecks:
             min_selected=self.min_selected,
         )
 
-    def _validate(self, response: "FieldChecks") -> Validation:
+    def _validate(self, response: FieldChecks) -> Validation:
         validation = self.validator(choices=response.options)
         if validation.error_msg:
             self.valid = False
@@ -73,7 +75,7 @@ class FieldChecks:
             self.valid = True
         return validation
 
-    def validate(self, response: "FieldChecks") -> None:
+    def validate(self, response: FieldChecks) -> None:
         """Validate this FieldChecks instance.
 
         :param response: Instance to check and verify options are valid
@@ -84,7 +86,7 @@ class FieldChecks:
         validation = self._validate(response)
         self.current_error = validation.error_msg
 
-    def conditional_validation(self, response: "FieldChecks") -> None:
+    def conditional_validation(self, response: FieldChecks) -> None:
         """Conditional validation for a Fieldchecks instance.
 
         :param response: Instance to check and verify options are valid

--- a/src/ansible_navigator/ui_framework/field_radio.py
+++ b/src/ansible_navigator/ui_framework/field_radio.py
@@ -1,4 +1,5 @@
 """Individual check and the form field checks for radios."""
+from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
@@ -57,7 +58,7 @@ class FieldRadio:
         """
         return partial(FieldValidators.some_of_or_none, max_selected=1, min_selected=1)
 
-    def _validate(self, response: "FieldRadio") -> Validation:
+    def _validate(self, response: FieldRadio) -> Validation:
         validation = self.validator(choices=response.options)
         if validation.error_msg:
             self.valid = False
@@ -65,7 +66,7 @@ class FieldRadio:
             self.valid = True
         return validation
 
-    def validate(self, response: "FieldRadio") -> None:
+    def validate(self, response: FieldRadio) -> None:
         """Validate this FieldRadio instance.
 
         :param response: Instance to check and verify options are valid
@@ -73,7 +74,7 @@ class FieldRadio:
         validation = self._validate(response)
         self.current_error = validation.error_msg
 
-    def conditional_validation(self, response: "FieldRadio") -> None:
+    def conditional_validation(self, response: FieldRadio) -> None:
         """Conditional validation for a FieldRadio instance.
 
         :param response: Instance to check and verify options are valid

--- a/tests/integration/_cli2runner.py
+++ b/tests/integration/_cli2runner.py
@@ -1,4 +1,6 @@
 """Test from the CLI up to to the invocation of runner."""
+from __future__ import annotations
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Dict
@@ -36,7 +38,7 @@ class Cli2Runner:
 
     def run_test(
         self,
-        mocked_runner: "MagicMock",
+        mocked_runner: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
         cli_entry: str,

--- a/tests/integration/test_execution_environment.py
+++ b/tests/integration/test_execution_environment.py
@@ -1,4 +1,6 @@
 """Test the use of ``execution-environment`` through to runner."""
+from __future__ import annotations
+
 import os
 import shlex
 
@@ -55,7 +57,7 @@ class Test(Cli2Runner):
 
     def run_test(
         self,
-        mocked_runner: "MagicMock",
+        mocked_runner: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
         cli_entry: str,

--- a/tests/integration/test_execution_environment_image.py
+++ b/tests/integration/test_execution_environment_image.py
@@ -1,4 +1,6 @@
 """Test the use of ``execution-environment-image`` through to runner."""
+from __future__ import annotations
+
 import os
 import shlex
 
@@ -66,7 +68,7 @@ class Test(Cli2Runner):
 
     def run_test(
         self,
-        mocked_runner: "MagicMock",
+        mocked_runner: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
         cli_entry: str,

--- a/tests/integration/test_pass_environment_variable.py
+++ b/tests/integration/test_pass_environment_variable.py
@@ -1,4 +1,6 @@
 """Test the use of ``pass-environment-variable`` through to runner."""
+from __future__ import annotations
+
 import os
 import shlex
 
@@ -71,7 +73,7 @@ class Test(Cli2Runner):
 
     def run_test(
         self,
-        mocked_runner: "MagicMock",
+        mocked_runner: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
         cli_entry: str,

--- a/tests/integration/test_set_environment_variable.py
+++ b/tests/integration/test_set_environment_variable.py
@@ -1,4 +1,6 @@
 """Test the use of ``set-environment-variable`` through to runner."""
+from __future__ import annotations
+
 import os
 import shlex
 
@@ -71,7 +73,7 @@ class Test(Cli2Runner):
 
     def run_test(
         self,
-        mocked_runner: "MagicMock",
+        mocked_runner: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
         cli_entry: str,


### PR DESCRIPTION
As the minimal version of python is py38, we can now avoid having to quote type hint information.

Reference: https://adamj.eu/tech/2021/05/15/python-type-hints-future-annotations/
Partial-Fix: https://github.com/ansible/devtools/issues/65