### PR TITLE
Ignore case of error

### DIFF
--- a/tests/integration/test_stdout_exit_codes.py
+++ b/tests/integration/test_stdout_exit_codes.py
@@ -73,6 +73,7 @@ fixture_test_data = (
     StdoutTest(
         action_name="doc",
         action_params=(("cmdline", ["--json"]),),
+        # cspelldisable-next
         present="ncorrect options passed",
         return_code=5,
     ),

--- a/tests/integration/test_stdout_exit_codes.py
+++ b/tests/integration/test_stdout_exit_codes.py
@@ -73,7 +73,7 @@ fixture_test_data = (
     StdoutTest(
         action_name="doc",
         action_params=(("cmdline", ["--json"]),),
-        present="Incorrect options passed",
+        present="ncorrect options passed",
         return_code=5,
     ),
     StdoutTest(

--- a/tests/integration/test_stdout_exit_codes.py
+++ b/tests/integration/test_stdout_exit_codes.py
@@ -73,7 +73,7 @@ fixture_test_data = (
     StdoutTest(
         action_name="doc",
         action_params=(("cmdline", ["--json"]),),
-        # cspelldisable-next
+        # cspell:disable-next-line
         present="ncorrect options passed",
         return_code=5,
     ),


### PR DESCRIPTION
The error from ansible 2.13.4 is:

```
ERROR! Missing name(s), incorrect options passed for detailed documentation.
```

in 2.12.4 it was:

```
ERROR! Incorrect options passed
```

