### PR TITLE
Prep for libtmux version 0.15 +

### DIFF
--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -326,6 +326,11 @@ class TmuxSession:
         if mode == "shell" and send_clear:
             self._pane.send_keys("clear")
 
+        # Prior to libtmux v15, all empty lines were removed
+        # from the captured pane. For fixture readability, remove them here
+        # https://github.com/tmux-python/libtmux/pull/405/files
+        showing = [line for line in showing if line != ""]
+
         return showing
 
     def _get_cli_prompt(self):

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -326,7 +326,7 @@ class TmuxSession:
         if mode == "shell" and send_clear:
             self._pane.send_keys("clear")
 
-        # Prior to libtmux v15, all empty lines were removed
+        # Prior to libtmux v0.15, all empty lines were removed
         # from the captured pane. For fixture readability, remove them here
         # https://github.com/tmux-python/libtmux/pull/405/files
         showing = [line for line in showing if line != ""]


### PR DESCRIPTION
Prior to version 0.15 of libtmux, all empty lines were removed from the captured output. This restores that behavior to prep for that dependency upgrade.
 
Their change:
https://github.com/tmux-python/libtmux/pull/405/files