### PR TITLE
Remove execution image default from schema

### DIFF
--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -363,7 +363,9 @@ NavigatorConfiguration = ApplicationConfiguration(
             cli_parameters=CliParameters(short="--eei"),
             settings_file_path_override="execution-environment.image",
             short_description="Specify the name of the execution environment image",
-            value=SettingsEntryValue(default="quay.io/ansible/creator-ee:v0.9.1"),
+            value=SettingsEntryValue(
+                default="quay.io/ansible/creator-ee:v0.9.1", schema_default=C.NONE
+            ),
             version_added="v1.0",
         ),
         SettingsEntry(

--- a/src/ansible_navigator/configuration_subsystem/transform.py
+++ b/src/ansible_navigator/configuration_subsystem/transform.py
@@ -129,7 +129,8 @@ def to_schema(settings: ApplicationConfiguration) -> dict[str, Any]:
                 # A single item
                 subschema[dot_parts[-1]]["enum"] = choices
         if entry.value.schema_default is not Constants.NOT_SET:
-            subschema[dot_parts[-1]]["default"] = entry.value.schema_default
+            if entry.value.schema_default is not Constants.NONE:
+                subschema[dot_parts[-1]]["default"] = entry.value.schema_default
         elif entry.value.default is not Constants.NOT_SET:
             subschema[dot_parts[-1]]["default"] = entry.value.default
 

--- a/src/ansible_navigator/data/ansible-navigator.json
+++ b/src/ansible_navigator/data/ansible-navigator.json
@@ -304,7 +304,6 @@
                             "type": "object"
                         },
                         "image": {
-                            "default": "quay.io/ansible/creator-ee:v0.9.1",
                             "description": "Specify the name of the execution environment image",
                             "type": "string"
                         },


### PR DESCRIPTION
Becasue the execution environment image is subject to change frequently, no reason to include the default in the schema file.

This will avoid having to update ansible-lint with a fresh schema for every update of the eei.