### PR TITLE
Enable black formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,10 +47,6 @@ repos:
     hooks:
       - id: black
         language_version: python3
-        args:
-          - --diff
-          - --check
-          - .
 
   - repo: https://github.com/streetsidesoftware/cspell-cli
     rev: v6.12.0


### PR DESCRIPTION
This aligns the configuration of black with other devtools maintained projects.

Black will now reformat via precommit, instead of simply warning that it would have.