### PR TITLE
Diagnostics file permissions

### DIFF
--- a/src/ansible_navigator/data/ansible-navigator.json
+++ b/src/ansible_navigator/data/ansible-navigator.json
@@ -493,7 +493,7 @@
     "required": [
         "ansible-navigator"
     ],
-    "title": "ansible-navigator settings v2.1",
+    "title": "ansible-navigator settings v2.2",
     "type": "object",
-    "version": "2.1"
+    "version": "2.2"
 }

--- a/src/ansible_navigator/data/ansible-navigator.json
+++ b/src/ansible_navigator/data/ansible-navigator.json
@@ -493,7 +493,7 @@
     "required": [
         "ansible-navigator"
     ],
-    "title": "ansible-navigator settings v2.2",
+    "title": "ansible-navigator settings v2.1",
     "type": "object",
-    "version": "2.2"
+    "version": "2.1"
 }

--- a/src/ansible_navigator/utils/write_json.py
+++ b/src/ansible_navigator/utils/write_json.py
@@ -1,0 +1,34 @@
+"""Utilities for writing files with specific permissions."""
+from __future__ import annotations
+
+import json
+import os
+
+from functools import partial
+
+
+def opener(path: str, flags: int, mode: int) -> int:
+    """Open a file with the given path and flags.
+
+    :param path: The path of the file to open.
+    :param flags: The flags to use when opening the file.
+    :param mode: The mode to use when opening the file.
+    :return: The file descriptor of the opened file.
+    """
+    return os.open(path=path, flags=flags, mode=mode)
+
+
+def write_with_permissions(path: str, mode: int, content: object) -> None:
+    """Write a file with the given name.
+
+    :param content: The content we want to write in the file.
+    :param mode: The mode to use when writing the file.
+    :param path: The path of the file to write.
+    """
+    # Without this, the created file will have 0o777 - 0o022 (default umask) = 0o755 permissions
+    oldmask = os.umask(0)
+
+    opener_func = partial(opener, mode=mode)
+    with open(path, "w", encoding="utf-8", opener=opener_func) as f:
+        f.write(json.dumps(content, indent=4, sort_keys=True))
+    os.umask(oldmask)

--- a/tests/integration/diagnostics/test_for_permissions.py
+++ b/tests/integration/diagnostics/test_for_permissions.py
@@ -1,0 +1,41 @@
+"""Check diagnostics permissions."""
+from __future__ import annotations
+
+import os
+import subprocess
+
+from pathlib import Path
+
+import pytest
+
+from ansible_navigator.utils.functions import remove_ansi
+
+
+@pytest.mark.usefixtures("use_venv")
+def test(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Test diagnostics generation.
+
+    :param monkeypatch: Fixture for patching
+    :param settings_env_var_to_full: The pytest subtest fixture
+    :param tmp_path: The pytest tmp_path fixture
+
+    :raises AssertionError: When tests fails
+    """
+    monkeypatch.chdir(tmp_path)
+
+    proc_out = subprocess.run(
+        "ansible-navigator --diagnostics",
+        check=False,
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
+    stdout_lines = proc_out.stdout.splitlines()
+    assert "Diagnostics written to: " in stdout_lines[-1]
+
+    file_name = remove_ansi(stdout_lines[-1].split(":", 1)[-1].strip())
+    status = os.stat(file_name)
+    assert oct(status.st_mode)[-3:] == str(oct(0o600))[-3:]

--- a/tests/integration/diagnostics/test_for_permissions.py
+++ b/tests/integration/diagnostics/test_for_permissions.py
@@ -19,7 +19,6 @@ def test(
     """Test diagnostics generation.
 
     :param monkeypatch: Fixture for patching
-    :param settings_env_var_to_full: The pytest subtest fixture
     :param tmp_path: The pytest tmp_path fixture
 
     :raises AssertionError: When tests fails


### PR DESCRIPTION
Summary :
- To ensure the diagnostics file is not written to a world readable location
- Setting the file permissions to user only before writing
 