### PR TITLE
Source runtime and test image from dockerfile

### DIFF
--- a/.config/Dockerfile
+++ b/.config/Dockerfile
@@ -1,1 +1,0 @@
-FROM ghcr.io/ansible/creator-ee:v0.11.0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ version: 2
 updates:
   - package-ecosystem: docker
     # We use this file to load the last known good version of the image
-    directory: .config/
+    directory: .src/ansible_navigator/data
     schedule:
       interval: daily
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ version: 2
 updates:
   - package-ecosystem: docker
     # We use this file to load the last known good version of the image
-    directory: .src/ansible_navigator/data
+    directory: src/ansible_navigator/data/
     schedule:
       interval: daily
     labels:

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -13,6 +13,7 @@ from ..utils.functions import abs_user_path
 from ..utils.functions import get_share_directory
 from ..utils.functions import oxfordcomma
 from ..utils.key_value_store import KeyValueStore
+from ..utils.packaged_data import retrieve_content
 from .definitions import ApplicationConfiguration
 from .definitions import CliParameters
 from .definitions import Constants as C
@@ -86,6 +87,17 @@ def generate_share_directory():
     initialization_messages.extend(messages)
     initialization_exit_messages.extend(exit_messages)
     return share_directory
+
+
+def retrieve_default_ee_image() -> str:
+    """Retrieve the default execution environment image.
+
+    :returns: The default execution environment image.
+    """
+    file_contents = retrieve_content(APP_NAME, "default_ee_dockerfile")
+    from_line = (line for line in file_contents.splitlines() if line.startswith("FROM"))
+    image = next(from_line).split()[1]
+    return image
 
 
 @dataclass
@@ -364,7 +376,7 @@ NavigatorConfiguration = ApplicationConfiguration(
             settings_file_path_override="execution-environment.image",
             short_description="Specify the name of the execution environment image",
             value=SettingsEntryValue(
-                default="quay.io/ansible/creator-ee:v0.9.2",
+                default=retrieve_default_ee_image(),
                 schema_default=C.NONE,
             ),
             version_added="v1.0",

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -94,7 +94,7 @@ def retrieve_default_ee_image() -> str:
 
     :returns: The default execution environment image.
     """
-    file_contents = retrieve_content(APP_NAME, "default_ee_dockerfile")
+    file_contents = retrieve_content(app_name=APP_NAME, filename="default_ee_dockerfile")
     from_line = (line for line in file_contents.splitlines() if line.startswith("FROM"))
     image = next(from_line).split()[1]
     return image

--- a/src/ansible_navigator/data/default_ee_dockerfile
+++ b/src/ansible_navigator/data/default_ee_dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/ansible/creator-ee:v0.9.2

--- a/src/ansible_navigator/data/default_ee_dockerfile
+++ b/src/ansible_navigator/data/default_ee_dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/ansible/creator-ee:v0.9.2
+FROM quay.io/ansible/creator-ee:v0.9.2

--- a/src/ansible_navigator/utils/packaged_data.py
+++ b/src/ansible_navigator/utils/packaged_data.py
@@ -12,7 +12,8 @@ def retrieve_content(app_name: str, filename: str) -> str:
     """
     data_directory = "data"
     package = f"{app_name}.{data_directory}"
-    with importlib_resources.open_text(package, filename) as fh:
+
+    with importlib_resources.files(package).joinpath(filename).open("r", encoding="utf-8") as fh:
         content = fh.read()
 
     return content

--- a/src/ansible_navigator/utils/packaged_data.py
+++ b/src/ansible_navigator/utils/packaged_data.py
@@ -1,0 +1,18 @@
+"""Functionality related to the retrieval of packaged data files."""
+
+from .compatibility import importlib_resources
+
+
+def retrieve_content(app_name: str, filename: str) -> str:
+    """Retrieve the content of a packaged data file.
+
+    :param app_name: The name of the application.
+    :param filename: The name of the file to retrieve.
+    :returns: The content of the file.
+    """
+    data_directory = "data"
+    package = f"{app_name}.{data_directory}"
+    with importlib_resources.open_text(package, filename) as fh:
+        content = fh.read()
+
+    return content

--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -1,6 +1,10 @@
 """Constants with default values used throughout the tests."""
 import os
 
+from ansible_navigator.configuration_subsystem.navigator_configuration import (
+    retrieve_default_ee_image,
+)
+
 
 FIXTURES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "fixtures"))
 FIXTURES_COLLECTION_DIR = os.path.abspath(
@@ -9,6 +13,6 @@ FIXTURES_COLLECTION_DIR = os.path.abspath(
 
 # every attempt should be made for these images to share as many layers as possible
 # or really small
-DEFAULT_CONTAINER_IMAGE = "quay.io/ansible/creator-ee:v0.9.2"
+DEFAULT_CONTAINER_IMAGE = retrieve_default_ee_image()
 SMALL_TEST_IMAGE = "quay.io/ansible/python-base:latest"
 PULLABLE_IMAGE = "registry.hub.docker.com/library/alpine:latest"


### PR DESCRIPTION
Ongoing work to centralize the default ee.

1) move the docker file to the source so it is packaged
2) update dependabot to look in that location for docker ecosystem
3) pull from that file for the runtime default
4) use runtime logic to provide the default for tests

additional PRs:
1) will remove the tox entry
2) put the pull in pytest for the default ee
3) move other image names into dockerfiles
4) get rid of the constant being set to a function :)
5) Move from quay to ghcr when centralized
