### PR TITLE
Arrange test-ids to order them correctly

### DIFF
--- a/tests/integration/actions/images/test_direct_interactive_ee.py
+++ b/tests/integration/actions/images/test_direct_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import IMAGE_VERSION
 from .base import BaseClass
 from .base import base_steps
@@ -23,7 +23,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for images from CLI, interactive, with an EE."""
 

--- a/tests/integration/actions/images/test_direct_interactive_noee.py
+++ b/tests/integration/actions/images/test_direct_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import IMAGE_VERSION
 from .base import BaseClass
 from .base import base_steps
@@ -24,7 +24,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for images from CLI, interactive, without an EE."""
 

--- a/tests/integration/actions/images/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/images/test_welcome_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import IMAGE_VERSION
 from .base import BaseClass
 from .base import base_steps
@@ -24,7 +24,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for images from welcome, interactive, with an EE."""
 

--- a/tests/integration/actions/images/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/images/test_welcome_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import IMAGE_VERSION
 from .base import BaseClass
 from .base import base_steps
@@ -25,7 +25,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for images from welcome, interactive, without an EE."""
 

--- a/tests/integration/actions/inventory/test_direct_interactive_ee.py
+++ b/tests/integration/actions/inventory/test_direct_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
 from .base import BaseClass
 from .base import base_steps
@@ -20,7 +20,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for inventory from CLI, interactive, with an EE."""
 

--- a/tests/integration/actions/inventory/test_direct_interactive_noee.py
+++ b/tests/integration/actions/inventory/test_direct_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
 from .base import BaseClass
 from .base import base_steps
@@ -20,7 +20,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for inventory from CLI, interactive, without an EE."""
 

--- a/tests/integration/actions/inventory/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/inventory/test_welcome_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
 from .base import BaseClass
 from .base import base_steps
@@ -21,7 +21,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for inventory from CLI, interactive, with an EE."""
 

--- a/tests/integration/actions/inventory/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/inventory/test_welcome_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import ANSIBLE_INVENTORY_FIXTURE_DIR
 from .base import BaseClass
 from .base import base_steps
@@ -21,7 +21,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for inventory from CLI, interactive, without an EE."""
 

--- a/tests/integration/actions/run/test_direct_interactive_ee.py
+++ b/tests/integration/actions/run/test_direct_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import BaseClass
 from .base import base_steps
 from .base import inventory_path
@@ -25,7 +25,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for run from CLI, interactive, with an EE."""
 

--- a/tests/integration/actions/run/test_direct_interactive_noee.py
+++ b/tests/integration/actions/run/test_direct_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import BaseClass
 from .base import base_steps
 from .base import inventory_path
@@ -25,7 +25,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for run from CLI, interactive, without an EE."""
 

--- a/tests/integration/actions/run/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/run/test_welcome_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import BaseClass
 from .base import base_steps
 from .base import inventory_path
@@ -26,7 +26,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for run from welcome, interactive, with an EE."""
 

--- a/tests/integration/actions/run/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/run/test_welcome_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import BaseClass
 from .base import base_steps
 from .base import inventory_path
@@ -26,7 +26,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for run from welcome, interactive, without an EE."""
 

--- a/tests/integration/actions/templar/test_direct_interactive_ee.py
+++ b/tests/integration/actions/templar/test_direct_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import BaseClass
 from .base import base_steps
 from .base import inventory_path
@@ -25,7 +25,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for templar from CLI, interactive, with an EE."""
 

--- a/tests/integration/actions/templar/test_direct_interactive_noee.py
+++ b/tests/integration/actions/templar/test_direct_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import BaseClass
 from .base import base_steps
 from .base import inventory_path
@@ -25,7 +25,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for templar from CLI, interactive, without an EE."""
 

--- a/tests/integration/actions/templar/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/templar/test_welcome_interactive_ee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import BaseClass
 from .base import base_steps
 from .base import inventory_path
@@ -26,7 +26,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for templar from welcome, interactive, with an EE."""
 

--- a/tests/integration/actions/templar/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/templar/test_welcome_interactive_noee.py
@@ -4,7 +4,7 @@ import pytest
 from ..._interactions import Command
 from ..._interactions import UiTestStep
 from ..._interactions import add_indices
-from ..._interactions import step_id
+from ..._interactions import step_id_padded
 from .base import BaseClass
 from .base import base_steps
 from .base import inventory_path
@@ -26,7 +26,7 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.parametrize("step", steps, ids=step_id)
+@pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for templar from welcome, interactive, without an EE."""
 


### PR DESCRIPTION
**Summary**

- Use the `step_id_padded` function instead of `step_id` for getting index padded to 2 (i.e. 01-99 format)
- With this we can see the tests in correct order while using VSCode test tree.