### PR TITLE
Add more configuration entry in vscode settings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,11 +6,18 @@
       "name": "Debug tests",
       "type": "python",
       "request": "launch",
-      "module": "ansible_navigator",
-      // Uncomment args attribute to debug exec subcommand with some parameter.
-      // "args": ["exec", "--", "pwd"],
       "purpose": ["debug-test"],
       "console": "integratedTerminal"
+    },
+    // Configuration for pure debugging (use args attribute accordingly)
+    {
+      "name": "Python: Module",
+      "type": "python",
+      "request": "launch",
+      "module": "ansible_navigator",
+      "args": ["exec", "--", "pwd"],
+      "cwd": "${workspaceFolder}/src",
+      "justMyCode": false
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,9 @@
       "name": "Debug tests",
       "type": "python",
       "request": "launch",
+      "module": "ansible_navigator",
+      // Uncomment args attribute to debug exec subcommand with some parameter.
+      // "args": ["exec", "--", "pwd"],
       "purpose": ["debug-test"],
       "console": "integratedTerminal"
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
     },
     // Configuration for pure debugging (use args attribute accordingly)
     {
-      "name": "Python: Module",
+      "name": "Debug subcommand: exec",
       "type": "python",
       "request": "launch",
       "module": "ansible_navigator",


### PR DESCRIPTION
- This PR adds example configuration to debug ansible-navigator subcommands.
- Example of debugging `exec` subcommand is mentioned.