### PR TITLE
Use a valid container engine in exit code tests

### DIFF
--- a/tests/integration/test_stdout_exit_codes.py
+++ b/tests/integration/test_stdout_exit_codes.py
@@ -18,7 +18,11 @@ PLAYBOOK = os.path.join(FIXTURES_DIR, "integration", "stdout_exit_codes", "site.
 
 
 @pytest.fixture(name="params")
-def fixture_params(default_ee_image_name: str, request: pytest.FixtureRequest) -> dict[str, str]:
+def fixture_params(
+    default_ee_image_name: str,
+    valid_container_engine: str,
+    request: pytest.FixtureRequest,
+) -> dict[str, str]:
     """Generate parameters.
 
     :param default_ee_image_name: The default execution environment image name
@@ -26,6 +30,7 @@ def fixture_params(default_ee_image_name: str, request: pytest.FixtureRequest) -
     :returns: The parameters
     """
     return {
+        "container_engine": valid_container_engine,
         "execution_environment": request.param,
         "execution_environment_image": default_ee_image_name,
     }


### PR DESCRIPTION
Without being specified the default of `podman` was used.  This will allow the test to use the "valid" container engine for the system where the tests are being run.

This was identified while running tests on macos with docker.