### PR TITLE
Suggest a fetch all for settings migration test

### DIFF
--- a/tests/integration/version_migration/test_v1_v2_settings.py
+++ b/tests/integration/version_migration/test_v1_v2_settings.py
@@ -68,6 +68,8 @@ def test_all(
     if os.environ.get("ANSIBLE_NAVIGATOR_UPDATE_TEST_FIXTURES") == "true":
         shutil.copy(destination, corrected)
 
-    assert any("ansible-navigator 2." in line for line in result)
+    assert any(
+        "ansible-navigator 3." in line for line in result
+    ), "(Note: requires recent tags, `git fetch --all`)"
     assert filecmp.cmp(destination, corrected)
     assert filecmp.cmp(source, backup)

--- a/tests/integration/version_migration/test_v1_v2_settings.py
+++ b/tests/integration/version_migration/test_v1_v2_settings.py
@@ -69,7 +69,7 @@ def test_all(
         shutil.copy(destination, corrected)
 
     assert any(
-        "ansible-navigator 3." in line for line in result
+        "ansible-navigator 2." in line for line in result
     ), "(Note: requires recent tags, `git fetch --all`)"
     assert filecmp.cmp(destination, corrected)
     assert filecmp.cmp(source, backup)


### PR DESCRIPTION
This test requires at least one 2. tag for the version.  Should rarely be a problem, but since I forgot to fetch all it's safe to assume I or someone else with do it again.