### PR TITLE
Ensure volume mounted collections are identified as `bind_mount`

### DIFF
--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -520,6 +520,13 @@ class Action(ActionBase):
                 if not Path(source_str).is_dir:
                     continue
                 dest_path = Path(destination_str)
+                # /x/ansible_collections/co:/x/ansible_collections/co
+                if dest_path.parent.name == "ansible_collections":
+                    continue
+                # /x/ansible_collections/co/ns:/x/ansible_collections/co/ns
+                if dest_path.parent.parent.name == "ansible_collections":
+                    continue
+                # /x:/x
                 if dest_path.name != "ansible_collections":
                     dest_path /= "ansible_collections"
                 tmp_list.append(str(dest_path))

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -514,7 +514,25 @@ class Action(ActionBase):
         )
         volume_mounts = self.app.args.execution_environment_volume_mounts
         if isinstance(volume_mounts, list):
-            dest_volmounts = tuple(mount.split(":")[1] for mount in volume_mounts)
+            tmp_list = []
+            for mount in volume_mounts:
+                source_str, destination_str = mount.split(":")[0:2]
+                # the mount may be a file
+                if not Path(source_str).is_dir:
+                    continue
+                dest_path = Path(destination_str)
+                # /some/dir/collections/ansible_collections
+                if dest_path.parts[-2:] == ("collections", "ansible_collections"):
+                    pass
+                # /some/dir/collections
+                elif dest_path.parts[-1] == "collections":
+                    dest_path /= "ansible_collections"
+                # /some/dir
+                else:
+                    dest_path /= "collections"
+                    dest_path /= "ansible_collections"
+                tmp_list.append(str(dest_path))
+            dest_volmounts = tuple(tmp_list)
         else:
             dest_volmounts = tuple()
 

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -517,19 +517,10 @@ class Action(ActionBase):
             tmp_list = []
             for mount in volume_mounts:
                 source_str, destination_str = mount.split(":")[0:2]
-                # the mount may be a file
                 if not Path(source_str).is_dir:
                     continue
                 dest_path = Path(destination_str)
-                # /some/dir/collections/ansible_collections
-                if dest_path.parts[-2:] == ("collections", "ansible_collections"):
-                    pass
-                # /some/dir/collections
-                elif dest_path.parts[-1] == "collections":
-                    dest_path /= "ansible_collections"
-                # /some/dir
-                else:
-                    dest_path /= "collections"
+                if dest_path.name != "ansible_collections":
                     dest_path /= "ansible_collections"
                 tmp_list.append(str(dest_path))
             dest_volmounts = tuple(tmp_list)

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -485,12 +485,14 @@ class Action(ActionBase):
             self._parse(output)
 
     def _parse(self, output) -> None:
-        # pylint: disable=too-many-branches
         """Load and process the ``json`` output from the collection cataloging process.
 
         :param output: The output from the collection cataloging process
         :returns: Nothing
         """
+        # pylint: disable=too-many-branches
+        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-statements
         try:
             if not output.startswith("{"):
                 _warnings, json_str = output.split("{", 1)
@@ -517,7 +519,7 @@ class Action(ActionBase):
             tmp_list = []
             for mount in volume_mounts:
                 source_str, destination_str = mount.split(":")[0:2]
-                if not Path(source_str).is_dir:
+                if not Path(source_str).is_dir():
                     continue
                 dest_path = Path(destination_str)
                 # /x/ansible_collections/co:/x/ansible_collections/co

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -532,16 +532,16 @@ class Action(ActionBase):
                 if dest_path.name != "ansible_collections":
                     dest_path /= "ansible_collections"
                 tmp_list.append(str(dest_path))
-            dest_volmounts = tuple(tmp_list)
+            dest_volume_mounts = tuple(tmp_list)
         else:
-            dest_volmounts = tuple()
+            dest_volume_mounts = tuple()
 
         for collection in self._collections:
             collection["__name"] = collection["known_as"]
             collection["__version"] = collection["collection_info"].get("version", "missing")
             collection["__shadowed"] = bool(collection["hidden_by"])
             if self._args.execution_environment:
-                if collection["path"].startswith(dest_volmounts):
+                if collection["path"].startswith(dest_volume_mounts):
                     collection["__type"] = "bind_mount"
                 elif collection["path"].startswith(self._adjacent_collection_dir):
                     collection["__type"] = "bind_mount"

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -512,12 +512,20 @@ class Action(ActionBase):
             list(parsed["collections"].values()),
             key=lambda i: i["known_as"],
         )
+        volume_mounts = self.app.args.execution_environment_volume_mounts
+        if isinstance(volume_mounts, list):
+            dest_volmounts = tuple(mount.split(":")[1] for mount in volume_mounts)
+        else:
+            dest_volmounts = tuple()
+
         for collection in self._collections:
             collection["__name"] = collection["known_as"]
             collection["__version"] = collection["collection_info"].get("version", "missing")
             collection["__shadowed"] = bool(collection["hidden_by"])
             if self._args.execution_environment:
-                if collection["path"].startswith(self._adjacent_collection_dir):
+                if collection["path"].startswith(dest_volmounts):
+                    collection["__type"] = "bind_mount"
+                elif collection["path"].startswith(self._adjacent_collection_dir):
                     collection["__type"] = "bind_mount"
                 elif collection["path"].startswith(os.path.dirname(self._adjacent_collection_dir)):
                     collection["__type"] = "bind_mount"


### PR DESCRIPTION
Closes #1265

This should identify if a collection found was in a volume mount.

All collections will be found in a xxxx/ansible_collections directory so we'll append ansible_collections as needed.

No tests are included, as json output for collections will be added and can be used to test this without tmux soon.

Related #1417