### PR TITLE
ansible-navigator for all

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [//]: # (DO-NOT-REMOVE-docs-intro-START)
 
-A text-based user interface (TUI) for the Red Hat Ansible Automation Platform.
+A text-based user interface (TUI) for Ansible.
 
 A demo of the interface can be found [on YouTube][YT demo].
 


### PR DESCRIPTION
ansible-navigator can be used on upstream Ansible, not just downsteam AAP