### PR TITLE
Runner artifact cleanup

### DIFF
--- a/src/ansible_navigator/runner/base.py
+++ b/src/ansible_navigator/runner/base.py
@@ -86,7 +86,6 @@ class Base:
         self.finished: bool = False
         self.status: str | None = None
         self._runner_args: dict = {}
-        self._runner_artifact_dir: str | None = None
         if self._ee:
             self._runner_args.update(
                 {
@@ -105,7 +104,6 @@ class Base:
                 "quiet": True,
                 "cancel_callback": self.runner_cancelled_callback,
                 "finished_callback": self.runner_finished_callback,
-                "artifacts_handler": self.runner_artifacts_handler,
                 "timeout": self._timeout,
             },
         )
@@ -165,15 +163,6 @@ class Base:
         self._private_data_dir_is_tmp = source != "user provided"
         self._private_data_dir = private_data_directory
         self._logger.debug("private data dir %s: %s", source, self._private_data_dir)
-
-    def runner_artifacts_handler(self, artifact_dir):
-        """Ansible-runner callback to handle artifacts after each runner invocation.
-
-        :param artifact_dir: The directory path of artifact directory for current
-            runner invocation.
-        """
-        self._logger.debug("ansible-runner artifact_dir set to: '%s'", artifact_dir)
-        self._runner_artifact_dir = artifact_dir
 
     def runner_cancelled_callback(self):
         """Check by runner to see if it should cancel.

--- a/src/ansible_navigator/runner/base.py
+++ b/src/ansible_navigator/runner/base.py
@@ -125,17 +125,17 @@ class Base:
             )
 
     def __del__(self):
-        """Drop the artifact directory when the rotation is disabled."""
+        """Drop the private_data_dir if it is temporary."""
         if (
-            self._rotate_artifacts is not None
-            and self._runner_artifact_dir
-            and os.path.exists(self._runner_artifact_dir)
+            self._private_data_dir_is_tmp
+            and self._private_data_dir
+            and os.path.exists(self._private_data_dir)
         ):
             self._logger.debug(
-                "delete ansible-runner artifact directory at path %s",
-                self._runner_artifact_dir,
+                "delete temporary ansible-runner private_data_dir at path %s",
+                self._private_data_dir,
             )
-            shutil.rmtree(self._runner_artifact_dir, ignore_errors=True)
+            shutil.rmtree(self._private_data_dir, ignore_errors=True)
 
     @staticmethod
     def _generate_tmp_directory():
@@ -155,13 +155,14 @@ class Base:
                 private_data_directory = provided
                 source = "user provided"
             else:
-                self._logger.debug("Provided private data dir `%s` was not user writable")
+                self._logger.debug("Provided private data dir `%s` was not user writable", provided)
                 private_data_directory = self._generate_tmp_directory()
                 source = "user provided, but changed to tmp location due to permissions"
         else:
             private_data_directory = self._generate_tmp_directory()
             source = "not user provided, used tmp location"
 
+        self._private_data_dir_is_tmp = source != "user provided"
         self._private_data_dir = private_data_directory
         self._logger.debug("private data dir %s: %s", source, self._private_data_dir)
 


### PR DESCRIPTION
The artifact_dir was only deleted if --rac was set by the user. 

This will now delete the entire temporary private_data_dir instead of just the artifacts_dir from the last run if the private_data_dir is a generated temp directory. 

Closes: #497 
Closes: #520


