### PR TITLE
Down version for select deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --extra=docs --extra=test --no-annotate --output-file=requirements.txt --strip-extras setup.cfg
 #
 ansible-builder==1.2.0
-ansible-core==2.14.3
+ansible-core==2.13.7
 ansible-runner==2.3.2
 attrs==22.2.0
 beautifulsoup4==4.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ iniconfig==2.0.0
 jinja2==3.1.2
 jsmin==3.0.1
 jsonschema==4.17.3
-libtmux==0.21.0
+libtmux==0.16.1
 lockfile==0.12.2
 markdown==3.3.7
 markdown-exec==1.3.0


### PR DESCRIPTION
`libtmux` - something changed related to screen width
`ansible-core` - ansible inventory output order appears to have changed

These should be upgraded after tests are green. 

Related #1450 