### PR TITLE
Remove dep on pkg_resources, ignore runner err

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
       "type": "python",
       "request": "launch",
       "module": "ansible_navigator",
-      "args": ["--diagnostics"],
+      "args": ["exec", "--", "pwd"],
       "cwd": "${workspaceFolder}/src",
       "justMyCode": false
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
       "type": "python",
       "request": "launch",
       "module": "ansible_navigator",
-      "args": ["exec", "--", "pwd"],
+      "args": ["--diagnostics"],
       "cwd": "${workspaceFolder}/src",
       "justMyCode": false
     }

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     ansible-builder >=1, <2
     ansible-runner >=2.3.1, <3
     backports.zoneinfo; python_version < "3.9.0"
+    importlib-metadata; python_version < "3.10.0"
     importlib-resources; python_version < "3.9.0"
     jinja2
     jsonschema

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -57,10 +57,7 @@ def log_dependencies() -> list[LogMessage]:
         for pkg_name in pkg_names:
             if pkg_name not in found:
                 found.append(pkg_name)
-                try:
-                    spec = find_spec(python_name)
-                except ModuleNotFoundError:
-                    spec = None
+                spec = find_spec(pkg_name)
                 if spec:
                     _location = spec.origin
                 else:

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -9,7 +9,6 @@ import sys
 
 from copy import deepcopy
 from curses import wrapper
-from importlib.metadata import packages_distributions
 from importlib.metadata import version
 from importlib.util import find_spec
 from pathlib import Path
@@ -27,6 +26,7 @@ from .image_manager import ImagePuller
 from .initialization import error_and_exit_early
 from .initialization import parse_and_update
 from .logger import setup_logger
+from .utils.compatibility import packages_distributions
 from .utils.definitions import ExitMessage
 from .utils.definitions import ExitPrefix
 from .utils.definitions import LogMessage

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -57,7 +57,10 @@ def log_dependencies() -> list[LogMessage]:
         for pkg_name in pkg_names:
             if pkg_name not in found:
                 found.append(pkg_name)
-                spec = find_spec(python_name)
+                try:
+                    spec = find_spec(python_name)
+                except ModuleNotFoundError:
+                    spec = None
                 if spec:
                     _location = spec.origin
                 else:

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -9,9 +9,10 @@ import sys
 
 from copy import deepcopy
 from curses import wrapper
+from importlib.metadata import packages_distributions
+from importlib.metadata import version
+from importlib.util import find_spec
 from pathlib import Path
-
-from pkg_resources import working_set
 
 from .action_defs import ActionReturn
 from .action_defs import RunInteractiveReturn
@@ -50,9 +51,18 @@ def log_dependencies() -> list[LogMessage]:
 
     :returns: All packages, version and location
     """
-    # pylint: disable=not-an-iterable
-    installed_packages_list = sorted(f"{i.key}=={i.version} {i.location}" for i in working_set)
-    messages = [LogMessage(level=logging.DEBUG, message=pkg) for pkg in installed_packages_list]
+    pkgs = []
+    found = []
+    for python_name, pkg_names in packages_distributions().items():
+        for pkg_name in pkg_names:
+            if pkg_name not in found:
+                found.append(pkg_name)
+                _location = find_spec(python_name).origin
+                _version = version(pkg_name)
+                pkgs.append(f"{pkg_name}=={_version} {_location}")
+
+    pkgs.sort()
+    messages = [LogMessage(level=logging.DEBUG, message=pkg) for pkg in pkgs]
     return messages
 
 

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -53,7 +53,7 @@ def log_dependencies() -> list[LogMessage]:
     """
     pkgs = []
     found = []
-    for python_name, pkg_names in importlib_metadata.packages_distributions().items():
+    for _python_name, pkg_names in importlib_metadata.packages_distributions().items():
         for pkg_name in pkg_names:
             if pkg_name not in found:
                 found.append(pkg_name)

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -26,7 +26,7 @@ from .image_manager import ImagePuller
 from .initialization import error_and_exit_early
 from .initialization import parse_and_update
 from .logger import setup_logger
-from .utils.compatibility import packages_distributions
+from .utils.compatibility import importlib_metadata
 from .utils.definitions import ExitMessage
 from .utils.definitions import ExitPrefix
 from .utils.definitions import LogMessage
@@ -53,11 +53,15 @@ def log_dependencies() -> list[LogMessage]:
     """
     pkgs = []
     found = []
-    for python_name, pkg_names in packages_distributions().items():
+    for python_name, pkg_names in importlib_metadata.packages_distributions().items():
         for pkg_name in pkg_names:
             if pkg_name not in found:
                 found.append(pkg_name)
-                _location = find_spec(python_name).origin
+                spec = find_spec(python_name)
+                if spec:
+                    _location = spec.origin
+                else:
+                    _location = ""
                 _version = version(pkg_name)
                 pkgs.append(f"{pkg_name}=={_version} {_location}")
 

--- a/src/ansible_navigator/diagnostics.py
+++ b/src/ansible_navigator/diagnostics.py
@@ -9,7 +9,6 @@ from dataclasses import asdict
 from dataclasses import dataclass
 from importlib.metadata import distribution
 from importlib.metadata import metadata
-from importlib.metadata import packages_distributions
 from importlib.util import find_spec
 from pathlib import Path
 from sys import stdout
@@ -28,6 +27,7 @@ from .configuration_subsystem.definitions import ApplicationConfiguration
 from .image_manager import introspect
 from .image_manager import introspector
 from .utils import ansi
+from .utils.compatibility import packages_distributions
 from .utils.definitions import ExitMessage
 from .utils.definitions import LogMessage
 from .utils.functions import now_iso

--- a/src/ansible_navigator/diagnostics.py
+++ b/src/ansible_navigator/diagnostics.py
@@ -365,7 +365,10 @@ class DiagnosticsCollector:
             for pkg_name in pkg_names:
                 if pkg_name not in meta:
                     meta[pkg_name] = importlib_metadata.metadata(pkg_name).json
-                    spec = find_spec(python_name)
+                    try:
+                        spec = find_spec(python_name)
+                    except ModuleNotFoundError:
+                        spec = None
                     if spec:
                         meta[pkg_name]["location"] = spec.origin
                     meta[pkg_name]["requires"] = importlib_metadata.distribution(pkg_name).requires

--- a/src/ansible_navigator/diagnostics.py
+++ b/src/ansible_navigator/diagnostics.py
@@ -365,10 +365,7 @@ class DiagnosticsCollector:
             for pkg_name in pkg_names:
                 if pkg_name not in meta:
                     meta[pkg_name] = importlib_metadata.metadata(pkg_name).json
-                    try:
-                        spec = find_spec(python_name)
-                    except ModuleNotFoundError:
-                        spec = None
+                    spec = find_spec(pkg_name)
                     if spec:
                         meta[pkg_name]["location"] = spec.origin
                     meta[pkg_name]["requires"] = importlib_metadata.distribution(pkg_name).requires

--- a/src/ansible_navigator/diagnostics.py
+++ b/src/ansible_navigator/diagnostics.py
@@ -361,7 +361,7 @@ class DiagnosticsCollector:
         """
         pkgs = importlib_metadata.packages_distributions()
         meta: dict[str, Any] = {}
-        for python_name, pkg_names in pkgs.items():
+        for _python_name, pkg_names in pkgs.items():
             for pkg_name in pkg_names:
                 if pkg_name not in meta:
                     meta[pkg_name] = importlib_metadata.metadata(pkg_name).json

--- a/src/ansible_navigator/diagnostics.py
+++ b/src/ansible_navigator/diagnostics.py
@@ -7,6 +7,10 @@ import traceback
 
 from dataclasses import asdict
 from dataclasses import dataclass
+from importlib.metadata import distribution
+from importlib.metadata import metadata
+from importlib.metadata import packages_distributions
+from importlib.util import find_spec
 from pathlib import Path
 from sys import stdout
 from typing import Callable
@@ -14,8 +18,6 @@ from typing import Dict
 from typing import Iterator
 from typing import List
 from typing import Union
-
-from pkg_resources import working_set
 
 from .command_runner import Command
 from .command_runner import CommandRunner
@@ -358,10 +360,15 @@ class DiagnosticsCollector:
 
         :returns: The python packages information
         """
-        return {
-            i.key: {"location": i.location, "name": i.key, "version": i.version}
-            for i in working_set  # pylint: disable=not-an-iterable
-        }
+        pkgs = packages_distributions()
+        meta = {}
+        for python_name, pkg_names in pkgs.items():
+            for pkg_name in pkg_names:
+                if pkg_name not in meta:
+                    meta[pkg_name] = dict(metadata(pkg_name))
+                    meta[pkg_name]["location"] = find_spec(python_name).origin
+                    meta[pkg_name]["requires"] = distribution(pkg_name).requires
+        return meta
 
     @diagnostic_runner
     @register(Collector(name="settings"))

--- a/src/ansible_navigator/utils/compatibility.py
+++ b/src/ansible_navigator/utils/compatibility.py
@@ -32,6 +32,6 @@ else:
 
 
 if sys.version_info < (3, 10):
-    from importlib_metadata import packages_distributions
+    import importlib_metadata
 else:
-    from importlib.metadata import packages_distributions
+    import importlib.metadata as importlib_metadata

--- a/src/ansible_navigator/utils/compatibility.py
+++ b/src/ansible_navigator/utils/compatibility.py
@@ -29,3 +29,9 @@ else:
     import importlib.resources as importlib_resources
 
     from importlib.abc import Traversable
+
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import packages_distributions
+else:
+    from importlib.metadata import packages_distributions

--- a/src/ansible_navigator/version.py
+++ b/src/ansible_navigator/version.py
@@ -3,9 +3,9 @@ try:
     from ._version import version as __version__
 except ImportError:  # pragma: no branch
     try:
-        import pkg_resources
+        from importlib.metadata import version
 
-        __version__ = pkg_resources.get_distribution("ansible-navigator").version
+        __version__ = version("ansible-navigator")
     except Exception:  # pylint: disable=broad-except
         # this is the fallback SemVer version picked by setuptools_scm when tag
         # information is not available.

--- a/tests/unit/test_circular_imports.py
+++ b/tests/unit/test_circular_imports.py
@@ -96,6 +96,11 @@ def test_no_warnings(import_path: str) -> None:
         "-W",
         "ignore: 'pipes' is deprecated and slated for removal in Python 3.13:DeprecationWarning:"
         "ansible_runner.utils",
+        # NOTE: This exclusion is only necessary because ansible-runner still uses `pkg_resources`
+        # NOTE: could not figure out how to ignore this warning only for ansible-runner
+        # https://github.com/ansible/ansible-runner/issues/1223
+        "-W",
+        "ignore: pkg_resources is deprecated as an API:DeprecationWarning",
         "-c",
         f"import {import_path!s}",
     )


### PR DESCRIPTION
Related: https://github.com/ansible/ansible-runner/issues/1223

`pkg_resources` is deprecated https://github.com/pypa/setuptools/blob/main/pkg_resources/__init__.py#L121