### PR TITLE
Docs and type hints in test integration root (D/DAR)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -76,11 +76,6 @@ per-file-ignores =
 
   # The following were present during the initial implementation.
   # They are expected to be fixed and unignored over time.
-  tests/integration/_action_run_test.py: D205, D400, D401, D403, DAR101, DAR201, DAR401
-  tests/integration/_cli2runner.py: D400, D401, D403, DAR101, DAR401
-  tests/integration/_interactions.py: D204, D400, D403, DAR101, DAR201
-  tests/integration/_tmux_session.py: D105, D205, D400, D403, DAR101, DAR201, DAR401
-  tests/integration/test_stdout_exit_codes.py: D400, D403, DAR101, DAR201
   tests/unit/configuration_subsystem/defaults.py: D400
   tests/unit/configuration_subsystem/test_entries_sanity.py: D400, DAR101
   tests/unit/configuration_subsystem/test_fixture_sanity.py: D205, D400

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
   // Override the pyproject.toml and disable xdist to enable test debugging
   "python.testing.pytestArgs": ["-n0", "--dist", "no"],
   "python.formatting.provider": "black",
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "python.linting.pylintEnabled": true,
   "python.linting.flake8Enabled": true,
   "python.linting.mypyEnabled": true,

--- a/tests/integration/_action_run_test.py
+++ b/tests/integration/_action_run_test.py
@@ -1,4 +1,4 @@
-"""directly run an action for testing"""
+"""Directly run an action for testing."""
 from __future__ import annotations
 
 import os
@@ -87,18 +87,31 @@ class ActionRunTest:
             fromlist=["Action"],
         )
 
-    def callable_pass_one_arg(self, value=0):
-        """a do nothing callable"""
+    def callable_pass_one_arg(self, value: int = 0) -> None:
+        """Do nothing callable.
 
-    def callable_pass(self, **kwargs):
-        """a do nothing callable"""
+        :param value: The value to return
+        """
+
+    def callable_pass(self, **kwargs) -> None:
+        """Do nothing callable.
+
+        :param kwargs: The call values
+        """
 
     def content_format(
         self,
         value: ContentFormat | None = None,
         default: bool = False,
-    ):
-        """A do nothing content format callable."""
+    ) -> ContentFormat:
+        # pylint: disable=unused-argument
+        """Do nothing content format callable.
+
+        :param value: The content format value
+        :param default: A boolean indicating if the default value should be used
+        :returns: The content format value
+        """
+        return value if value else ContentFormat.YAML
 
     def show(
         self,
@@ -110,17 +123,36 @@ class ActionRunTest:
         filter_content_keys: Callable = lambda x: x,
         color_menu_item: Callable = lambda *args, **kwargs: (0, 0),
         content_heading: Callable = lambda *args, **kwargs: None,
-    ):
-        """me"""
+    ) -> None:
+        """Show a content object, but don't really.
 
-    def show_form(self, form: Form):
-        """A do nothing show form callable."""
+        :param obj: The content object to show
+        :param content_format: The content format to use
+        :param index: The index of the content object
+        :param columns: The columns to display
+        :param await_input: A boolean indicating if input should be awaited
+        :param filter_content_keys: A callable to filter content keys
+        :param color_menu_item: A callable to color menu items
+        :param content_heading: A callable to display content headings
+        """
+
+    def show_form(self, form: Form) -> Form:
+        """Do nothing show form callable.
+
+        :param form: The form to show
+        :returns: The form to show
+        """
+        return form
 
     def run_action_interactive(self) -> Any:
-        """run the action
+        """Run the action.
+
         The return type is set to Any here since not all actions
         have the same signature, the corresponding integration test
         will be using the action internals for asserts
+
+        :returns: The action return value
+        :raises ValueError: If no action name match
         """
         self._app_args.update({"mode": "interactive"})
         args = deepcopy(NavigatorConfiguration)
@@ -144,7 +176,10 @@ class ActionRunTest:
             clear=self.callable_pass,
             menu_filter=self.callable_pass_one_arg,
             scroll=self.callable_pass_one_arg,
-            show=self.show,
+            # Ignored here because it doesn't make sens to mock up a full
+            # Interaction for the above show function, this returns
+            # None and the ShowCallable protocol returns an Interaction
+            show=self.show,  # type: ignore[arg-type]
             show_form=self.show_form,
             update_status=self.callable_pass,
             content_format=self.content_format,
@@ -163,7 +198,11 @@ class ActionRunTest:
 
     def run_action_stdout(self, **kwargs) -> tuple[RunStdoutReturn, str, str]:
         # pylint: disable=too-many-locals
-        """run the action"""
+        """Run the action, stdout.
+
+        :param kwargs: The action arguments
+        :returns: The result, stdout and stderr
+        """
         self._app_args.update({"mode": "stdout"})
         self._app_args.update(kwargs)
         args = deepcopy(NavigatorConfiguration)

--- a/tests/integration/_interactions.py
+++ b/tests/integration/_interactions.py
@@ -8,7 +8,7 @@ from typing import NamedTuple
 
 
 class SearchFor(Enum):
-    """set the test mode"""
+    """An enum for response search types."""
 
     HELP = "search for help"
     PROMPT = "search for the shell prompt"
@@ -16,7 +16,7 @@ class SearchFor(Enum):
 
 
 class Command(NamedTuple):
-    """command details"""
+    """Command details."""
 
     execution_environment: bool
     cmdline: str | None = None
@@ -31,14 +31,17 @@ class Command(NamedTuple):
     """Anything raw that should be appended, and not shlex quoted"""
     subcommand: str | None = None
 
-    def join(self):
-        """create CLI command"""
+    def join(self) -> str:
+        """Create  the CLI command.
+
+        :return: The command
+        """
         args = [self.command]
         if isinstance(self.subcommand, str):
             args.append(self.subcommand)
         if isinstance(self.cmdline, str):
             args.extend(shlex.split(self.cmdline))
-        args.extend(["--ee", self.execution_environment])
+        args.extend(["--ee", str(self.execution_environment)])
         args.extend(["--ll", self.log_level])
         args.extend(["--mode", self.mode])
         if self.format:
@@ -74,24 +77,36 @@ class UiTestStep(NamedTuple):
     #: Find this before returning from the tmux session to the test
     search_within_response: SearchFor | str | list = SearchFor.HELP
 
-    def __str__(self):
-        """Produce a test id for this step."""
+    def __str__(self) -> str:
+        """Produce a test id for this step.
+
+        :return: The test id
+        """
         return f"{self.comment}  {self.user_input}"
 
 
-def add_indices(steps):
-    """update the index of each"""
-    return (step._replace(step_index=idx) for idx, step in enumerate(steps))
+def add_indices(steps: tuple[UiTestStep, ...]) -> tuple[UiTestStep, ...]:
+    """Update the index of each.
+
+    :param steps: The list of steps
+    :return: The list of steps with the index updated
+    """
+    return tuple(step._replace(step_index=idx) for idx, step in enumerate(steps))
 
 
-def step_id(value):
-    """return the test id from the test step object"""
+def step_id(value: UiTestStep) -> str:
+    """Create a test id from the test step object.
+
+    :param value: The test value
+    :return: The test id
+    """
     return f"{value.step_index}-{value.user_input}-{value.comment}"
 
 
-def step_id_padded(value):
+def step_id_padded(value: UiTestStep) -> str:
     """Return the test id from the test step object, index padded to 2.
 
     :param value: The test value
+    :return: The test id
     """
     return f"{value.step_index:02d}-{value.user_input}-{value.comment}"

--- a/tests/integration/actions/config/test_welcome_interactive_param_use.py
+++ b/tests/integration/actions/config/test_welcome_interactive_param_use.py
@@ -10,7 +10,7 @@ from .base import BaseClass
 
 CLI = Command(execution_environment=False).join()
 
-steps = (
+steps: tuple[UiTestStep, ...] = (
     UiTestStep(user_input=CLI, comment="welcome screen"),
     UiTestStep(
         user_input=":config",

--- a/tests/integration/actions/config/test_welcome_interactive_specified_config.py
+++ b/tests/integration/actions/config/test_welcome_interactive_specified_config.py
@@ -11,7 +11,7 @@ from .base import BaseClass
 
 CLI = Command(execution_environment=False).join()
 
-steps = (
+steps: tuple[UiTestStep, ...] = (
     UiTestStep(user_input=CLI, comment="welcome screen"),
     UiTestStep(
         user_input=":config",

--- a/tests/integration/actions/exec/test_stdout_vault.py
+++ b/tests/integration/actions/exec/test_stdout_vault.py
@@ -36,7 +36,7 @@ variations = (
     f'{BASE_COMMAND} exec "{VAULT_COMMAND}" --mode stdout --exec-shell false',
 )
 
-stdout_tests = (
+stdout_tests = tuple(
     ShellCommand(
         comment="Vault variation",
         user_input=f"clear && {variation}",

--- a/tests/integration/actions/lint/test_direct_interactive_ee.py
+++ b/tests/integration/actions/lint/test_direct_interactive_ee.py
@@ -11,7 +11,7 @@ from .base import BaseClass
 
 CLI = Command(subcommand="lint", cmdline=LINT_FIXTURES, execution_environment=True).join()
 
-steps = (
+steps: tuple[UiTestStep, ...] = (
     UiTestStep(
         user_input=CLI,
         comment="ansible-navigator lint top window",

--- a/tests/integration/actions/lint/test_direct_interactive_no_errors_ee.py
+++ b/tests/integration/actions/lint/test_direct_interactive_no_errors_ee.py
@@ -20,7 +20,7 @@ CLI = Command(
     execution_environment=True,
 ).join()
 
-steps = (
+steps: tuple[UiTestStep, ...] = (
     UiTestStep(
         user_input=CLI,
         comment="ansible-navigator lint top window",

--- a/tests/integration/actions/templar/test_direct_interactive_ee_readme.py
+++ b/tests/integration/actions/templar/test_direct_interactive_ee_readme.py
@@ -10,7 +10,7 @@ from .base import BaseClass
 
 CLI = Command(subcommand="collections", execution_environment=True).join()
 
-steps = (
+steps: tuple[UiTestStep, ...] = (
     UiTestStep(
         user_input=CLI,
         comment="ansible-navigator collections",


### PR DESCRIPTION
Ongoing work to improve type hins and doc string.

Changes are made to files in the root of the test intregration directory.


This also restores format on save accidentally changed in #1450 