### PR TITLE
Require py3.9 or later

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires = [
 ]
 
 [project]
+requires-python = ">=3.9"
 classifiers = [
   'Development Status :: 5 - Production/Stable',
   'Intended Audience :: Developers',


### PR DESCRIPTION
Fixes #1468 


Version 3 of navigator is getting pulled into 3.8.

```
m910x ➜  /tmp python3.8 -m venv venv
m910x ➜  /tmp source venv/bin/activate
(venv) m910x ➜  /tmp pip install ansible-navigator
Collecting ansible-navigator
  Downloading ansible_navigator-3.0.1-py3-none-any.whl (299 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 299.9/299.9 kB 1.6 MB/s eta 0:00:00
```

This will trigger a release of 3.0.2 and a delete of 3.0.0 and 3.0.1 from pypi.
