### PR TITLE
Fix issues while cataloging collections

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
       "type": "python",
       "request": "launch",
       "module": "ansible_navigator",
-      "args": ["collections"],
+      "args": ["collections", "--ee", "false"],
       "cwd": "${workspaceFolder}/src",
       "justMyCode": false
     },

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -578,4 +578,4 @@ class Action(ActionBase):
         msgs.append("Details have been added to the log file")
         closing = ["[HINT] Please log an issue about this one, it shouldn't have happened"]
         warning = warning_notification(messages=msgs + closing)
-        self._interaction.ui.show(warning)
+        self._interaction.ui.show_form(warning)

--- a/src/ansible_navigator/data/catalog_collections.py
+++ b/src/ansible_navigator/data/catalog_collections.py
@@ -118,6 +118,8 @@ class CollectionCatalog:
             return
 
         for role_directory in roles_directory.iterdir():
+            if not role_directory.is_dir():
+                continue
             role: dict[str, str | dict[str, Any]] = {
                 "short_name": role_directory.name,
                 "full_name": f"{collection_name}.{role_directory.name}",


### PR DESCRIPTION
The purestorage flasharray collection has a file in it's roles directory which was causing the catalog_collecitons script to fail.

Additionally, we were calling show instead of show form for a few of the notifications.

In the case of a complete failure of the collection catalog script, we will show a failure warning before the nothing found.

https://github.com/Pure-Storage-Ansible/FlashArray-Collection/tree/master/roles

Fixes #1482 