### PR TITLE
Improve type hinting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ ignore = [
   'TRY400', # Use `logging.exception` instead of `logging.error`
   'TRY401', # Redundant exception object included in `logging.exception` call
   'UP033', # [*] Use `@functools.cache` instead of `@functools.lru_cache(maxsize=None)`
-  'UP035', # `typing.Dict` is deprecated, use `dict` instead
 
 ]
 exclude = ["tests/fixtures/**", ".git"]

--- a/src/ansible_navigator/tm_tokenize/compiler.py
+++ b/src/ansible_navigator/tm_tokenize/compiler.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import functools
 
 from typing import TYPE_CHECKING
-from typing import Dict
-from typing import List
-from typing import Tuple
 
 from .fchainmap import FChainMap
 from .reg import make_regset

--- a/src/ansible_navigator/tm_tokenize/grammars.py
+++ b/src/ansible_navigator/tm_tokenize/grammars.py
@@ -4,11 +4,7 @@ import json
 import os
 
 from typing import Any
-from typing import Dict
-from typing import FrozenSet
-from typing import List
 from typing import NamedTuple
-from typing import Tuple
 from typing import TypeVar
 
 from .compiler import Compiler

--- a/src/ansible_navigator/tm_tokenize/reg.py
+++ b/src/ansible_navigator/tm_tokenize/reg.py
@@ -6,7 +6,6 @@ import re
 from re import Match
 from typing import TYPE_CHECKING
 from typing import Optional
-from typing import Tuple
 
 import onigurumacffi
 

--- a/src/ansible_navigator/tm_tokenize/region.py
+++ b/src/ansible_navigator/tm_tokenize/region.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import NamedTuple
-from typing import Tuple
 
 
 Scope = tuple[str, ...]

--- a/src/ansible_navigator/tm_tokenize/rules.py
+++ b/src/ansible_navigator/tm_tokenize/rules.py
@@ -3,11 +3,8 @@ from __future__ import annotations
 from re import Match
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
-from typing import List
 from typing import NamedTuple
 from typing import Optional
-from typing import Tuple
 
 from ._types import Protocol
 from .fchainmap import FChainMap

--- a/src/ansible_navigator/tm_tokenize/state.py
+++ b/src/ansible_navigator/tm_tokenize/state.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import NamedTuple
-from typing import Tuple
 
 
 if TYPE_CHECKING:

--- a/src/ansible_navigator/tm_tokenize/tokenize.py
+++ b/src/ansible_navigator/tm_tokenize/tokenize.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import List
-from typing import Tuple
 
 from .region import Region
 from .region import Regions

--- a/src/ansible_navigator/tm_tokenize/utils.py
+++ b/src/ansible_navigator/tm_tokenize/utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from re import Match  # noqa: F401
-from typing import List  # noqa: F401
 from typing import TypeVar
 
 

--- a/src/ansible_navigator/utils/json_schema.py
+++ b/src/ansible_navigator/utils/json_schema.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 import json
 
+from collections import deque
 from dataclasses import dataclass
 from typing import Any
-from typing import Deque
 
 from jsonschema import SchemaError
 from jsonschema import ValidationError
@@ -14,7 +14,7 @@ from jsonschema.validators import validator_for
 from .functions import ExitMessage
 
 
-def to_path(schema_path: Deque[str]):
+def to_path(schema_path: deque):
     """Flatten a path to a dot delimited string.
 
     :param schema_path: The schema path
@@ -23,7 +23,7 @@ def to_path(schema_path: Deque[str]):
     return ".".join(str(index) for index in schema_path)
 
 
-def json_path(absolute_path: Deque[str]):
+def json_path(absolute_path: deque):
     """Flatten a data path to a dot delimited string.
 
     :param absolute_path: The path

--- a/tests/smoke/no_test_dependencies.py
+++ b/tests/smoke/no_test_dependencies.py
@@ -10,8 +10,6 @@ import uuid
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
-from typing import Tuple
 
 from ansible_navigator.command_runner import Command
 from ansible_navigator.command_runner import CommandRunner


### PR DESCRIPTION
Fix to address **ruff: UP035**

For the built-in types like list, tuple, dict, etc. it is recommended to use the built-in types directly.
Example: `typing.List` is deprecated and `list` is preferred to use.

Similarly, `typing.Deque` class is deprecated and is replaced by the `collections.deque` class