### PR TITLE
Avoid f-string in logging statement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,6 @@ ignore = [
   'FBT001', # Boolean positional arg in function definition
   'FBT002', # Boolean default value in function definition
   'FBT003', # Boolean positional value in function call
-  'G003', # Logging statement uses `+`
   'INP001', # File `docs/_ext/regenerate_docs.py` is part of an implicit namespace package. Add an `__init__.py`.
   'ISC001', # Implicitly concatenated string literals on one line
   'ISC003', # Explicitly concatenated string should be implicitly concatenated

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -567,7 +567,7 @@ class Action(ActionBase):
             kwargs.update({"container_options": self._args.container_options})
 
         self._logger.debug(
-            f"Invoke runner with executable_cmd: {python_exec_path}" + f" and kwargs: {kwargs}",
+            "Invoke runner with executable_cmd: %s and kwargs: %s", python_exec_path, kwargs
         )
         _runner = Command(executable_cmd=python_exec_path, **kwargs)
         output, error, return_code = _runner.run()


### PR DESCRIPTION
Fix to address **ruff: G003**

As per: https://beta.ruff.rs/docs/rules/#flake8-logging-format-g, we should avoid using `+` and `f-string` while logging.

Related: https://github.com/ansible/ansible-navigator/pull/1493

