### PR TITLE
Address SIM rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,13 +220,6 @@ ignore = [
   'S603', # `subprocess` call: check for execution of untrusted input
   'S605', # Starting a process with a shell, possible injection detected
   'S607', # Starting a process with a partial executable path
-  'SIM102', # [*] Use a single `if` statement instead of nested `if` statements
-  'SIM105', # [*] Use `contextlib.suppress(ValueError)` instead of `try`-`except`-`pass`
-  'SIM108', # [*] Use ternary operator `inventory_err = parts[0] + inventory_err if inventory_err else parts[0]` instead of `if`-`else`-block
-  'SIM110', # [*] Use `return any(self._search_value(self.menu_filter(), obj.get(key)) for key in columns)` instead of `for` loop
-  'SIM114', # Combine `if` branches using logical `or` operator
-  'SIM118', # [*] Use `group in self._inventory` instead of `group in self._inventory.keys()`
-  'SIM401', # [*] Use `cache_version = collection_cache.get("version", None)` instead of an `if` block
   'SLF001', # Private member accessed: `_ui`
   'T201', # `print` found
   'TCH001', # Move application import `ansible_navigator.configuration_subsystem.definitions.SettingsEntry` into a type-checking block

--- a/src/ansible_navigator/actions/_actions.py
+++ b/src/ansible_navigator/actions/_actions.py
@@ -43,10 +43,8 @@ def _import_all(package: str) -> None:
     :param package: The name of the package
     """
     for entry in importlib_resources.files(package).iterdir():
-        if entry.is_file():
-            if entry.name.endswith(".py"):
-                if not entry.name.startswith("_"):
-                    _import(package, entry.name[0:-3])
+        if entry.is_file() and entry.name.endswith(".py") and not entry.name.startswith("_"):
+            _import(package, entry.name[0:-3])
 
 
 def register(cls: Any) -> Any:

--- a/src/ansible_navigator/actions/back.py
+++ b/src/ansible_navigator/actions/back.py
@@ -38,10 +38,14 @@ class Action:
         this = app.steps.back_one()  # pop this
         step = app.steps.back_one()  # pop current
 
-        if app.steps:
-            if isinstance(step, Step) and isinstance(app.steps.current, Step):
-                if step.type == "menu" and app.steps.current.type == "menu":
-                    interaction.ui.menu_filter(None)
+        if (
+            app.steps
+            and isinstance(step, Step)
+            and isinstance(app.steps.current, Step)
+            and step.type == "menu"
+            and app.steps.current.type == "menu"
+        ):
+            interaction.ui.menu_filter(None)
             self._logger.debug(
                 "Stepping back in %s from %s to %s",
                 app.name,

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -564,9 +564,9 @@ class Action(ActionBase):
             collection["__version"] = collection["collection_info"].get("version", "missing")
             collection["__shadowed"] = bool(collection["hidden_by"])
             if self._args.execution_environment:
-                if collection["path"].startswith(dest_volume_mounts):
-                    collection["__type"] = "bind_mount"
-                elif collection["path"].startswith(self._adjacent_collection_dir):
+                if collection["path"].startswith(dest_volume_mounts) or collection[
+                    "path"
+                ].startswith(self._adjacent_collection_dir):
                     collection["__type"] = "bind_mount"
                 elif collection["path"].startswith(os.path.dirname(self._adjacent_collection_dir)):
                     collection["__type"] = "bind_mount"

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -138,7 +138,7 @@ class Action(ActionBase):
             k: {**v, "inventory_hostname": k}
             for k, v in value.get("_meta", {}).get("hostvars", {}).items()
         }
-        for group in self._inventory.keys():
+        for group in self._inventory:
             for host in self._inventory[group].get("hosts", []):
                 if host in self._host_vars:
                     continue
@@ -438,7 +438,6 @@ class Action(ActionBase):
         self,
         kwargs: dict[str, Any],
     ) -> None:
-        # pylint: disable=too-many-branches
         """Use the runner subsystem to collect inventory details for mode interactive.
 
         :param kwargs: The arguments for the runner call
@@ -468,15 +467,8 @@ class Action(ActionBase):
         )
         if inventory_output:
             parts = inventory_output.split("{", 1)
-            if inventory_err:
-                inventory_err = parts[0] + inventory_err
-            else:
-                inventory_err = parts[0]
-
-            if len(parts) == 2:
-                inventory_output = "{" + parts[1]
-            else:
-                inventory_output = ""
+            inventory_err = parts[0] + inventory_err if inventory_err else parts[0]
+            inventory_output = "{" + parts[1] if len(parts) == 2 else ""
         preface = ["Errors were encountered while gathering the inventory:"]
         notify = ("ERROR!", "Error", "Unable to parse")
         if any(string in inventory_err for string in notify):

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -102,15 +102,12 @@ def color_menu(_colno: int, colname: str, entry: dict[str, Any]) -> tuple[int, i
             decoration = curses.A_BOLD
 
     elif "task" in entry:
-        if entry["__result"].lower() == "in progress":
-            color = get_color(entry["__result"])
-        elif colname in ["__result", "__host", "__number", "__task", "__task_action"]:
+        if entry["__result"].lower() == "in progress" or (
+            colname in ["__result", "__host", "__number", "__task", "__task_action"]
+        ):
             color = get_color(entry["__result"])
         elif colname == "__changed":
-            if colval is True:
-                color = 11
-            else:
-                color = get_color(entry["__result"])
+            color = 11 if colval is True else get_color(entry["__result"])
         elif colname == "__duration":
             color = 12
 
@@ -491,15 +488,9 @@ class Action(ActionBase):
         """
         self._logger.debug("Inventory/Playbook not set, provided, or valid, prompting")
 
-        if isinstance(self._args.playbook, str):
-            playbook = self._args.playbook
-        else:
-            playbook = ""
+        playbook = self._args.playbook if isinstance(self._args.playbook, str) else ""
 
-        if isinstance(self._args.cmdline, list):
-            cmdline = " ".join(self._args.cmdline)
-        else:
-            cmdline = ""
+        cmdline = " ".join(self._args.cmdline) if isinstance(self._args.cmdline, list) else ""
 
         FType = dict[str, Any]
         form_dict: FType = {
@@ -574,10 +565,7 @@ class Action(ActionBase):
         """
         executable_cmd: str | None
 
-        if self.mode == "stdout_w_artifact":
-            mode = "interactive"
-        else:
-            mode = self.mode
+        mode = "interactive" if self.mode == "stdout_w_artifact" else self.mode
 
         if isinstance(self._args.set_environment_variable, dict):
             set_env_vars = {**self._args.set_environment_variable}

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -81,10 +81,7 @@ def log_dependencies() -> list[LogMessage]:
             if pkg_name not in found:
                 found.append(pkg_name)
                 spec = find_spec(pkg_name)
-                if spec:
-                    _location = spec.origin
-                else:
-                    _location = ""
+                _location = spec.origin if spec else ""
                 _version = version(pkg_name)
                 pkgs.append(f"{pkg_name}=={_version} {_location}")
 

--- a/src/ansible_navigator/configuration_subsystem/configurator.py
+++ b/src/ansible_navigator/configuration_subsystem/configurator.py
@@ -353,18 +353,16 @@ class Configurator:
         :param value: The value to check.
         :return: True if the value is invalid and an error message was logged.
         """
-        if entry.cli_parameters and entry.choices:
-            if value not in entry.choices:
-                self._exit_messages.append(ExitMessage(message=entry.invalid_choice))
-                choices = [
-                    f"{entry.cli_parameters.short} {str(choice).lower()}"
-                    for choice in entry.choices
-                ]
-                exit_msg = f"Try again with {oxfordcomma(choices, 'or')}"
-                self._exit_messages.append(
-                    ExitMessage(message=exit_msg, prefix=ExitPrefix.HINT),
-                )
-                return True
+        if entry.cli_parameters and entry.choices and value not in entry.choices:
+            self._exit_messages.append(ExitMessage(message=entry.invalid_choice))
+            choices = [
+                f"{entry.cli_parameters.short} {str(choice).lower()}" for choice in entry.choices
+            ]
+            exit_msg = f"Try again with {oxfordcomma(choices, 'or')}"
+            self._exit_messages.append(
+                ExitMessage(message=exit_msg, prefix=ExitPrefix.HINT),
+            )
+            return True
         return False
 
     def _apply_previous_cli_to_current(self) -> None:
@@ -411,9 +409,11 @@ class Configurator:
                 continue
 
             # skip if the same subcommand is required for reapplication
-            if current_entry.apply_to_subsequent_cli is C.SAME_SUBCOMMAND:
-                if current_subcommand != previous_subcommand:
-                    continue
+            if (
+                current_entry.apply_to_subsequent_cli is C.SAME_SUBCOMMAND
+                and current_subcommand != previous_subcommand
+            ):
+                continue
 
             # skip if the previous entry was not set by the CLI
             if previous_entry.value.source is not C.USER_CLI:

--- a/src/ansible_navigator/configuration_subsystem/definitions.py
+++ b/src/ansible_navigator/configuration_subsystem/definitions.py
@@ -222,10 +222,7 @@ class SettingsEntry:
         :param prefix: The prefix for the settings file path
         :returns: Settings file path
         """
-        if prefix:
-            prefix_str = f"{prefix}."
-        else:
-            prefix_str = prefix
+        prefix_str = f"{prefix}." if prefix else prefix
 
         if self.settings_file_path_override is not None:
             sfp = f"{prefix_str}{self.settings_file_path_override}"

--- a/src/ansible_navigator/data/catalog_collections.py
+++ b/src/ansible_navigator/data/catalog_collections.py
@@ -452,10 +452,7 @@ def parse_args() -> tuple[argparse.Namespace, list[Path]]:
     parsed_args = parser.parse_args()
 
     adjacent = vars(parsed_args).get("adjacent")
-    if adjacent:
-        directories = [adjacent] + parsed_args.dirs
-    else:
-        directories = parsed_args.dirs
+    directories = [adjacent] + parsed_args.dirs if adjacent else parsed_args.dirs
 
     directories.extend(reversed(sys.path))
 

--- a/src/ansible_navigator/image_manager/puller.py
+++ b/src/ansible_navigator/image_manager/puller.py
@@ -117,11 +117,11 @@ class ImagePuller:
 
     def _determine_pull(self):
         """Determine if a pull is required."""
-        if self._pull_policy == "missing" and self._image_present is False:
+        if self._pull_policy == "missing" and self._image_present is False:  # noqa: SIM114
             pull = True
-        elif self._pull_policy == "always":
+        elif self._pull_policy == "always":  # noqa: SIM114
             pull = True
-        elif self._pull_policy == "tag" and self._image_tag == "latest":
+        elif self._pull_policy == "tag" and self._image_tag == "latest":  # noqa: SIM114
             pull = True
         elif self._pull_policy == "tag" and self._image_present is False:
             pull = True

--- a/src/ansible_navigator/initialization.py
+++ b/src/ansible_navigator/initialization.py
@@ -123,10 +123,7 @@ def get_and_check_collection_doc_cache(
         return messages, exit_messages, None
 
     collection_cache: KeyValueStore = KeyValueStore(collection_doc_cache_path)
-    if "version" in collection_cache:
-        cache_version = collection_cache["version"]
-    else:
-        cache_version = None
+    cache_version = collection_cache["version"] if "version" in collection_cache else None
     message = f"Collection doc cache: 'current version' is '{cache_version}'"
     messages.append(LogMessage(level=logging.DEBUG, message=message))
     if cache_version is None or cache_version != VERSION_CDC:

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -346,9 +346,7 @@ def ansi_to_curses(line: str) -> CursesLine:
                 cap = match.groupdict()
                 one = cap["one"]
                 two = cap["two"]
-                if cap["fg_action"] == "39;":
-                    pass  # default color
-                elif one == "0" and two is None:
+                if cap["fg_action"] == "39;" or (one == "0" and two is None):
                     pass  # default color
                 elif cap["fg_action"] == "38;5;":
                     color = int(one)

--- a/src/ansible_navigator/ui_framework/form.py
+++ b/src/ansible_navigator/ui_framework/form.py
@@ -247,10 +247,7 @@ class FormPresenter(CursesWindow):
                 f.valid for f in self._form.fields if not isinstance(f, FieldButton)
             ]
             form_field.conditional_validation(form_validity_state)
-            if form_field.disabled is True:
-                color = 8
-            else:
-                color = form_field.color
+            color = 8 if form_field.disabled is True else form_field.color
             line_part = CursesLinePart(far_right, string, color, 0)
             line_parts.append(line_part)
             far_right -= 1
@@ -345,10 +342,7 @@ class FormPresenter(CursesWindow):
         :returns: A list of CursesLinePart containing the prompt
         """
         prompt_start = self._prompt_end - len(form_field.full_prompt)
-        if form_field.valid is True:
-            color = 10
-        else:
-            color = 0
+        color = 10 if form_field.valid is True else 0
 
         cl_prompt = CursesLinePart(prompt_start, form_field.prompt, color, 0)
         cl_default = CursesLinePart(

--- a/src/ansible_navigator/ui_framework/form_handler_button.py
+++ b/src/ansible_navigator/ui_framework/form_handler_button.py
@@ -30,10 +30,7 @@ class FormHandlerButton(CursesWindow):
 
     def populate(self):
         """Populate the window with the button."""
-        if self._form_field.disabled is True:
-            color = 8
-        else:
-            color = self._form_field.color
+        color = 8 if self._form_field.disabled is True else self._form_field.color
 
         if self._ui_config.color is False:
             text = f"[{self._form_field.text.upper()}]"

--- a/src/ansible_navigator/ui_framework/form_handler_options.py
+++ b/src/ansible_navigator/ui_framework/form_handler_options.py
@@ -39,10 +39,9 @@ class FormHandlerOptions(CursesWindow):
             decoration = curses.A_STANDOUT if idx == active else 0
             clp_option_code = CursesLinePart(0, option_code, color, 0)
             if self._ui_config.color is False:
-                if idx == active:
-                    text = f"[{option.text.capitalize()}]"
-                else:
-                    text = option.text + "  "  # clear the []
+                text = (
+                    f"[{option.text.capitalize()}]" if idx == active else option.text + "  "
+                )  # clear the [], for else  # noqa: E501
             else:
                 text = option.text
             clp_text = CursesLinePart(len(option_code) + 1, text, color, decoration)

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -289,10 +289,7 @@ class UserInterface(CursesWindow):
         :returns: The footer line
         """
         column_widths = [len(f"{str(k)}: {str(v)}") for k, v in key_dict.items()]
-        if self._status:
-            status_width = self._progress_bar_width
-        else:
-            status_width = 0
+        status_width = self._progress_bar_width if self._status else 0
         gap = floor((self._screen_width - status_width - sum(column_widths)) / len(key_dict))
         adjusted_column_widths = [c + gap for c in column_widths]
         col_starts = [0]
@@ -525,21 +522,22 @@ class UserInterface(CursesWindow):
         :param current: the content on the screen
         :returns: The name of the action and the action to call or nothing if no match found
         """
-        if not entry.startswith("{{"):  # don't match pure template
-            if "{{" in entry and "}}" in entry:
-                if isinstance(current, Mapping):
-                    template_vars = current
-                    type_msgs = []
-                else:
-                    template_vars = {"this": current}
-                    type_msgs = ["Current content passed for templating is not a dictionary."]
-                    type_msgs.append("[HINT] Use 'this' to reference it (e.g. {{ this[0] }}")
-                errors, entry = templar(entry, template_vars)
-                if errors:
-                    msgs = ["Errors encountered while templating input"] + errors
-                    msgs.extend(type_msgs)
-                    self._show_form(warning_notification(msgs))
-                    return None, None
+        if (
+            not entry.startswith("{{") and "{{" in entry and "}}" in entry
+        ):  # don't match pure template
+            if isinstance(current, Mapping):
+                template_vars = current
+                type_msgs = []
+            else:
+                template_vars = {"this": current}
+                type_msgs = ["Current content passed for templating is not a dictionary."]
+                type_msgs.append("[HINT] Use 'this' to reference it (e.g. {{ this[0] }}")
+            errors, entry = templar(entry, template_vars)
+            if errors:
+                msgs = ["Errors encountered while templating input"] + errors
+                msgs.extend(type_msgs)
+                self._show_form(warning_notification(msgs))
+                return None, None
         for kegex in self._kegexes():
             match = kegex.kegex.match(entry)
             if match:
@@ -691,10 +689,7 @@ class UserInterface(CursesWindow):
         """
         heading, lines = self._filter_and_serialize(objs[index])
         while True:
-            if heading is not None:
-                heading_len = len(heading)
-            else:
-                heading_len = 0
+            heading_len = len(heading) if heading is not None else 0
             footer_len = 1
 
             if self.scroll() == 0:
@@ -710,10 +705,7 @@ class UserInterface(CursesWindow):
                 last_line_idx - (self._screen_height - 1 - heading_len - footer_len),
             )
 
-            if len(objs) > 1:
-                key_dict = {"-": "previous", "+": "next", "[0-9]": "goto"}
-            else:
-                key_dict = {}
+            key_dict = {"-": "previous", "+": "next", "[0-9]": "goto"} if len(objs) > 1 else {}
 
             line_numbers = tuple(range(first_line_idx, last_line_idx + 1))
 
@@ -786,10 +778,7 @@ class UserInterface(CursesWindow):
         :param columns: The dicts keys to check
         :returns: True if a match else False
         """
-        for key in columns:
-            if self._search_value(self.menu_filter(), obj.get(key)):
-                return True
-        return False
+        return any(self._search_value(self.menu_filter(), obj.get(key)) for key in columns)
 
     @staticmethod
     @cache

--- a/src/ansible_navigator/ui_framework/utils.py
+++ b/src/ansible_navigator/ui_framework/utils.py
@@ -54,9 +54,8 @@ def is_percent(string):
     :param string: The string to check
     :returns: Boolean of comparison
     """
-    if string.endswith("%"):
-        if re.match(r"^\d{1,3}%$", string):
-            return True
+    if string.endswith("%") and re.match(r"^\d{1,3}%$", string):
+        return True
     return False
 
 

--- a/src/ansible_navigator/ui_framework/validators.py
+++ b/src/ansible_navigator/ui_framework/validators.py
@@ -52,10 +52,7 @@ class FieldValidators:
         """
         if hint:
             return "Please provide a value (optional)"
-        if text:
-            value = "*" * randrange(15, 20)
-        else:
-            value = ""
+        value = "*" * randrange(15, 20) if text else ""
         return Validation(value=value, error_msg="")
 
     @staticmethod
@@ -95,10 +92,7 @@ class FieldValidators:
         :param hint: If True, return a hint message instead of a Validation
         :returns: A Validation or a hint message
         """
-        if choices:
-            choices_str = f"{', '.join(choices[:-1])} or {choices[-1]}"
-        else:
-            choices_str = ""
+        choices_str = f"{', '.join(choices[:-1])} or {choices[-1]}" if choices else ""
         msg = f"Please enter {choices_str}"
         value = text
         if hint:

--- a/src/ansible_navigator/utils/dict_merge.py
+++ b/src/ansible_navigator/utils/dict_merge.py
@@ -34,7 +34,7 @@ def in_place_list_replace(left: Mergeable, right: Mergeable):
     """
     key = None
     try:
-        if left is None or isinstance(left, (str, int, float, bool)):
+        if left is None or isinstance(left, (str, int, float, bool)):  # noqa: SIM114
             # Border case for first run or if a is a primitive
             left = right
         elif isinstance(left, (tuple, list)):

--- a/src/ansible_navigator/utils/dot_paths.py
+++ b/src/ansible_navigator/utils/dot_paths.py
@@ -155,15 +155,14 @@ def place_at_path(
                     nested[part].sort()
                 continue
 
-            if isinstance(nested.get(part), dict):
-                if isinstance(value, dict):
-                    if MergeBehaviors.DICT_DICT_UPDATE in behaviors:
-                        nested[part].update(value)
-                    elif MergeBehaviors.DICT_DICT_REPLACE in behaviors:
-                        nested[part] = value
-                    else:
-                        raise ValueError("No behavior specified for DICT_DICT")
-                    continue
+            if isinstance(nested.get(part), dict) and isinstance(value, dict):
+                if MergeBehaviors.DICT_DICT_UPDATE in behaviors:
+                    nested[part].update(value)
+                elif MergeBehaviors.DICT_DICT_REPLACE in behaviors:
+                    nested[part] = value
+                else:
+                    raise ValueError("No behavior specified for DICT_DICT")
+                continue
 
             nested[part] = value
         elif part not in nested:

--- a/src/ansible_navigator/utils/serialize.py
+++ b/src/ansible_navigator/utils/serialize.py
@@ -339,11 +339,7 @@ def _is_multiline_string(value: str):
     :param value: The value to check
     :returns: A boolean indicating if the string is multiline
     """
-    for character in "\u000a\u000d\u001c\u001d\u001e\u0085\u2028\u2029":
-        if character in value:
-            return True
-
-    return False
+    return any(character in value for character in "\n\r\x1c\x1d\x1e\x85\u2028\u2029")
 
 
 def opener(path: str, flags: int, mode: int) -> int:

--- a/src/ansible_navigator/utils/version_migration/definitions.py
+++ b/src/ansible_navigator/utils/version_migration/definitions.py
@@ -1,6 +1,8 @@
 """Common definitions for a version migration."""
 from __future__ import annotations
 
+import contextlib
+
 from enum import Enum
 from pathlib import Path
 from typing import Callable
@@ -163,10 +165,9 @@ class Migration:
             return
 
         step.print_start()
-        try:
+        with contextlib.suppress(Exception):
             step.needed = function(*args, **kwargs)
-        except Exception:
-            pass
+
         if step.needed:
             step.print_failed()
         else:

--- a/tests/integration/_common.py
+++ b/tests/integration/_common.py
@@ -200,10 +200,7 @@ def copytree(
     :raises Error: If an error occurs
     """
     names = os.listdir(src)
-    if ignore is not None:
-        ignored_names = ignore(src, names)
-    else:
-        ignored_names = set()
+    ignored_names = ignore(src, names) if ignore is not None else set()
 
     os.makedirs(dst, exist_ok=dirs_exist_ok)
     errors = []

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -272,10 +272,7 @@ class TmuxSession:
             showing = self._capture_pane()
 
             if showing:
-                if self.cli_prompt in showing[-1]:
-                    mode = "shell"
-                else:
-                    mode = "app"
+                mode = "shell" if self.cli_prompt in showing[-1] else "app"
 
             if mode is not None:
                 break

--- a/tests/integration/actions/doc/base.py
+++ b/tests/integration/actions/doc/base.py
@@ -79,9 +79,7 @@ class BaseClass:
         updated_received_output = []
         mask = "X" * 50
         for line in received_output:
-            if tmux_doc_session.cli_prompt in line:
-                updated_received_output.append(mask)
-            elif "filename" in line or "│warnings:" in line:
+            if tmux_doc_session.cli_prompt in line or ("filename" in line or "│warnings:" in line):
                 updated_received_output.append(mask)
             else:
                 for value in ["time=", "skipping entry", "failed:", "permission denied"]:

--- a/tests/unit/actions/settings/test_settings.py
+++ b/tests/unit/actions/settings/test_settings.py
@@ -96,10 +96,7 @@ class ContentHeadingEntry(BaseScenario):
 
         :returns: The expected heading
         """
-        if self.content.default:
-            heading = CONTENT_HEADING_DEFAULT
-        else:
-            heading = CONTENT_HEADING_NOT_DEFAULT
+        heading = CONTENT_HEADING_DEFAULT if self.content.default else CONTENT_HEADING_NOT_DEFAULT
         return heading.format(**asdict(self.content))
 
     def __str__(self):

--- a/tests/unit/configuration_subsystem/test_entries_sanity.py
+++ b/tests/unit/configuration_subsystem/test_entries_sanity.py
@@ -59,11 +59,13 @@ def test_entries_no_short_long_if_positional(entry: SettingsEntry):
 
     :param entry: The entry to test
     """
-    if hasattr(entry, "cli_arguments"):
-        if entry.cli_parameters is not None:
-            if entry.cli_parameters.positional:
-                assert entry.cli_parameters.short is None
-                assert entry.cli_parameters.long_override is None
+    if (
+        hasattr(entry, "cli_arguments")
+        and entry.cli_parameters is not None
+        and entry.cli_parameters.positional
+    ):
+        assert entry.cli_parameters.short is None
+        assert entry.cli_parameters.long_override is None
 
 
 @pytest.mark.parametrize("entry", NavigatorConfiguration.entries, ids=id_for_name)

--- a/tests/unit/configuration_subsystem/test_invalid_params.py
+++ b/tests/unit/configuration_subsystem/test_invalid_params.py
@@ -233,10 +233,7 @@ def test_poor_choices(
             look_for in exit_msg.message for exit_msg in response.exit_messages
         ), response.exit_messages
 
-    if isinstance(entry.subcommands, list):
-        subcommand = entry.subcommands[0]
-    else:
-        subcommand = None
+    subcommand = entry.subcommands[0] if isinstance(entry.subcommands, list) else None
 
     if entry.cli_parameters and entry.cli_parameters.action == "store_true":
         pass


### PR DESCRIPTION
Fix to address **ruff: SIM**

This PR covers: 
1. SIM102 - Use a single if statement instead of nested if statements
2. SIM105 - Use contextlib.suppress({exception}) instead of try-except-pass
3. SIM108 - Use ternary operator {contents} instead of if-else-block
4. SIM110 - Use {repl} instead of for loop
5. SIM114 - Combine if branches using logical or operator
6. SIM118 - Use {key} in {dict} instead of {key} in {dict}.keys()
7. SIM401 - Use {contents} instead of an if block

Related: https://github.com/ansible/ansible-navigator/pull/1493