### PR TITLE
Exception must not use string or f-string literal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,8 +148,6 @@ ignore = [
   'D403', # [*] First word of the first line should be capitalized: `tokenize` -> `Tokenize`
   'DTZ003', # The use of `datetime.datetime.utcnow()` is not allowed, use `datetime.datetime.now(tz=)` instead
   'DTZ005', # The use of `datetime.datetime.now()` without `tz` argument is not allowed
-  'EM101', # Exception must not use a string literal, assign to variable first
-  'EM102', # Exception must not use an f-string literal, assign to variable first
   'ERA001', # [*] Found commented-out code
   'F401', # [*] `ansible_navigator.version.__version__` imported but unused
   'FBT001', # Boolean positional arg in function definition

--- a/src/ansible_navigator/action_base.py
+++ b/src/ansible_navigator/action_base.py
@@ -78,7 +78,8 @@ class ActionBase:
                 update=self.update,
                 write_artifact=self.write_artifact,
             )
-        raise AttributeError("app passed without args initialized")
+        msg = "app passed without args initialized"
+        raise AttributeError(msg)
 
     def no_interactive_mode(self, interaction: Interaction, app: AppPublic) -> None:
         # pylint: disable=unused-argument

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -320,7 +320,8 @@ class Action(ActionBase):
             return self._build_group_menu("all")
         if self.steps.current.index == 1:
             return self._build_host_menu()
-        raise IndexError("broken modules somewhere?")
+        msg = "broken modules somewhere?"
+        raise IndexError(msg)
 
     def _build_group_menu(self, key=None) -> Step:
         """Build the menu for inventory groups.
@@ -432,7 +433,8 @@ class Action(ActionBase):
             return self._build_group_menu()
         if self.steps.current.selected["__type"] == "host":
             return self._build_host_content()
-        raise TypeError("unknown step type")
+        msg = "unknown step type"
+        raise TypeError(msg)
 
     def _collect_inventory_details_interactive(
         self,

--- a/src/ansible_navigator/configuration_subsystem/configurator.py
+++ b/src/ansible_navigator/configuration_subsystem/configurator.py
@@ -61,9 +61,11 @@ class Configurator:
         """
         if self._apply_previous_cli_entries is not C.NONE:
             if self._config.internals.initializing:
-                raise ValueError("'apply_previous_cli' cannot be used while initializing")
+                msg = "'apply_previous_cli' cannot be used while initializing"
+                raise ValueError(msg)
             if not self._config.initial:
-                raise ValueError("'apply_previous_cli' enabled prior to an initialization")
+                msg = "'apply_previous_cli' enabled prior to an initialization"
+                raise ValueError(msg)
 
     def _roll_back(self) -> None:
         """In the case of a rollback, log the configuration state prior to roll back."""
@@ -180,7 +182,8 @@ class Configurator:
                     # the file will be empty, but we shouldn't exit.
                     if self._params in (["settings", "--sample"], ["settings", "--gs"]):
                         return
-                    raise ValueError("Settings file cannot be empty.")
+                    msg = "Settings file cannot be empty."
+                    raise ValueError(msg)
             except (yaml.scanner.ScannerError, yaml.parser.ParserError, ValueError) as exc:
                 exit_msg = f"Settings file found {settings_filesystem_path}, but failed to load it."
                 self._exit_messages.append(ExitMessage(message=exit_msg))

--- a/src/ansible_navigator/configuration_subsystem/definitions.py
+++ b/src/ansible_navigator/configuration_subsystem/definitions.py
@@ -192,7 +192,8 @@ class SettingsEntry:
         """
         name = self.name.replace("_", "-")
         if self.value.source is Constants.NOT_SET:
-            raise ValueError(f"Current source not set for {self.name}")
+            msg = f"Current source not set for {self.name}"
+            raise ValueError(msg)
 
         choices = [str(choice).lower() for choice in self.choices]
         current = self.value.current

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -820,7 +820,8 @@ class NavigatorPostProcessor:
                 entry.value.current = auto_mode
                 entry.value.source = C.AUTO
         elif len(mode_set) > 1:
-            raise ValueError(f"Conflicting mode requests: {self._requested_mode}")
+            msg = f"Conflicting mode requests: {self._requested_mode}"
+            raise ValueError(msg)
         return messages, exit_messages
 
     # Post process osc4.
@@ -957,7 +958,8 @@ class NavigatorPostProcessor:
                 )
                 entry.value.current = auto_pae
         elif len(pae_set) > 1:
-            raise ValueError(f"Conflicting pae requests: {self._requested_pae}")
+            msg = f"Conflicting pae requests: {self._requested_pae}"
+            raise ValueError(msg)
         with contextlib.suppress(ValueError):
             entry.value.current = str2bool(entry.value.current)
 

--- a/src/ansible_navigator/configuration_subsystem/parser.py
+++ b/src/ansible_navigator/configuration_subsystem/parser.py
@@ -93,9 +93,11 @@ class Parser:
             entry for entry in self._config.entries if entry.subcommand_value is True
         ]
         if len(subcommand_value) == 0:
-            raise ValueError("No entry with subparser value defined")
+            msg = "No entry with subparser value defined"
+            raise ValueError(msg)
         if len(subcommand_value) > 1:
-            raise ValueError("Multiple entries with subparser value defined")
+            msg = "Multiple entries with subparser value defined"
+            raise ValueError(msg)
         entry = subcommand_value[0]
         return self.parser.add_subparsers(
             title=entry.short_description,
@@ -181,9 +183,10 @@ class CustomHelpFormatter(HelpFormatter):
 
         if len(action.option_strings) == 2:
             # Account for a --1234 --long-option-name
-            return f"{action.option_strings[0].ljust(6)} {action.option_strings[1]}"
-
-        raise ValueError("Too many option strings")
+            msg = f"{action.option_strings[0].ljust(6)} {action.option_strings[1]}"
+            return msg
+        msg = "Too many option strings"
+        raise ValueError(msg)
 
     def _format_usage(self, usage, actions, groups, prefix):
         """Format the usage.

--- a/src/ansible_navigator/steps.py
+++ b/src/ansible_navigator/steps.py
@@ -128,7 +128,8 @@ class Step:
         :raises ValueError: If value type doesn't match wanted type
         """
         if not isinstance(value, want):
-            raise ValueError(f"wanted {want}, got {type(value)}")
+            msg = f"wanted {want}, got {type(value)}"
+            raise ValueError(msg)
 
 
 class StepType(Enum):

--- a/src/ansible_navigator/tm_tokenize/compiler.py
+++ b/src/ansible_navigator/tm_tokenize/compiler.py
@@ -86,7 +86,8 @@ class Compiler:
                 ret_regs.append(rule.begin)
                 ret_rules.append(self._visit_rule(grammar, rule))
             else:
-                raise AssertionError(f"unreachable {rule}")
+                msg = f"unreachable {rule}"
+                raise AssertionError(msg)
         return ret_regs, tuple(ret_rules)
 
     def _captures_ref(self, grammar: Grammar, captures: Captures) -> Captures:

--- a/src/ansible_navigator/tm_tokenize/rules.py
+++ b/src/ansible_navigator/tm_tokenize/rules.py
@@ -228,7 +228,8 @@ class MatchRule(NamedTuple):
         first_line: bool,
         boundary: bool,
     ) -> tuple[State, int, bool, Regions] | None:
-        raise AssertionError(f"unreachable {self}")
+        msg = f"unreachable {self}"
+        raise AssertionError(msg)
 
 
 @uniquely_constructed
@@ -243,7 +244,8 @@ class PatternRule(NamedTuple):
         match: Match[str],
         state: State,
     ) -> tuple[State, bool, Regions]:
-        raise AssertionError(f"unreachable {self}")
+        msg = f"unreachable {self}"
+        raise AssertionError(msg)
 
     def search(
         self,

--- a/src/ansible_navigator/utils/dict_merge.py
+++ b/src/ansible_navigator/utils/dict_merge.py
@@ -47,11 +47,12 @@ def in_place_list_replace(left: Mergeable, right: Mergeable):
                     else:
                         left[key] = right[key]
             else:
-                raise DictMergeError(f"Cannot merge non-dict '{right}' into dict '{left}'")
+                msg = f"Cannot merge non-dict '{right}' into dict '{left}'"
+                raise DictMergeError(msg)
         else:
-            raise DictMergeError(f"Not implemented '{right}' into '{left}'")
+            msg = f"Not implemented '{right}' into '{left}'"
+            raise DictMergeError(msg)
     except TypeError as exc:
-        raise DictMergeError(
-            f"TypeError '{exc}' in key '{key}' when merging '{right}' into '{left}'",
-        ) from exc
+        msg = f"TypeError '{exc}' in key '{key}' when merging '{right}' into '{left}'"
+        raise DictMergeError(msg) from exc
     return left

--- a/src/ansible_navigator/utils/dot_paths.py
+++ b/src/ansible_navigator/utils/dot_paths.py
@@ -109,16 +109,19 @@ def place_at_path(
     :return: The updated content
     """
     # pylint: disable=too-many-branches
+    # pylint: disable=too-many-statements
     if (
         MergeBehaviors.DICT_DICT_REPLACE in behaviors
         and MergeBehaviors.DICT_DICT_UPDATE in behaviors
     ):
-        raise ValueError("Can't use both DICT_DICT_REPLACE and DICT_DICT_UPDATE behaviors")
+        msg = "Can't use both DICT_DICT_REPLACE and DICT_DICT_UPDATE behaviors"
+        raise ValueError(msg)
     if (
         MergeBehaviors.LIST_LIST_EXTEND in behaviors
         and MergeBehaviors.LIST_LIST_REPLACE in behaviors
     ):
-        raise ValueError("Can't use both LIST_LIST_EXTEND and LIST_LIST_REPLACE behaviors")
+        msg = "Can't use both LIST_LIST_EXTEND and LIST_LIST_REPLACE behaviors"
+        raise ValueError(msg)
 
     copied_content = copy.deepcopy(content)
     nested = copied_content
@@ -128,7 +131,8 @@ def place_at_path(
                 return value
             if MergeBehaviors.DICT_DICT_UPDATE in behaviors:
                 return {**nested, **value}
-        raise ValueError("Cannot place non dict at root of dict")
+        msg = "Cannot place non dict at root of dict"
+        raise ValueError(msg)
 
     for part in path.split("."):
         if part == path.rsplit(".", maxsplit=1)[-1]:
@@ -139,7 +143,8 @@ def place_at_path(
                     elif MergeBehaviors.LIST_LIST_REPLACE in behaviors:
                         nested[part] = value
                     else:
-                        raise ValueError("No behavior specified for LIST_LIST")
+                        msg = "No behavior specified for LIST_LIST"
+                        raise ValueError(msg)
                 else:
                     if MergeBehaviors.LIST_APPEND in behaviors:
                         nested[part].append(value)
@@ -147,7 +152,8 @@ def place_at_path(
                         nested[part] = value
                         continue
                     else:
-                        raise ValueError("No behavior specified for LIST_*")
+                        msg = "No behavior specified for LIST_*"
+                        raise ValueError(msg)
 
                 if MergeBehaviors.LIST_UNIQUE in behaviors:
                     nested[part] = list(dict.fromkeys(nested[part]))
@@ -161,7 +167,8 @@ def place_at_path(
                 elif MergeBehaviors.DICT_DICT_REPLACE in behaviors:
                     nested[part] = value
                 else:
-                    raise ValueError("No behavior specified for DICT_DICT")
+                    msg = "No behavior specified for DICT_DICT"
+                    raise ValueError(msg)
                 continue
 
             nested[part] = value

--- a/src/ansible_navigator/utils/serialize.py
+++ b/src/ansible_navigator/utils/serialize.py
@@ -63,7 +63,8 @@ def serialize(
         return _yaml_dumps(dumpable=dumpable)
     if serialization_format == SerializationFormat.JSON:
         return _json_dumps(dumpable=dumpable)
-    raise ValueError("Unknown serialization format")
+    msg = "Unknown serialization format"
+    raise ValueError(msg)
 
 
 def serialize_write_file(
@@ -94,7 +95,8 @@ def serialize_write_file(
         if serialization_format == SerializationFormat.YAML:
             _yaml_dump(dumpable=dumpable, file_handle=file_handle)
             return
-    raise ValueError("Unknown serialization format")
+    msg = "Unknown serialization format"
+    raise ValueError(msg)
 
 
 def serialize_write_temp_file(
@@ -131,8 +133,8 @@ def serialize_write_temp_file(
             return Path(file_like.name)
         _text_dump(dumpable=str(dumpable), file_handle=file_like)
         return Path(file_like.name)
-
-    raise ValueError("Unknown serialization format")
+    msg = "Unknown serialization format"
+    raise ValueError(msg)
 
 
 SERIALIZATION_FAILURE_MSG = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,9 +133,8 @@ def use_venv(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     venv_path = os.environ.get("VIRTUAL_ENV")
     if venv_path is None:
-        raise AssertionError(
-            "VIRTUAL_ENV environment variable was not set but tox should have set it.",
-        )
+        msg = "VIRTUAL_ENV environment variable was not set but tox should have set it."
+        raise AssertionError(msg)
     path_prepend = Path.cwd() / venv_path / "bin"
     monkeypatch.setenv("PATH", str(path_prepend), prepend=os.pathsep)
 

--- a/tests/integration/_common.py
+++ b/tests/integration/_common.py
@@ -28,7 +28,8 @@ def get_executable_path(name: str) -> str:
         return sys.executable
     exec_path = shutil.which(name)
     if not exec_path:
-        raise ValueError(f"{name} executable not found")
+        msg = f"{name} executable not found"
+        raise ValueError(msg)
     return exec_path
 
 

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -131,9 +131,8 @@ class TmuxSession:
         # it before we enter tmux. Do this before we switch to bash
         venv_path = os.environ.get("VIRTUAL_ENV")
         if venv_path is None:
-            raise AssertionError(
-                "VIRTUAL_ENV environment variable was not set but tox should have set it.",
-            )
+            msg = "VIRTUAL_ENV environment variable was not set but tox should have set it."
+            raise AssertionError(msg)
         venv = os.path.join(shlex.quote(venv_path), "bin", "activate")
 
         # get the USER before we start a clean shell

--- a/tests/integration/actions/builder/base.py
+++ b/tests/integration/actions/builder/base.py
@@ -53,7 +53,8 @@ class BaseClass:
         elif step.search_within_response is SearchFor.PROMPT:
             search_within_response = tmux_session.cli_prompt
         else:
-            raise ValueError("test mode not set")
+            msg = "test mode not set"
+            raise ValueError(msg)
 
         received_output = tmux_session.interaction(
             value=step.user_input,

--- a/tests/integration/actions/collections/base.py
+++ b/tests/integration/actions/collections/base.py
@@ -142,7 +142,8 @@ class BaseClass:
         elif step.search_within_response is SearchFor.WARNING:
             search_within_response = "Warning"
         else:
-            raise ValueError("test mode not set")
+            msg = "test mode not set"
+            raise ValueError(msg)
 
         received_output = tmux_session.interaction(
             value=step.user_input,

--- a/tests/integration/actions/config/base.py
+++ b/tests/integration/actions/config/base.py
@@ -77,7 +77,8 @@ class BaseClass:
         elif step.search_within_response is SearchFor.WARNING:
             search_within_response = "Warning"
         else:
-            raise ValueError("test mode not set")
+            msg = "test mode not set"
+            raise ValueError(msg)
 
         received_output = tmux_session.interaction(
             value=step.user_input,

--- a/tests/integration/actions/doc/base.py
+++ b/tests/integration/actions/doc/base.py
@@ -70,10 +70,11 @@ class BaseClass:
             # clear the screen so it starts with stdout
             user_input = f"clear && {user_input}"
         else:
-            raise ValueError(
-                "Value of 'TEST_FOR_MODE' is not set."
+            msg = (
+                "Value of 'TEST_FOR_MODE' is not set.",
                 " Valid value is either 'interactive' or 'stdout'",
             )
+            raise ValueError(msg)
 
         received_output = tmux_doc_session.interaction(user_input, search_within_response)
         updated_received_output = []

--- a/tests/integration/actions/exec/base.py
+++ b/tests/integration/actions/exec/base.py
@@ -62,7 +62,8 @@ class BaseClass:
         :raises ValueError: If test mode isn't set
         """
         if step.search_within_response is not SearchFor.PROMPT:
-            raise ValueError("test mode not set")
+            msg = "test mode not set"
+            raise ValueError(msg)
 
         search_within_response = tmux_session.cli_prompt
 

--- a/tests/integration/actions/images/base.py
+++ b/tests/integration/actions/images/base.py
@@ -88,7 +88,8 @@ class BaseClass:
         elif step.search_within_response is SearchFor.WARNING:
             search_within_response = "Warning"
         else:
-            raise ValueError("test mode not set")
+            msg = "test mode not set"
+            raise ValueError(msg)
 
         received_output = tmux_session.interaction(
             value=step.user_input,

--- a/tests/integration/actions/inventory/base.py
+++ b/tests/integration/actions/inventory/base.py
@@ -94,7 +94,8 @@ class BaseClass:
         elif step.search_within_response is SearchFor.WARNING:
             search_within_response = "Warning"
         else:
-            raise ValueError("test mode not set")
+            msg = "test mode not set"
+            raise ValueError(msg)
 
         received_output = tmux_session.interaction(
             value=step.user_input,

--- a/tests/integration/actions/settings/base.py
+++ b/tests/integration/actions/settings/base.py
@@ -79,7 +79,8 @@ class BaseClass:
         elif step.search_within_response is SearchFor.WARNING:
             search_within_response = "Warning"
         else:
-            raise ValueError("test mode not set")
+            msg = "test mode not set"
+            raise ValueError(msg)
 
         received_output = tmux_session.interaction(
             value=step.user_input,

--- a/tests/integration/settings_from_cli/test_json_schema_errors.py
+++ b/tests/integration/settings_from_cli/test_json_schema_errors.py
@@ -78,9 +78,8 @@ def test(data: Scenario, subtests: Any, tmp_path: Path):
     assert data.settings_file.exists()
     venv_path = os.environ.get("VIRTUAL_ENV")
     if venv_path is None:
-        raise AssertionError(
-            "VIRTUAL_ENV environment variable was not set but tox should have set it.",
-        )
+        msg = "VIRTUAL_ENV environment variable was not set but tox should have set it."
+        raise AssertionError(msg)
     venv = Path(venv_path, "bin", "activate")
     log_file = tmp_path / "log.txt"
 

--- a/tests/smoke/no_test_dependencies.py
+++ b/tests/smoke/no_test_dependencies.py
@@ -18,9 +18,8 @@ from ansible_navigator.command_runner import CommandRunner
 def _get_venv():
     venv_path = os.environ.get("VIRTUAL_ENV")
     if venv_path is None:
-        raise AssertionError(
-            "VIRTUAL_ENV environment variable was not set but tox should have set it.",
-        )
+        msg = "VIRTUAL_ENV environment variable was not set but tox should have set it."
+        raise AssertionError(msg)
     venv = Path(venv_path, "bin", "activate")
     return venv
 

--- a/tests/unit/actions/run/test_artifact.py
+++ b/tests/unit/actions/run/test_artifact.py
@@ -63,7 +63,8 @@ class Scenario(BaseScenario):
         :raises ValueError: When neither is set
         """
         if not (self.re_match or self.starts_with):
-            raise ValueError("re_match or starts_with required")
+            msg = "re_match or starts_with required"
+            raise ValueError(msg)
 
     def __str__(self):
         """Provide the test id.


### PR DESCRIPTION
Fix to address **ruff: EM**

Exception must not use an string or f-string literal, assign to variable first
As per: https://beta.ruff.rs/docs/rules/#flake8-errmsg-em

Related: https://github.com/ansible/ansible-navigator/pull/1493