### PR TITLE
Disable `pylint` checks that overlap with `ruff`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,120 @@ disable = [
   "fixme",
   "too-few-public-methods",
   "unsubscriptable-object",
+  # https://gist.github.com/cidrblock/ec3412bacfeb34dbc2d334c1d53bef83
+  "C0103", # invalid-name / ruff N815
+  "C0112", # empty-docstring / ruff D419
+  "C0114", # missing-module-docstring / ruff D100
+  "C0115", # missing-class-docstring / ruff D101
+  "C0116", # missing-function-docstring / ruff D103
+  "C0121", # singleton-comparison / ruff PLC0121
+  "C0123", # unidiomatic-typecheck / ruff E721
+  # "C0198", # bad-docstring-quotes / ruff Q002
+  # "C0199", # docstring-first-line-empty / ruff D210
+  "C0202", # bad-classmethod-argument / ruff PLC0202
+  "C0301", # line-too-long / ruff E501
+  "C0304", # missing-final-newline / ruff W292
+  "C0325", # superfluous-parens / ruff UP034
+  "C0410", # multiple-imports / ruff E401
+  "C0411", # wrong-import-order / ruff I001
+  "C0412", # ungrouped-imports / ruff I001
+  "C0413", # wrong-import-position / ruff E402
+  "C0414", # useless-import-alias / ruff PLC0414
+  # "C0501", # consider-using-any-or-all / ruff PLC0501
+  # "C2201", # misplaced-comparison-constant / ruff SIM300
+  "C3001", # unnecessary-lambda-assignment / ruff PLC3001
+  "C3002", # unnecessary-direct-lambda-call / ruff PLC3002
+  "E0001", # syntax-error / ruff E999
+  "E0101", # return-in-init / ruff PLE0101
+  "E0102", # function-redefined / ruff F811
+  "E0103", # not-in-loop / ruff PLE0103
+  "E0104", # return-outside-function / ruff F706
+  "E0105", # yield-outside-function / ruff F704
+  "E0107", # nonexistent-operator / ruff B002
+  "E0116", # continue-in-finally / ruff PLE0116
+  "E0117", # nonlocal-without-binding / ruff PLE0117
+  "E0118", # used-prior-global-declaration / ruff PLE0118
+  "E0211", # no-method-argument / ruff N805
+  "E0213", # no-self-argument / ruff N805
+  "E0602", # undefined-variable / ruff F821
+  "E0604", # invalid-all-object / ruff PLE0604
+  "E0605", # invalid-all-format / ruff PLE0605
+  "E0711", # notimplemented-raised / ruff F901
+  "E1142", # await-outside-async / ruff PLE1142
+  "E1205", # logging-too-many-args / ruff PLE1205
+  "E1206", # logging-too-few-args / ruff PLE1206
+  "E1301", # truncated-format-string / ruff F501
+  "E1302", # mixed-format-string / ruff F506
+  "E1303", # format-needs-mapping / ruff F502
+  "E1304", # missing-format-string-key / ruff F524
+  "E1307", # bad-string-format-type / ruff PLE1307
+  "E1310", # bad-str-strip-call / ruff PLE1310
+  "E2502", # bidirectional-unicode / ruff PLE2502
+  "E2510", # invalid-character-backspace / ruff PLE2510
+  "E2512", # invalid-character-sub / ruff PLE2512
+  "E2513", # invalid-character-esc / ruff PLE2513
+  "E2514", # invalid-character-nul / ruff PLE2514
+  "E2515", # invalid-character-zero-width-space / ruff PLE2515
+  "R0123", # literal-comparison / ruff F632
+  "R0133", # comparison-of-constants / ruff PLR0133
+  "R0205", # useless-object-inheritance / ruff UP004
+  "R0911", # too-many-return-statements / ruff PLR0911
+  "R0912", # too-many-branches / ruff PLR0912
+  "R0915", # too-many-statements / ruff PLR0915
+  # "R1260", # too-complex / ruff C901
+  "R1701", # consider-merging-isinstance / ruff PLR1701
+  "R1706", # consider-using-ternary / ruff SIM108
+  "R1707", # trailing-comma-tuple / ruff COM818
+  "R1710", # inconsistent-return-statements / ruff PLR1710
+  "R1711", # useless-return / ruff PLR1711
+  "R1715", # consider-using-get / ruff SIM401
+  "R1717", # consider-using-dict-comprehension / ruff C402
+  "R1718", # consider-using-set-comprehension / ruff C401
+  "R1721", # unnecessary-comprehension / ruff PLR1721
+  "R1722", # consider-using-sys-exit / ruff PLR1722
+  "R1725", # super-with-arguments / ruff UP008
+  "R1728", # consider-using-generator / ruff C417
+  "R1729", # use-a-generator / ruff C417
+  "R1734", # use-list-literal / ruff C405
+  "R1735", # use-dict-literal / ruff C406
+  # "R2004", # magic-value-comparison / ruff PLR2004
+  # "R5501", # else-if-used / ruff PLR5501
+  # "R6002", # consider-using-alias / ruff UP006
+  # "R6003", # consider-alternative-union-syntax / ruff UP007
+  "W0102", # dangerous-default-value / ruff B006
+  "W0104", # pointless-statement / ruff B018
+  "W0106", # expression-not-assigned / ruff B018
+  "W0109", # duplicate-key / ruff F601
+  "W0120", # useless-else-on-loop / ruff PLW0120
+  "W0129", # assert-on-string-literal / ruff PLW0129
+  # "W0160", # consider-ternary-expression / ruff SIM108
+  "W0199", # assert-on-tuple / ruff F631
+  "W0401", # wildcard-import / ruff F403
+  "W0406", # import-self / ruff PLW0406
+  "W0410", # misplaced-future / ruff F404
+  "W0602", # global-variable-not-assigned / ruff PLW0602
+  "W0603", # global-statement / ruff PLW0603
+  "W0611", # unused-import / ruff F401
+  "W0612", # unused-variable / ruff F841
+  "W0613", # unused-argument / ruff ARG001
+  "W0622", # redefined-builtin / ruff A001
+  "W0640", # cell-var-from-loop / ruff B023
+  "W0702", # bare-except / ruff E722
+  "W0705", # duplicate-except / ruff B014
+  "W0711", # binary-op-exception / ruff PLW0711
+  "W0718", # broad-exception-caught / ruff PLW0718
+  "W1300", # bad-format-string-key / ruff PLW1300
+  "W1301", # unused-format-string-key / ruff F504
+  "W1302", # bad-format-string / ruff PLW1302
+  "W1304", # unused-format-string-argument / ruff F507
+  "W1308", # duplicate-string-formatting-argument / ruff PLW1308
+  "W1309", # f-string-without-interpolation / ruff F541
+  "W1310", # format-string-without-interpolation / ruff PLW1310
+  "W1401", # anomalous-backslash-in-string / ruff W605
+  "W1405", # inconsistent-quotes / ruff Q000
+  "W1508", # invalid-envvar-default / ruff PLW1508
+  "W1515", # forgotten-debug-statement / ruff T100
+
 ]
 enable = [
   "useless-suppression", # Identify unneeded pylint disable statements

--- a/rip.sh
+++ b/rip.sh
@@ -1,0 +1,2 @@
+for file in $(find tests -mindepth 1 -type f); do \
+sed -i -E '/.*(attribute-defined-outside-init|import-outside-toplevel|no-else-return|not-an-iterable|too-many-ancestors|too-many-instance-attributes|too-many-arguments|too-many-lines|too-many-locals|too-many-nested-blocks|preferred-module|protected-access|unused-import|used-before-assignment).*/! s/(.*)# pylint: disable=.*/\1/g' $file; done

--- a/rip.sh
+++ b/rip.sh
@@ -1,2 +1,0 @@
-for file in $(find tests -mindepth 1 -type f); do \
-sed -i -E '/.*(attribute-defined-outside-init|import-outside-toplevel|no-else-return|not-an-iterable|too-many-ancestors|too-many-instance-attributes|too-many-arguments|too-many-lines|too-many-locals|too-many-nested-blocks|preferred-module|protected-access|unused-import|used-before-assignment).*/! s/(.*)# pylint: disable=.*/\1/g' $file; done

--- a/src/ansible_navigator/action_base.py
+++ b/src/ansible_navigator/action_base.py
@@ -82,7 +82,6 @@ class ActionBase:
         raise AttributeError(msg)
 
     def no_interactive_mode(self, interaction: Interaction, app: AppPublic) -> None:
-        # pylint: disable=unused-argument
         """Show a warning notification that the user interactive mode is not supported.
 
         :param interaction: The interaction from the user

--- a/src/ansible_navigator/actions/_actions.py
+++ b/src/ansible_navigator/actions/_actions.py
@@ -152,7 +152,7 @@ def run_interactive(package: str, action: str, *args: Any, **_kwargs: Any) -> An
     # Capture and show a UI notification
     try:
         return run_action(app=app, interaction=interaction)
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         logger.critical("Subcommand '%s' encountered a fatal error.", action)
         logger.exception("Logging an uncaught exception")
         warn_msg = [f"Unexpected errors were encountered while running '{action}'."]

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -36,7 +36,6 @@ from . import run_action
 
 
 def color_menu(colno: int, colname: str, entry: dict[str, Any]) -> tuple[int, int]:
-    # pylint: disable=unused-argument
     """Provide a color for a collections menu entry in one column.
 
     :param colno: The column number
@@ -370,8 +369,6 @@ class Action(ActionBase):
         )
 
     def _run_runner(self) -> None:
-        # pylint: disable=too-many-branches
-        # pylint: disable=too-many-statements
         # pylint: disable=too-many-locals
         """Use the runner subsystem to catalog collections."""
         if isinstance(self._args.set_environment_variable, dict):
@@ -513,9 +510,8 @@ class Action(ActionBase):
         :param output: The output from the collection cataloging process
         :returns: Nothing
         """
-        # pylint: disable=too-many-branches
         # pylint: disable=too-many-locals
-        # pylint: disable=too-many-statements
+
         try:
             if not output.startswith("{"):
                 _warnings, json_str = output.split("{", 1)

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -30,7 +30,6 @@ from . import run_action
 
 
 def color_menu(colno: int, colname: str, entry: dict[str, Any]) -> tuple[int, int]:
-    # pylint: disable=unused-argument
     """Provide a color for a collections menu entry in one column.
 
     :param colno: The column number
@@ -210,8 +209,6 @@ class Action(ActionBase):
         )
 
     def _run_runner(self) -> tuple | None:
-        # pylint: disable=too-many-branches
-        # pylint: disable=too-many-statements
         """Use the runner subsystem to retrieve the configuration.
 
         :raises RuntimeError: When the ansible-config command cannot be found with execution
@@ -309,7 +306,6 @@ class Action(ActionBase):
         :param dump_output: The output from config dump
         :returns: Nothing
         """
-        # pylint: disable=too-many-branches
         # pylint: disable=too-many-locals
         try:
             parsed = yaml.load(list_output, Loader=Loader)

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -134,7 +134,6 @@ class Action(ActionBase):
         return RunStdoutReturn(message=error, return_code=return_code)
 
     def _run_runner(self) -> dict | tuple[str, str, int] | None:
-        # pylint: disable=too-many-branches
         # pylint: disable=no-else-return
         """Use the runner subsystem to retrieve the configuration.
 
@@ -239,7 +238,6 @@ class Action(ActionBase):
         :param err: Any runner errors
         :returns: The plugin's doc or errors
         """
-        # pylint: disable=too-many-branches
         plugin_doc = {}
         if self._args.execution_environment:
             error_key_name = "execution_environment_errors"

--- a/src/ansible_navigator/actions/filter.py
+++ b/src/ansible_navigator/actions/filter.py
@@ -22,7 +22,6 @@ class Action:
         self._args = args
         self._logger = logging.getLogger(__name__)
 
-    # pylint: disable=unused-argument
     def run(self, interaction: Interaction, app: AppPublic) -> None:
         """Execute the ``:filter`` request.
 

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -70,7 +70,6 @@ class Action(ActionBase):
         )
 
     def color_menu(self, colno: int, colname: str, entry: dict[str, Any]) -> tuple[int, int]:
-        # pylint: disable=unused-argument
         """Provide a color for a images menu entry in one column.
 
         :param colno: The column number

--- a/src/ansible_navigator/actions/lint.py
+++ b/src/ansible_navigator/actions/lint.py
@@ -92,7 +92,6 @@ def severity_to_color(severity: str) -> int:
 
 
 def color_menu(colno: int, colname: str, entry: dict[str, Any]) -> tuple[int, int]:
-    # pylint: disable=unused-argument
     """Color the menu.
 
     :param colno: The column number

--- a/src/ansible_navigator/actions/open_file.py
+++ b/src/ansible_navigator/actions/open_file.py
@@ -150,7 +150,6 @@ class Action:
         return file_name
 
     def run(self, interaction: Interaction, app: AppPublic) -> None:
-        # pylint: disable=unused-argument
         """Execute the ``:open`` request for mode interactive.
 
         :param interaction: The interaction from the user

--- a/src/ansible_navigator/actions/quit.py
+++ b/src/ansible_navigator/actions/quit.py
@@ -22,7 +22,6 @@ class Action:
         self._args = args
         self._logger = logging.getLogger(__name__)
 
-    # pylint: disable=unused-argument
     def run(self, interaction: Interaction, app: AppPublic) -> Interaction:
         """Handle a request to quit the application from the user interface.
 

--- a/src/ansible_navigator/actions/rerun.py
+++ b/src/ansible_navigator/actions/rerun.py
@@ -23,7 +23,6 @@ class Action:
         self._args = args
         self._logger = logging.getLogger(__name__)
 
-    # pylint: disable=unused-argument
     def run(self, interaction: Interaction, app: AppPublic) -> None:
         """Execute the ``:rerun`` request for mode interactive.
 

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -72,7 +72,6 @@ def get_color(word):
 
 
 def color_menu(_colno: int, colname: str, entry: dict[str, Any]) -> tuple[int, int]:
-    # pylint: disable=too-many-branches
     """Find matching color for word.
 
     :param colname: The column name
@@ -347,7 +346,6 @@ class Action(ActionBase):
         self._prepare_to_exit(interaction)
         return None
 
-    # pylint: disable=too-many-branches
     def _init_run(self) -> bool:
         """In the case of :run, check the user input.
 
@@ -639,10 +637,7 @@ class Action(ActionBase):
             self._logger.debug("Drained %s events", drain_count)
 
     def _handle_message(self, message: dict) -> None:
-        # pylint: disable=too-many-branches
-        # pylint: disable=too-many-statements
         # pylint: disable=too-many-locals
-        # pylint: disable=too-many-return-statements
         """Handle a runner message.
 
         :param message: The message from runner

--- a/src/ansible_navigator/actions/serialize_json.py
+++ b/src/ansible_navigator/actions/serialize_json.py
@@ -23,7 +23,6 @@ class Action:
         self._args = args
         self._logger = logging.getLogger(__name__)
 
-    # pylint: disable=unused-argument
     def run(self, interaction: Interaction, app: AppPublic) -> None:
         """Execute the ``:json`` request for mode interactive.
 

--- a/src/ansible_navigator/actions/serialize_yaml.py
+++ b/src/ansible_navigator/actions/serialize_yaml.py
@@ -23,7 +23,6 @@ class Action:
         self._args = args
         self._logger = logging.getLogger(__name__)
 
-    # pylint: disable=unused-argument
     def run(self, interaction: Interaction, app: AppPublic) -> None:
         """Execute the ``:yaml`` request for mode interactive.
 

--- a/src/ansible_navigator/actions/settings.py
+++ b/src/ansible_navigator/actions/settings.py
@@ -31,7 +31,6 @@ from . import run_action
 
 
 def color_menu(colno: int, colname: str, entry: PresentableSettingsEntry) -> tuple[int, int]:
-    # pylint: disable=unused-argument
     """Color the menu.
 
     :param colno: Column number

--- a/src/ansible_navigator/actions/template.py
+++ b/src/ansible_navigator/actions/template.py
@@ -41,7 +41,6 @@ class Action(ActionBase):
         :returns: The pending :class:`~ansible_navigator.ui_framework.ui.Interaction` or
             :data:`None`
         """
-        # pylint: disable=too-many-branches
         self._logger.debug("template requested '%s'", interaction.action.value)
         self._prepare_to_run(app, interaction)
 

--- a/src/ansible_navigator/actions/write_file.py
+++ b/src/ansible_navigator/actions/write_file.py
@@ -30,7 +30,6 @@ class Action:
         self._args = args
         self._logger = logging.getLogger(__name__)
 
-    # pylint: disable=unused-argument
     def run(self, interaction: Interaction, app: AppPublic) -> None:
         """Execute the ``:write`` request for mode interactive.
 
@@ -38,7 +37,6 @@ class Action:
         :param app: The app instance
         :returns: Nothing
         """
-        # pylint: disable=too-many-branches
         self._logger.debug("write requested as %s", interaction.action.value)
         match = interaction.action.match.groupdict()
         filename = os.path.abspath(match["filename"])

--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -137,7 +137,6 @@ def run(args: ApplicationConfiguration) -> ActionReturn:
 
 def main():
     """Start application here."""
-    # pylint: disable=broad-except
     messages: list[LogMessage] = log_dependencies()
     exit_messages: list[ExitMessage] = []
 

--- a/src/ansible_navigator/configuration_subsystem/configurator.py
+++ b/src/ansible_navigator/configuration_subsystem/configurator.py
@@ -159,7 +159,6 @@ class Configurator:
 
     def _apply_settings_file(self) -> None:
         # pylint: disable=too-many-locals
-        # pylint: disable=too-many-statements
         """Apply the settings file.
 
         :raises ValueError: If the settings file is empty

--- a/src/ansible_navigator/configuration_subsystem/definitions.py
+++ b/src/ansible_navigator/configuration_subsystem/definitions.py
@@ -328,16 +328,16 @@ class VolumeMountOption(Enum):
     OVERLAY = "O"
 
     # Read Only
-    ro = "ro"  # pylint: disable=invalid-name
+    ro = "ro"
 
     # Read Write
-    rw = "rw"  # pylint: disable=invalid-name
+    rw = "rw"
 
     # Relabel as private
     Z = "Z"
 
     # Relabel as shared.
-    z = "z"  # pylint: disable=invalid-name
+    z = "z"
 
 
 V = TypeVar("V", bound="VolumeMount")

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -87,7 +87,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process a boolean value.
 
         :param entry: The current settings entry
@@ -107,7 +106,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process ansible_runner_artifact_dir path.
 
         :param entry: The current settings entry
@@ -126,7 +124,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process ansible_runner_rotate_artifacts_count.
 
         :param entry: The current settings entry
@@ -152,7 +149,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process ansible_runner_timeout.
 
         :param entry: The current settings entry
@@ -175,7 +171,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process collection doc cache path.
 
         :param entry: The current settings entry
@@ -190,7 +185,6 @@ class NavigatorPostProcessor:
     @staticmethod
     @_post_processor
     def cmdline(entry: SettingsEntry, config: ApplicationConfiguration) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process cmdline.
 
         :param entry: The current settings entry
@@ -209,7 +203,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process container_engine.
 
         :param entry: The current settings entry
@@ -253,9 +246,7 @@ class NavigatorPostProcessor:
 
     @_post_processor
     def execution_environment(self, entry: SettingsEntry, config) -> PostProcessorReturn:
-        # pylint: disable=too-many-branches
         # pylint: disable=too-many-locals
-        # pylint: disable=too-many-statements
         """Post process execution_environment.
 
         :param entry: The current settings entry
@@ -338,7 +329,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process execution_environment_image.
 
         :param entry: The current settings entry
@@ -363,8 +353,6 @@ class NavigatorPostProcessor:
         :param config: The full application configuration
         :return: An instance of the standard post process return object
         """
-        # pylint: disable=unused-argument
-        # pylint: disable=too-many-branches
         # pylint: disable=too-many-locals
 
         messages: list[LogMessage] = []
@@ -464,7 +452,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process container_options.
 
         :param entry: The current settings entry
@@ -550,7 +537,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process execution_environment_image_details.
 
         :param entry: The current settings entry
@@ -626,7 +612,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process inventory_columns.
 
         :param entry: The current settings entry
@@ -700,7 +685,6 @@ class NavigatorPostProcessor:
     @staticmethod
     @_post_processor
     def log_file(entry: SettingsEntry, config: ApplicationConfiguration) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process log_file.
 
         If the parent directory for the log file cannot be created and is writable.
@@ -886,7 +870,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process pass_environment_variable.
 
         :param entry: The current settings entry
@@ -939,7 +922,6 @@ class NavigatorPostProcessor:
         :raises ValueError: When more than 1 pae changes requests are present, shouldn't happen
         :returns: An instance of the standard post process return object
         """
-        # pylint: disable=unused-argument
         messages: list[LogMessage] = []
         exit_messages: list[ExitMessage] = []
 
@@ -1003,7 +985,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process playbook_artifact_save_as.
 
         :param entry: The current settings entry
@@ -1037,7 +1018,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process ``pull_arguments``.
 
         :param entry: The current settings entry
@@ -1084,7 +1064,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process set_environment_variable.
 
         :param entry: The current settings entry
@@ -1123,7 +1102,6 @@ class NavigatorPostProcessor:
         entry: SettingsEntry,
         config: ApplicationConfiguration,
     ) -> PostProcessorReturn:
-        # pylint: disable=unused-argument
         """Post process ``time_zone``.
 
         :param entry: The current settings entry

--- a/src/ansible_navigator/configuration_subsystem/utils.py
+++ b/src/ansible_navigator/configuration_subsystem/utils.py
@@ -100,7 +100,6 @@ def parse_ansible_cfg(ee_enabled: bool) -> ParseAnsibleCfgResponse:
     :param ee_enabled: Indicates if EE support is enabled
     :returns: The ansible.cfg contents
     """
-    # pylint: disable=too-many-return-statements
     response = ParseAnsibleCfgResponse(messages=[], exit_messages=[])
     response.config.path = Constants.NONE
     response.config.text = Constants.NONE

--- a/src/ansible_navigator/data/catalog_collections.py
+++ b/src/ansible_navigator/data/catalog_collections.py
@@ -109,7 +109,6 @@ class CollectionCatalog:
         :param collection: Details describing the collection
         """
         # pylint: disable=too-many-locals
-        # pylint: disable=too-many-statements
 
         collection_name: str = collection["known_as"]
         collection["roles"] = []
@@ -357,7 +356,7 @@ def worker(pending_queue: multiprocessing.Queue, completed_queue: multiprocessin
     :param completed_queue: The queue in which extracted documentation will be placed
     """
     # pylint: disable=import-outside-toplevel
-    # pylint: disable=broad-except
+
     # load the fragment_loader _after_ the path is set
     from ansible.plugins.loader import fragment_loader
 

--- a/src/ansible_navigator/data/image_introspect.py
+++ b/src/ansible_navigator/data/image_introspect.py
@@ -13,8 +13,6 @@ from typing import Any
 from typing import Callable
 
 
-# pylint: disable=broad-except
-
 PROCESSES = (multiprocessing.cpu_count() - 1) or 1
 
 

--- a/src/ansible_navigator/diagnostics.py
+++ b/src/ansible_navigator/diagnostics.py
@@ -81,7 +81,7 @@ class Diagnostics:
 
     # pylint: disable=too-many-instance-attributes
 
-    __WARNING__: dict[str, JSONTypes]  # pylint: disable=invalid-name
+    __WARNING__: dict[str, JSONTypes]
     basics: dict[str, JSONTypes]
     container_engines: dict[str, JSONTypes]
     execution_environment: dict[str, JSONTypes]
@@ -141,8 +141,7 @@ def diagnostic_runner(func):
         :param kwargs: The keyword arguments
         :returns: The result of the function with elapsed or error information
         """
-        # pylint: disable=broad-except
-        global DIAGNOSTIC_FAILURES  # pylint: disable=global-statement
+        global DIAGNOSTIC_FAILURES
         start = datetime.datetime.now()
         color = args[0].color
         collector = func.__collector__

--- a/src/ansible_navigator/image_manager/introspect.py
+++ b/src/ansible_navigator/image_manager/introspect.py
@@ -14,8 +14,6 @@ from typing import Callable
 from typing import Union
 
 
-# pylint: disable=broad-except
-
 JSONTypes = Union[bool, int, str, dict, list]
 
 

--- a/src/ansible_navigator/initialization.py
+++ b/src/ansible_navigator/initialization.py
@@ -140,7 +140,6 @@ def get_and_check_collection_doc_cache(
     return messages, exit_messages, collection_cache
 
 
-# pylint: disable=inconsistent-return-statements
 def _diagnose(
     args: ApplicationConfiguration,
     exit_messages: list[ExitMessage],

--- a/src/ansible_navigator/initialization.py
+++ b/src/ansible_navigator/initialization.py
@@ -160,9 +160,6 @@ def _diagnose(
         return messages, exit_messages
 
 
-# pylint: enable=inconsistent-return-statements
-
-
 def parse_and_update(
     params: list,
     args: ApplicationConfiguration,

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -121,7 +121,6 @@ class Colorize:
         :param scope: The scope, aka the format of the string
         :returns: A list of lines, each a list of dicts
         """
-        # pylint: disable=broad-except
         try:
             compiler = self._grammars.compiler_for_scope(scope)
         except KeyError:
@@ -258,7 +257,6 @@ def columns_and_colors(
     lines: list[tuple[Regions, str]],
     schema: ColorSchema,
 ) -> list[list[SimpleLinePart]]:
-    # pylint: disable=too-many-branches
     """Convert to colors and columns.
 
     :param lines: Lines of text and their regions

--- a/src/ansible_navigator/ui_framework/field_curses_information.py
+++ b/src/ansible_navigator/ui_framework/field_curses_information.py
@@ -39,7 +39,6 @@ class FieldCursesInformation:
         )
 
     def validate(self, response: str) -> None:
-        # pylint: disable=unused-argument
         """No validation required for information field.
 
         :param response: The response to validate

--- a/src/ansible_navigator/ui_framework/field_information.py
+++ b/src/ansible_navigator/ui_framework/field_information.py
@@ -35,7 +35,6 @@ class FieldInformation:
         return max(self.information)
 
     def validate(self, response: str) -> None:
-        # pylint: disable=unused-argument
         """No validation required for information field.
 
         :param response: Field data

--- a/src/ansible_navigator/ui_framework/field_working.py
+++ b/src/ansible_navigator/ui_framework/field_working.py
@@ -35,7 +35,6 @@ class FieldWorking:
         return max(self.messages)
 
     def validate(self, response: str) -> None:
-        # pylint: disable=unused-argument
         """No validation required for working field.
 
         :param response: Field response

--- a/src/ansible_navigator/ui_framework/form_handler_button.py
+++ b/src/ansible_navigator/ui_framework/form_handler_button.py
@@ -11,7 +11,7 @@ from .curses_window import CursesWindow
 
 
 if TYPE_CHECKING:
-    from .field_button import FieldButton  # pylint: disable=cyclic-import
+    from .field_button import FieldButton
 
 
 class FormHandlerButton(CursesWindow):

--- a/src/ansible_navigator/ui_framework/form_handler_information.py
+++ b/src/ansible_navigator/ui_framework/form_handler_information.py
@@ -8,7 +8,7 @@ from .curses_window import CursesWindow
 
 
 if TYPE_CHECKING:
-    from .field_information import FieldInformation  # pylint: disable=cyclic-import
+    from .field_information import FieldInformation
 
 
 class FormHandlerInformation(CursesWindow):

--- a/src/ansible_navigator/ui_framework/form_handler_options.py
+++ b/src/ansible_navigator/ui_framework/form_handler_options.py
@@ -11,8 +11,8 @@ from .curses_window import CursesWindow
 
 
 if TYPE_CHECKING:
-    from .field_checks import FieldChecks  # pylint: disable=cyclic-import
-    from .field_radio import FieldRadio  # pylint: disable=cyclic-import
+    from .field_checks import FieldChecks
+    from .field_radio import FieldRadio
 
 
 class FormHandlerOptions(CursesWindow):

--- a/src/ansible_navigator/ui_framework/form_handler_text.py
+++ b/src/ansible_navigator/ui_framework/form_handler_text.py
@@ -53,8 +53,6 @@ class FormHandlerText(CursesWindow, Textbox):
                   1 if the window should be repainted
                   -1 if the window should be closed
         """
-        # pylint: disable=too-many-branches
-
         # in the case the term returns 127 instead of 263
         if char == curses_ascii.DEL:
             char = curses.KEY_BACKSPACE

--- a/src/ansible_navigator/ui_framework/form_handler_working.py
+++ b/src/ansible_navigator/ui_framework/form_handler_working.py
@@ -8,7 +8,7 @@ from .curses_window import CursesWindow
 
 
 if TYPE_CHECKING:
-    from .field_working import FieldWorking  # pylint: disable=cyclic-import
+    from .field_working import FieldWorking
 
 
 class FormHandlerWorking(CursesWindow):

--- a/src/ansible_navigator/ui_framework/form_utils.py
+++ b/src/ansible_navigator/ui_framework/form_utils.py
@@ -28,7 +28,6 @@ from .validators import FieldValidators
 
 
 def dict_to_form(form_data: dict) -> Form:
-    # pylint: disable=too-many-branches
     """Convert a python dict to a form.
 
     :param form_data: Form data

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -411,9 +411,7 @@ class UserInterface(CursesWindow):
         await_input: bool,
         count: int,
     ) -> str:
-        # pylint: disable=too-many-branches
         # pylint: disable=too-many-locals
-        # pylint: disable=too-many-statements
         """Show something on the screen.
 
         :param lines: The lines to show
@@ -677,9 +675,7 @@ class UserInterface(CursesWindow):
         index: int,
         await_input: bool,
     ) -> Interaction:
-        # pylint: disable=too-many-branches
         # pylint: disable=too-many-locals
-        # pylint: disable=too-many-statements
         """Show an object on the display.
 
         :param objs: A list of one or more object

--- a/src/ansible_navigator/ui_framework/validators.py
+++ b/src/ansible_navigator/ui_framework/validators.py
@@ -84,7 +84,6 @@ class FieldValidators:
 
     @staticmethod
     def one_of(choices: list = [], text: str = "", hint: bool = False) -> Validation | str:
-        # pylint: disable=dangerous-default-value
         """Validate that some text is one of choices.
 
         :param choices: The list of choices

--- a/src/ansible_navigator/utils/dot_paths.py
+++ b/src/ansible_navigator/utils/dot_paths.py
@@ -108,8 +108,6 @@ def place_at_path(
     :raises ValueError: If something can't be done
     :return: The updated content
     """
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-statements
     if (
         MergeBehaviors.DICT_DICT_REPLACE in behaviors
         and MergeBehaviors.DICT_DICT_UPDATE in behaviors

--- a/src/ansible_navigator/utils/version_migration/definitions.py
+++ b/src/ansible_navigator/utils/version_migration/definitions.py
@@ -149,7 +149,6 @@ class Migration:
         :param args: The positional arguments
         :param kwargs: The keyword arguments
         """
-        # pylint: disable=broad-except
         if not isinstance(step.function_name, str):
             return
         function = getattr(self, step.function_name)

--- a/src/ansible_navigator/utils/version_migration/migrate.py
+++ b/src/ansible_navigator/utils/version_migration/migrate.py
@@ -41,7 +41,6 @@ def run_migrations(settings_file_str: str, migration_type: MigrationType) -> Non
     :param settings_file_str: Path to the settings file
     :param migration_type: Type of migration
     """
-    # pylint: disable=too-many-branches
     migrations_to_run = [
         migration()
         for migration in migrations

--- a/src/ansible_navigator/version.py
+++ b/src/ansible_navigator/version.py
@@ -1,5 +1,5 @@
 """Ansible-navigator version information."""
-# pylint: disable=broad-except
+
 try:
     from ._version import version as __version__
 except ImportError:  # pragma: no branch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -336,7 +336,7 @@ def pytest_sessionstart(session: pytest.Session):
 USER_ENVIRONMENT = {}
 
 
-def pytest_configure(config: pytest.Config):  # pylint: disable=unused-argument
+def pytest_configure(config: pytest.Config):
     """Attempt to save a contributor some troubleshooting.
 
     :param config: The pytest config object
@@ -374,7 +374,7 @@ def pytest_configure(config: pytest.Config):  # pylint: disable=unused-argument
         pytest.exit("Please install tmux before testing.")
 
 
-def pytest_unconfigure(config: pytest.Config):  # pylint: disable=unused-argument
+def pytest_unconfigure(config: pytest.Config):
     """Restore the environment variables that start with ANSIBLE_.
 
     :param config: The pytest config object

--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -29,7 +29,7 @@ def id_func(param: Any) -> str:
     :return: Returns a string.
     """
     result = ""
-    global _AUTO_ID_COUNTER  # pylint: disable=global-statement
+    global _AUTO_ID_COUNTER
     if isinstance(param, str):
         result = param
     elif hasattr(param, "value") and isinstance(param.value, str):  # covers for Enums too

--- a/tests/fixtures/common/collections/ansible_collections/company_name/coll_1/plugins/lookup/lookup_1.py
+++ b/tests/fixtures/common/collections/ansible_collections/company_name/coll_1/plugins/lookup/lookup_1.py
@@ -1,9 +1,6 @@
 """An ansible test lookup plugin."""
 
 
-# pylint: enable=invalid-name
-
-
 DOCUMENTATION = """
     name: lookup_1
     author: test

--- a/tests/fixtures/common/collections/ansible_collections/company_name/coll_1/plugins/lookup/lookup_1.py
+++ b/tests/fixtures/common/collections/ansible_collections/company_name/coll_1/plugins/lookup/lookup_1.py
@@ -1,7 +1,6 @@
 """An ansible test lookup plugin."""
 
 
-# pylint: disable=invalid-name
 # pylint: enable=invalid-name
 
 

--- a/tests/fixtures/common/collections/ansible_collections/company_name/coll_2/plugins/lookup/lookup_2.py
+++ b/tests/fixtures/common/collections/ansible_collections/company_name/coll_2/plugins/lookup/lookup_2.py
@@ -1,7 +1,6 @@
 """An ansible test lookup plugin."""
 
 
-# pylint: disable=invalid-name
 # pylint: enable=invalid-name
 
 

--- a/tests/fixtures/common/collections/ansible_collections/company_name/coll_2/plugins/lookup/lookup_2.py
+++ b/tests/fixtures/common/collections/ansible_collections/company_name/coll_2/plugins/lookup/lookup_2.py
@@ -1,9 +1,6 @@
 """An ansible test lookup plugin."""
 
 
-# pylint: enable=invalid-name
-
-
 DOCUMENTATION = """
     name: lookup_2
     author: test

--- a/tests/fixtures/common/collections/ansible_collections/company_name/coll_2/plugins/modules/mod_2.py
+++ b/tests/fixtures/common/collections/ansible_collections/company_name/coll_2/plugins/modules/mod_2.py
@@ -1,9 +1,6 @@
 """An ansible test module."""
 
 
-# pylint: enable=invalid-name
-
-
 DOCUMENTATION = """
 module: mod_2
 author:

--- a/tests/fixtures/common/collections/ansible_collections/company_name/coll_2/plugins/modules/mod_2.py
+++ b/tests/fixtures/common/collections/ansible_collections/company_name/coll_2/plugins/modules/mod_2.py
@@ -1,7 +1,6 @@
 """An ansible test module."""
 
 
-# pylint: disable=invalid-name
 # pylint: enable=invalid-name
 
 

--- a/tests/integration/_action_run_test.py
+++ b/tests/integration/_action_run_test.py
@@ -104,7 +104,6 @@ class ActionRunTest:
         value: ContentFormat | None = None,
         default: bool = False,
     ) -> ContentFormat:
-        # pylint: disable=unused-argument
         """Do nothing content format callable.
 
         :param value: The content format value

--- a/tests/integration/_cli2runner.py
+++ b/tests/integration/_cli2runner.py
@@ -45,7 +45,6 @@ class Cli2Runner:
         expected: dict[str, str],
     ):
         # pylint: disable=too-many-arguments
-        # pylint: disable=unused-argument
         """Confirm execution of ``cli.main()`` produces the desired results.
 
         :param mocked_runner: A patched instance of runner
@@ -68,7 +67,6 @@ class Cli2Runner:
         expected: dict[str, str],
     ):
         # pylint: disable=too-many-arguments
-        # pylint: disable=unused-argument
         """Test using config, interactive.
 
         :param mocker: The mocker fixture
@@ -98,7 +96,6 @@ class Cli2Runner:
         expected: dict[str, str],
     ):
         # pylint: disable=too-many-arguments
-        # pylint: disable=unused-argument
         """Test using config, stdout.
 
         :param mocker: The mocker fixture
@@ -128,7 +125,6 @@ class Cli2Runner:
         expected: dict[str, str],
     ):
         # pylint: disable=too-many-arguments
-        # pylint: disable=unused-argument
         """Test using inventory, interactive.
 
         :param mocker: The mocker fixture
@@ -158,7 +154,6 @@ class Cli2Runner:
         expected: dict[str, str],
     ):
         # pylint: disable=too-many-arguments
-        # pylint: disable=unused-argument
         """Test using inventory, stdout.
 
         :param mocker: The mocker fixture
@@ -188,7 +183,6 @@ class Cli2Runner:
         expected: dict[str, str],
     ):
         # pylint: disable=too-many-arguments
-        # pylint: disable=unused-argument
         """Test using run, interactive.
 
         :param mocker: The mocker fixture
@@ -218,7 +212,6 @@ class Cli2Runner:
         expected: dict[str, str],
     ):
         # pylint: disable=too-many-arguments
-        # pylint: disable=unused-argument
         """Test using run, stdout.
 
         :param mocker: The mocker fixture

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -113,7 +113,7 @@ class TmuxSession:
         """
         # pylint: disable=attribute-defined-outside-init
         # pylint: disable=too-many-locals
-        # pylint: disable=too-many-statements
+
         self._server = libtmux.Server()
         self._build_tmux_session()
         self._window = self._session.new_window(self._session_name)
@@ -248,8 +248,6 @@ class TmuxSession:
         timeout: int = 300,
         send_clear: bool = True,
     ) -> list[str]:
-        # pylint: disable=too-many-branches
-        # pylint: disable=too-many-statements
         """Interact with the tmux session.
 
         :param value: Send to screen

--- a/tests/integration/actions/doc/base.py
+++ b/tests/integration/actions/doc/base.py
@@ -51,7 +51,6 @@ class BaseClass:
     ):
         # pylint: disable=too-many-arguments
         # pylint: disable=too-many-locals
-        # pylint: disable=too-many-branches
         """Run the tests for ``doc``, mode and ``ee`` set in child class.
 
         :param request: A fixture providing details about the test caller

--- a/tests/integration/actions/run/base.py
+++ b/tests/integration/actions/run/base.py
@@ -66,7 +66,6 @@ class BaseClass:
             yield tmux_session
 
     def test(self, request, tmux_session, step):
-        # pylint: disable=too-many-branches
         """Run the tests for run, mode and ``ee`` set in child class.
 
         :param request: A fixture providing details about the test caller

--- a/tests/integration/actions/run_unicode/base.py
+++ b/tests/integration/actions/run_unicode/base.py
@@ -64,7 +64,6 @@ class BaseClass:
         tmux_session: TmuxSession,
         step: UiTestStep,
     ):
-        # pylint: disable=too-many-branches
         """Run the tests for run, mode and ``ee`` set in child class.
 
         :param request: The request for a test

--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -83,7 +83,6 @@ class BaseClass:
             yield tmux_session
 
     def test(self, request, tmux_session, step):
-        # pylint: disable=too-many-branches
         """Test interactive and ``stdout`` mode ``config``.
 
         :param request: A fixture providing details about the test caller

--- a/tests/unit/configuration_subsystem/test_precedence.py
+++ b/tests/unit/configuration_subsystem/test_precedence.py
@@ -169,7 +169,6 @@ def test_all_entries_reflect_cli_given_settings_and_env_vars(
     cli_entry: str,
     expected: Iterable[tuple[str, str]],
 ):
-    # pylint: disable=unused-argument
     # pylint:disable=too-many-locals
     """Ensure all entries are set by the CLI.
 

--- a/tests/unit/configuration_subsystem/test_sample_configurations.py
+++ b/tests/unit/configuration_subsystem/test_sample_configurations.py
@@ -136,7 +136,7 @@ def test_invalid_choice_not_set():
         ],
     )
     with pytest.raises(ValueError, match="Current source not set for e1"):
-        test_config.entry("e1").invalid_choice  # pylint: disable=expression-not-assigned
+        test_config.entry("e1").invalid_choice
 
 
 def test_custom_nargs_for_positional():

--- a/tests/unit/configuration_subsystem/test_settings_sources.py
+++ b/tests/unit/configuration_subsystem/test_settings_sources.py
@@ -76,7 +76,6 @@ def test_full(settings_env_var_to_full):
 
     :param settings_env_var_to_full: The pytest fixture to provide a full config
     """
-    # pylint: disable=unused-argument
     settings = deepcopy(NavigatorConfiguration)
     settings.internals.initializing = True
     _messages, _exit_messages = parse_and_update(params=[], args=settings)


### PR DESCRIPTION
This was done with a combination of:

https://gist.github.com/cidrblock/ec3412bacfeb34dbc2d334c1d53bef83

to generate the list and

```
for file in $(find tests -mindepth 1 -type f); do \
sed -i -E '/.*(attribute-defined-outside-init|import-outside-toplevel|no-else-return|not-an-iterable|too-many-ancestors|too-many-instance-attributes|too-many-arguments|too-many-lines|too-many-locals|too-many-nested-blocks|preferred-module|protected-access|unused-import|used-before-assignment).*/! s/(.*)# pylint: disable=.*/\1/g' $file; done
```
to remove pylint disable statements except for those we still needed.

Related: https://github.com/charliermarsh/ruff/issues/970

The commented out entries were because pylint was complainging they were invalid codes........hmpf
