### PR TITLE
Test sidecar filter plugin doc

### DIFF
--- a/tests/fixtures/common/collections/ansible_collections/company_name/coll_1/plugins/filter/coll_1.py
+++ b/tests/fixtures/common/collections/ansible_collections/company_name/coll_1/plugins/filter/coll_1.py
@@ -1,0 +1,20 @@
+"""An ansible test filter plugin."""
+
+
+def filter_1():
+    """Convert strings to Candlepin labels."""
+    return
+
+
+# ---- Ansible filters ----
+class FilterModule:
+    """Coll_1 filter."""
+
+    def filters(self):
+        """Convert an arbitrary string to a valid Candlepin label.
+
+        :returns: converted Candlepin label
+        """
+        return {
+            "filter_1": filter_1,
+        }

--- a/tests/fixtures/common/collections/ansible_collections/company_name/coll_1/plugins/filter/filter_1.yml
+++ b/tests/fixtures/common/collections/ansible_collections/company_name/coll_1/plugins/filter/filter_1.yml
@@ -1,0 +1,9 @@
+DOCUMENTATION:
+  name: filter_1
+  author: test
+  version_added: "1.0.0"
+  short_description: This is test filter plugin
+  description:
+    - This is test filter plugin
+  notes:
+    - This is a dummy filter plugin

--- a/tests/fixtures/integration/actions/doc/test_direct_interactive_ee.py/test/filter_doc_pass/0.json
+++ b/tests/fixtures/integration/actions/doc/test_direct_interactive_ee.py/test/filter_doc_pass/0.json
@@ -1,0 +1,26 @@
+{
+    "name": "test[0-ansible-navigator doc company_name.coll_1.filter_1 -t filter --execution-environment true-ansible-navigator doc filter plugin display-filter_doc_pass-expected_in_output0]",
+    "index": 0,
+    "comment": "ansible-navigator doc filter plugin display",
+    "output": [
+        "Name: company_name.coll_1.filter_1 (filter)",
+        " 0│---",
+        " 1│doc:",
+        " 2│  author: test",
+        " 3│  collection: company_name.coll_1",
+        " 4│  description:",
+        " 5│  - This is test filter plugin",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        " 7│  name: filter_1",
+        " 8│  notes:",
+        " 9│  - This is a dummy filter plugin",
+        "10│  short_description: This is test filter plugin",
+        "11│  version_added: 1.0.0",
+        "12│  version_added_collection: company_name.coll_1",
+        "13│examples: null",
+        "14│metadata: null",
+        "15│return: null",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "^b/PgUp page up                            ^f/PgDn page down                            ↑↓ scroll                            esc back                            :help help"
+    ]
+}

--- a/tests/fixtures/integration/actions/doc/test_direct_interactive_noee.py/test/filter_doc_pass/0.json
+++ b/tests/fixtures/integration/actions/doc/test_direct_interactive_noee.py/test/filter_doc_pass/0.json
@@ -1,0 +1,26 @@
+{
+    "name": "test[0-ansible-navigator doc company_name.coll_1.filter_1 -t filter --execution-environment false-ansible-navigator doc filter plugin display-filter_doc_pass-expected_in_output0]",
+    "index": 0,
+    "comment": "ansible-navigator doc filter plugin display",
+    "output": [
+        "Name: company_name.coll_1.filter_1 (filter)",
+        " 0│---",
+        " 1│doc:",
+        " 2│  author: test",
+        " 3│  collection: company_name.coll_1",
+        " 4│  description:",
+        " 5│  - This is test filter plugin",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        " 7│  name: filter_1",
+        " 8│  notes:",
+        " 9│  - This is a dummy filter plugin",
+        "10│  short_description: This is test filter plugin",
+        "11│  version_added: 1.0.0",
+        "12│  version_added_collection: company_name.coll_1",
+        "13│examples: null",
+        "14│metadata: null",
+        "15│return: null",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "^b/PgUp page up                            ^f/PgDn page down                            ↑↓ scroll                            esc back                            :help help"
+    ]
+}

--- a/tests/fixtures/integration/actions/doc/test_stdout.py/test/filter_doc_with_ee/0.json
+++ b/tests/fixtures/integration/actions/doc/test_stdout.py/test/filter_doc_with_ee/0.json
@@ -1,0 +1,30 @@
+{
+    "name": "test[0-ansible-navigator doc company_name.coll_1.filter_1 -t filter -m stdout -j --execution-environment true-ansible-navigator filter doc in stdout mode with EE-filter_doc_with_ee-None]",
+    "index": 0,
+    "comment": "ansible-navigator filter doc in stdout mode with EE",
+    "output": [
+        "{",
+        "    \"company_name.coll_1.filter_1\": {",
+        "        \"doc\": {",
+        "            \"author\": \"test\",",
+        "            \"collection\": \"company_name.coll_1\",",
+        "            \"description\": [",
+        "                \"This is test filter plugin\"",
+        "            ],",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "            \"name\": \"filter_1\",",
+        "            \"notes\": [",
+        "                \"This is a dummy filter plugin\"",
+        "            ],",
+        "            \"short_description\": \"This is test filter plugin\",",
+        "            \"version_added\": \"1.0.0\",",
+        "            \"version_added_collection\": \"company_name.coll_1\"",
+        "        },",
+        "        \"examples\": null,",
+        "        \"metadata\": null,",
+        "        \"return\": null",
+        "    }",
+        "}",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    ]
+}

--- a/tests/fixtures/integration/actions/doc/test_stdout.py/test/filter_doc_without_ee/0.json
+++ b/tests/fixtures/integration/actions/doc/test_stdout.py/test/filter_doc_without_ee/0.json
@@ -1,0 +1,30 @@
+{
+    "name": "test[0-ansible-navigator doc company_name.coll_1.filter_1 -t filter -m stdout -j --execution-environment false-ansible-navigator filter doc in stdout mode without EE-filter_doc_without_ee-None]",
+    "index": 0,
+    "comment": "ansible-navigator filter doc in stdout mode without EE",
+    "output": [
+        "{",
+        "    \"company_name.coll_1.filter_1\": {",
+        "        \"doc\": {",
+        "            \"author\": \"test\",",
+        "            \"collection\": \"company_name.coll_1\",",
+        "            \"description\": [",
+        "                \"This is test filter plugin\"",
+        "            ],",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "            \"name\": \"filter_1\",",
+        "            \"notes\": [",
+        "                \"This is a dummy filter plugin\"",
+        "            ],",
+        "            \"short_description\": \"This is test filter plugin\",",
+        "            \"version_added\": \"1.0.0\",",
+        "            \"version_added_collection\": \"company_name.coll_1\"",
+        "        },",
+        "        \"examples\": null,",
+        "        \"metadata\": null,",
+        "        \"return\": null",
+        "    }",
+        "}",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    ]
+}

--- a/tests/fixtures/integration/actions/doc/test_welcome_interactive_ee.py/test/filter_doc_pass/0.json
+++ b/tests/fixtures/integration/actions/doc/test_welcome_interactive_ee.py/test/filter_doc_pass/0.json
@@ -1,0 +1,29 @@
+{
+    "name": "test[0-ansible-navigator --execution-environment true-welcome-filter_doc_pass-expected_in_output0]",
+    "index": 0,
+    "comment": "welcome",
+    "output": [
+        " 0│Welcome",
+        " 1│————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————",
+        " 2│",
+        " 3│Some things you can try from here:",
+        " 4│- :collections                                    Explore available collections",
+        " 5│- :config                                         Explore the current ansible configuration",
+        " 6│- :doc <plugin>                                   Review documentation for a module or plugin",
+        " 7│- :help                                           Show the main help page",
+        " 8│- :images                                         Explore execution environment images",
+        " 9│- :inventory -i <inventory>                       Explore an inventory",
+        "10│- :log                                            Review the application log",
+        "11│- :lint <file or directory>                       Lint Ansible/YAML files (experimental)",
+        "12│- :open                                           Open current page in the editor",
+        "13│- :replay                                         Explore a previous run using a playbook artifact",
+        "14│- :run <playbook> -i <inventory>                  Run a playbook in interactive mode",
+        "15│- :settings                                       Review the current ansible-navigator settings",
+        "16│- :quit                                           Quit the application",
+        "17│",
+        "18│happy automating,",
+        "19│",
+        "20│-winston",
+        "^b/PgUp page up                            ^f/PgDn page down                            ↑↓ scroll                            esc back                            :help help"
+    ]
+}

--- a/tests/fixtures/integration/actions/doc/test_welcome_interactive_ee.py/test/filter_doc_pass/1.json
+++ b/tests/fixtures/integration/actions/doc/test_welcome_interactive_ee.py/test/filter_doc_pass/1.json
@@ -1,0 +1,26 @@
+{
+    "name": "test[1-:doc company_name.coll_1.filter_1 -t filter-load doc-filter_doc_pass-expected_in_output1]",
+    "index": 1,
+    "comment": "load doc",
+    "output": [
+        "Name: company_name.coll_1.filter_1 (filter)",
+        " 0│---",
+        " 1│doc:",
+        " 2│  author: test",
+        " 3│  collection: company_name.coll_1",
+        " 4│  description:",
+        " 5│  - This is test filter plugin",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        " 7│  name: filter_1",
+        " 8│  notes:",
+        " 9│  - This is a dummy filter plugin",
+        "10│  short_description: This is test filter plugin",
+        "11│  version_added: 1.0.0",
+        "12│  version_added_collection: company_name.coll_1",
+        "13│examples: null",
+        "14│metadata: null",
+        "15│return: null",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "^b/PgUp page up                            ^f/PgDn page down                            ↑↓ scroll                            esc back                            :help help"
+    ]
+}

--- a/tests/fixtures/integration/actions/doc/test_welcome_interactive_noee.py/test/filter_doc_pass/0.json
+++ b/tests/fixtures/integration/actions/doc/test_welcome_interactive_noee.py/test/filter_doc_pass/0.json
@@ -1,0 +1,29 @@
+{
+    "name": "test[0-ansible-navigator  --execution-environment false-welcome-filter_doc_pass-expected_in_output0]",
+    "index": 0,
+    "comment": "welcome",
+    "output": [
+        " 0│Welcome",
+        " 1│————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————",
+        " 2│",
+        " 3│Some things you can try from here:",
+        " 4│- :collections                                    Explore available collections",
+        " 5│- :config                                         Explore the current ansible configuration",
+        " 6│- :doc <plugin>                                   Review documentation for a module or plugin",
+        " 7│- :help                                           Show the main help page",
+        " 8│- :images                                         Explore execution environment images",
+        " 9│- :inventory -i <inventory>                       Explore an inventory",
+        "10│- :log                                            Review the application log",
+        "11│- :lint <file or directory>                       Lint Ansible/YAML files (experimental)",
+        "12│- :open                                           Open current page in the editor",
+        "13│- :replay                                         Explore a previous run using a playbook artifact",
+        "14│- :run <playbook> -i <inventory>                  Run a playbook in interactive mode",
+        "15│- :settings                                       Review the current ansible-navigator settings",
+        "16│- :quit                                           Quit the application",
+        "17│",
+        "18│happy automating,",
+        "19│",
+        "20│-winston",
+        "^b/PgUp page up                            ^f/PgDn page down                            ↑↓ scroll                            esc back                            :help help"
+    ]
+}

--- a/tests/fixtures/integration/actions/doc/test_welcome_interactive_noee.py/test/filter_doc_pass/1.json
+++ b/tests/fixtures/integration/actions/doc/test_welcome_interactive_noee.py/test/filter_doc_pass/1.json
@@ -1,0 +1,26 @@
+{
+    "name": "test[1-:doc company_name.coll_1.filter_1 -t filter-load doc-filter_doc_pass-expected_in_output1]",
+    "index": 1,
+    "comment": "load doc",
+    "output": [
+        "Name: company_name.coll_1.filter_1 (filter)",
+        " 0│---",
+        " 1│doc:",
+        " 2│  author: test",
+        " 3│  collection: company_name.coll_1",
+        " 4│  description:",
+        " 5│  - This is test filter plugin",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        " 7│  name: filter_1",
+        " 8│  notes:",
+        " 9│  - This is a dummy filter plugin",
+        "10│  short_description: This is test filter plugin",
+        "11│  version_added: 1.0.0",
+        "12│  version_added_collection: company_name.coll_1",
+        "13│examples: null",
+        "14│metadata: null",
+        "15│return: null",
+        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "^b/PgUp page up                            ^f/PgDn page down                            ↑↓ scroll                            esc back                            :help help"
+    ]
+}

--- a/tests/integration/actions/doc/test_direct_interactive_ee.py
+++ b/tests/integration/actions/doc/test_direct_interactive_ee.py
@@ -23,6 +23,15 @@ testdata_lookup_doc: list = [
     (0, CLI_LOOKUP_DOC, "ansible-navigator doc lookup plugin display", "lookup_doc_pass", []),
 ]
 
+# filter plugin doc
+CLI_FILTER_DOC = (
+    "ansible-navigator doc company_name.coll_1.filter_1 -t filter --execution-environment true"
+)
+
+testdata_filter_doc: list = [
+    (0, CLI_FILTER_DOC, "ansible-navigator doc filter plugin display", "filter_doc_pass", []),
+]
+
 # plugin does not exist
 CLI_WRONG_MODULE_NOT_EXIST = (
     "ansible-navigator doc company_name.coll_1.doesnotexist --execution-environment true"
@@ -62,6 +71,17 @@ class TestModuleDoc(BaseClass):
     testdata_lookup_doc,
 )
 class TestLookUpDoc(BaseClass):
+    """Run the tests."""
+
+    TEST_FOR_MODE = "interactive"
+    UPDATE_FIXTURES = False
+
+
+@pytest.mark.parametrize(
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_filter_doc,
+)
+class TestFilterDoc(BaseClass):
     """Run the tests."""
 
     TEST_FOR_MODE = "interactive"

--- a/tests/integration/actions/doc/test_direct_interactive_noee.py
+++ b/tests/integration/actions/doc/test_direct_interactive_noee.py
@@ -22,6 +22,14 @@ testdata_lookup_doc: list = [
     (0, CLI_LOOKUP_DOC, "ansible-navigator doc lookup plugin display", "lookup_doc_pass", []),
 ]
 
+# filter plugin doc
+CLI_FILTER_DOC = (
+    "ansible-navigator doc company_name.coll_1.filter_1 -t filter --execution-environment false"
+)
+testdata_filter_doc: list = [
+    (0, CLI_FILTER_DOC, "ansible-navigator doc filter plugin display", "filter_doc_pass", []),
+]
+
 # plugin does not exist
 CLI_WRONG_MODULE_NOT_EXIST = (
     "ansible-navigator doc company_name.coll_1.doesnotexist --execution-environment false"
@@ -53,6 +61,17 @@ class TestModuleDoc(BaseClass):
     testdata_lookup_doc,
 )
 class TestLookUpDoc(BaseClass):
+    """Run the tests."""
+
+    TEST_FOR_MODE = "interactive"
+    UPDATE_FIXTURES = False
+
+
+@pytest.mark.parametrize(
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_filter_doc,
+)
+class TestFilterDoc(BaseClass):
     """Run the tests."""
 
     TEST_FOR_MODE = "interactive"

--- a/tests/integration/actions/doc/test_stdout.py
+++ b/tests/integration/actions/doc/test_stdout.py
@@ -198,3 +198,53 @@ class TestLookUpDocWithEE(BaseClass):
 
     TEST_FOR_MODE = "stdout"
     UPDATE_FIXTURES = False
+
+
+# doc command run in stdout mode without EE
+CLI_FILTER_DOC_WITHOUT_EE = (
+    "ansible-navigator doc company_name.coll_1.filter_1 -t filter -m stdout -j"
+    " --execution-environment false"
+)
+
+testdata_9: list = [
+    (
+        0,
+        CLI_FILTER_DOC_WITHOUT_EE,
+        "ansible-navigator filter doc in stdout mode without EE",
+        "filter_doc_without_ee",
+        None,
+    ),
+]
+
+
+@pytest.mark.parametrize("index, user_input, comment, testname, expected_in_output", testdata_9)
+class TestFilterDocWithoutEE(BaseClass):
+    """Run the tests for doc from CLI, stdout, without an EE, filter doc."""
+
+    TEST_FOR_MODE = "stdout"
+    UPDATE_FIXTURES = False
+
+
+# doc command run in stdout mode with EE
+CLI_FILTER_DOC_WITH_EE = (
+    "ansible-navigator doc company_name.coll_1.filter_1 -t filter -m stdout -j"
+    " --execution-environment true"
+)
+
+testdata_10: list = [
+    (
+        0,
+        CLI_FILTER_DOC_WITH_EE,
+        "ansible-navigator filter doc in stdout mode with EE",
+        "filter_doc_with_ee",
+        None,
+    ),
+]
+
+
+@pytest.mark.parametrize("index, user_input, comment, testname, expected_in_output", testdata_10)
+class TestFilterDocWithEE(BaseClass):
+    """Run the tests for doc from CLI, stdout, with an EE, filter doc."""
+
+    TEST_FOR_MODE = "stdout"
+    UPDATE_FIXTURES = False

--- a/tests/integration/actions/doc/test_welcome_interactive_ee.py
+++ b/tests/integration/actions/doc/test_welcome_interactive_ee.py
@@ -23,6 +23,14 @@ testdata_lookup_doc: list = [
     (1, ":doc company_name.coll_1.lookup_1 -t lookup", "load doc", "lookup_doc_pass", []),
 ]
 
+# filter plugin doc
+CLI_FILTER_DOC = "ansible-navigator --execution-environment true"
+
+testdata_filter_doc: list = [
+    (0, CLI_FILTER_DOC, "welcome", "filter_doc_pass", []),
+    (1, ":doc company_name.coll_1.filter_1 -t filter", "load doc", "filter_doc_pass", []),
+]
+
 # plugin does not exist
 CLI_WRONG_MODULE_NOT_EXIST = "ansible-navigator --execution-environment true"
 
@@ -62,6 +70,17 @@ class TestModuleDoc(BaseClass):
 )
 class TestLookUpDoc(BaseClass):
     """Run the tests for doc from welcome, interactive, with an EE, lookup doc."""
+
+    TEST_FOR_MODE = "interactive"
+    UPDATE_FIXTURES = False
+
+
+@pytest.mark.parametrize(
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_filter_doc,
+)
+class TestFilterDoc(BaseClass):
+    """Run the tests for doc from welcome, interactive, with an EE, filter doc."""
 
     TEST_FOR_MODE = "interactive"
     UPDATE_FIXTURES = False

--- a/tests/integration/actions/doc/test_welcome_interactive_noee.py
+++ b/tests/integration/actions/doc/test_welcome_interactive_noee.py
@@ -23,6 +23,14 @@ testdata_lookup_doc: list = [
     (1, ":doc company_name.coll_1.lookup_1 -t lookup", "load doc", "lookup_doc_pass", []),
 ]
 
+# filter plugin doc
+CLI_FILTER_DOC = "ansible-navigator  --execution-environment false"
+
+testdata_filter_doc: list = [
+    (0, CLI_FILTER_DOC, "welcome", "filter_doc_pass", []),
+    (1, ":doc company_name.coll_1.filter_1 -t filter", "load doc", "filter_doc_pass", []),
+]
+
 # plugin does not exist
 CLI_WRONG_MODULE_NOT_EXIST = "ansible-navigator --execution-environment false"
 
@@ -55,6 +63,17 @@ class TestModuleDoc(BaseClass):
 )
 class TestLookUpDoc(BaseClass):
     """Run the tests for doc from welcome, interactive, without an EE, lookup doc."""
+
+    TEST_FOR_MODE = "interactive"
+    UPDATE_FIXTURES = False
+
+
+@pytest.mark.parametrize(
+    "index, user_input, comment, testname, expected_in_output",
+    testdata_filter_doc,
+)
+class TestFilterDoc(BaseClass):
+    """Run the tests for doc from welcome, interactive, without an EE, filter doc."""
 
     TEST_FOR_MODE = "interactive"
     UPDATE_FIXTURES = False


### PR DESCRIPTION
As the support for `filter` plugins are added with [PR](https://github.com/ansible/ansible-navigator/pull/1515).
Adding the tests and fixtures for sidecar filter plugin doc feature.

Closes: https://github.com/ansible/ansible-navigator/issues/617