### PR TITLE
Isolate navigator from ansible-runner internal warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,11 @@ enable = [
 
 [tool.pytest.ini_options]
 addopts = "-n=auto --dist=loadfile --maxfail=10 --durations=30 --showlocals"
+filterwarnings = [
+  "error",
+  # https://github.com/ansible/ansible-runner/issues/1246
+  "ignore::ResourceWarning:ansible_runner",
+]
 
 [tool.ruff]
 fix = true

--- a/src/ansible_navigator/runner/ansible_config.py
+++ b/src/ansible_navigator/runner/ansible_config.py
@@ -1,7 +1,14 @@
 """Herein lies the ability for ansible-runner to run the ansible-config command."""
 from __future__ import annotations
 
-from ansible_runner import get_ansible_config
+import warnings
+
+
+# Remove this catch-all once newer ansible-runner is released
+# https://github.com/ansible/ansible-runner/issues/1223
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from ansible_runner import get_ansible_config
 
 from .base import Base
 

--- a/tests/integration/test_stdout_exit_codes.py
+++ b/tests/integration/test_stdout_exit_codes.py
@@ -47,7 +47,7 @@ def id_ee(value: bool):
     :param value: The value of the parameter
     :returns: The test id
     """
-    return f"execution_environment={value}"
+    return "-ee" if value else "-no_ee"
 
 
 def id_test_data(value: StdoutTest):
@@ -56,7 +56,7 @@ def id_test_data(value: StdoutTest):
     :param value: The value of the parameter
     :returns: The test id
     """
-    return f"action={value.action_name} return={value.return_code}"
+    return f"{value.action_name}-r{value.return_code}"
 
 
 class StdoutTest(NamedTuple):
@@ -129,7 +129,7 @@ fixture_test_data = (
 
 @pytest.mark.parametrize("params", (True, False), indirect=["params"], ids=id_ee)
 @pytest.mark.parametrize("test_data", fixture_test_data, ids=id_test_data)
-def test(
+def test_stdout(
     action_run_stdout: type[ActionRunTest],
     params: dict[str, Any],
     test_data: StdoutTest,


### PR DESCRIPTION
Related: https://github.com/ansible/ansible-runner/issues/1223
