### PR TITLE
Set user to root with podman

### DIFF
--- a/src/ansible_navigator/runner/base.py
+++ b/src/ansible_navigator/runner/base.py
@@ -86,6 +86,14 @@ class Base:
         self.finished: bool = False
         self.status: str | None = None
         self._runner_args: dict = {}
+
+        # when the ce is podman, set the container user to root
+        if self._ce == "podman":
+            if container_options:
+                container_options.append("--user=root")
+            else:
+                container_options = ["--user=root"]
+
         if self._ee:
             self._runner_args.update(
                 {
@@ -119,7 +127,11 @@ class Base:
 
         if self._navigator_mode == "stdout":
             self._runner_args.update(
-                {"input_fd": sys.stdin, "output_fd": sys.stdout, "error_fd": sys.stderr},
+                {
+                    "input_fd": sys.stdin,
+                    "output_fd": sys.stdout,
+                    "error_fd": sys.stderr,
+                },
             )
 
     def __del__(self):


### PR DESCRIPTION
Related: https://github.com/ansible/ansible-builder/issues/541
Related: https://github.com/ansible/ansible-navigator/issues/1448

Due to changes with the container build introduced with builder version 3, we will now run as user=root in a podman container.

See the builder issue above for details