### PR TITLE
suggested cleanups for vault password faq entry

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -276,21 +276,6 @@ $  export ANSIBLE_VAULT_PASSWORD=my_password
 $ ANSIBLE_VAULT_PASSWORD_FILE=.vault_password.sh ansible-navigator run site.yml
 ```
 
-#### Store the vault password securely on the local file system
-
-```bash
-$ touch ~/.vault_password
-$ chmod 600 ~/.vault_password
-# The leading space here is necessary to keep the command out of the command history
-$  echo my_password >> ~/.vault_password
-# Link the password file into the current working directory
-$ ln ~/.vault_password .
-# Set the environment variable to the location of the file
-$ export ANSIBLE_VAULT_PASSWORD_FILE=.vault_password
-# Pass the variable into the execution-environment
-$ ansible-navigator run --pass-environment-variable ANSIBLE_VAULT_PASSWORD_FILE site.yml
-```
-
 ## Other
 
 ### How can complex commands be run inside an execution-environment?

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -284,9 +284,8 @@ $ ln ~/.vault_password.sh .
 # into the execution environment
 $ HISTCONTROL=ignorespace
 $  export ANSIBLE_VAULT_PASSWORD=my_password
-# Set the environment variable to the location of the file
-$ ANSIBLE_VAULT_PASSWORD_FILE=.vault_password.sh
-$ ansible-navigator run site.yml
+# Set the environment variable to the location of the file when executing ansible-navigator
+$ ANSIBLE_VAULT_PASSWORD_FILE=.vault_password.sh ansible-navigator run site.yml
 ```
 
 Additional information about `ansible-vault` can be found

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -247,7 +247,7 @@ the text-based user interface (TUI). **Please ensure these do not conflict with
 your enterprise security standards. Do not add password files to source
 control.**
 
-1. Store the vault password securely on the local file system
+#### Store the vault password securely on the local file system
 
 ```bash
 $ touch ~/.vault_password
@@ -262,7 +262,7 @@ $ export ANSIBLE_VAULT_PASSWORD_FILE=.vault_password
 $ ansible-navigator run --pass-environment-variable ANSIBLE_VAULT_PASSWORD_FILE site.yml
 ```
 
-2. Store the vault password in an environment variable
+#### Store the vault password in an environment variable
 
 Chances are that your environment prohibits saving passwords in cleartext on disk.
 If you are subject to such a rule, then this will obviously include any command history

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -264,6 +264,15 @@ $ ansible-navigator run --pass-environment-variable ANSIBLE_VAULT_PASSWORD_FILE 
 
 2. Store the vault password in an environment variable
 
+Chances are that your environment prohibits saving passwords in cleartext on disk.
+If you are subject to such a rule, then this will obviously include any command history
+file your shell saves to disk.
+
+In case you use bash, you can leverage
+[HISTCONTROL](https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html#index-HISTCONTROL)
+and an [environment](https://www.gnu.org/software/bash/manual/html_node/Environment.html) variable
+as shown in the following example.
+
 ```bash
 $ touch ~/.vault_password.sh
 $ chmod 700 ~/.vault_password.sh

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -247,12 +247,24 @@ the text-based user interface (TUI). **Please ensure these do not conflict with
 your enterprise security standards. Do not add password files to source
 control.**
 
-Additional information about `ansible-vault` can be found
-[here](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
+1. Store the vault password securely on the local file system
 
-#### Store the vault password in an environment variable
+```bash
+$ touch ~/.vault_password
+$ chmod 600 ~/.vault_password
+# The leading space here is necessary to keep the command out of the command history
+$  echo my_password >> ~/.vault_password
+# Link the password file into the current working directory
+$ ln ~/.vault_password .
+# Set the environment variable to the location of the file
+$ export ANSIBLE_VAULT_PASSWORD_FILE=.vault_password
+# Pass the variable into the execution-environment
+$ ansible-navigator run --pass-environment-variable ANSIBLE_VAULT_PASSWORD_FILE site.yml
+```
 
-Chances are that your environment prohibits saving passwords in cleartext on
+2. Store the vault password in an environment variable
+
+Chances are that your environment prohibits saving passwords in clear text on
 disk. If you are subject to such a rule, then this will obviously include any
 command history file your shell saves to disk.
 
@@ -276,6 +288,9 @@ $  export ANSIBLE_VAULT_PASSWORD=my_password
 # Set the environment variable to the location of the file when executing ansible-navigator
 $ ANSIBLE_VAULT_PASSWORD_FILE=.vault_password.sh ansible-navigator run site.yml
 ```
+
+Additional information about `ansible-vault` can be found
+[here](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
 
 ## Other
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -250,21 +250,6 @@ control.**
 Additional information about `ansible-vault` can be found
 [here](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
 
-#### Store the vault password securely on the local file system
-
-```bash
-$ touch ~/.vault_password
-$ chmod 600 ~/.vault_password
-# The leading space here is necessary to keep the command out of the command history
-$  echo my_password >> ~/.vault_password
-# Link the password file into the current working directory
-$ ln ~/.vault_password .
-# Set the environment variable to the location of the file
-$ export ANSIBLE_VAULT_PASSWORD_FILE=.vault_password
-# Pass the variable into the execution-environment
-$ ansible-navigator run --pass-environment-variable ANSIBLE_VAULT_PASSWORD_FILE site.yml
-```
-
 #### Store the vault password in an environment variable
 
 Chances are that your environment prohibits saving passwords in cleartext on disk.
@@ -289,6 +274,21 @@ $ HISTCONTROL=ignorespace
 $  export ANSIBLE_VAULT_PASSWORD=my_password
 # Set the environment variable to the location of the file when executing ansible-navigator
 $ ANSIBLE_VAULT_PASSWORD_FILE=.vault_password.sh ansible-navigator run site.yml
+```
+
+#### Store the vault password securely on the local file system
+
+```bash
+$ touch ~/.vault_password
+$ chmod 600 ~/.vault_password
+# The leading space here is necessary to keep the command out of the command history
+$  echo my_password >> ~/.vault_password
+# Link the password file into the current working directory
+$ ln ~/.vault_password .
+# Set the environment variable to the location of the file
+$ export ANSIBLE_VAULT_PASSWORD_FILE=.vault_password
+# Pass the variable into the execution-environment
+$ ansible-navigator run --pass-environment-variable ANSIBLE_VAULT_PASSWORD_FILE site.yml
 ```
 
 ## Other

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -247,6 +247,9 @@ the text-based user interface (TUI). **Please ensure these do not conflict with
 your enterprise security standards. Do not add password files to source
 control.**
 
+Additional information about `ansible-vault` can be found
+[here](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
+
 #### Store the vault password securely on the local file system
 
 ```bash
@@ -287,9 +290,6 @@ $  export ANSIBLE_VAULT_PASSWORD=my_password
 # Set the environment variable to the location of the file when executing ansible-navigator
 $ ANSIBLE_VAULT_PASSWORD_FILE=.vault_password.sh ansible-navigator run site.yml
 ```
-
-Additional information about `ansible-vault` can be found
-[here](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
 
 ## Other
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -252,14 +252,15 @@ Additional information about `ansible-vault` can be found
 
 #### Store the vault password in an environment variable
 
-Chances are that your environment prohibits saving passwords in cleartext on disk.
-If you are subject to such a rule, then this will obviously include any command history
-file your shell saves to disk.
+Chances are that your environment prohibits saving passwords in cleartext on
+disk. If you are subject to such a rule, then this will obviously include any
+command history file your shell saves to disk.
 
 In case you use bash, you can leverage
 [HISTCONTROL](https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html#index-HISTCONTROL)
-and an [environment](https://www.gnu.org/software/bash/manual/html_node/Environment.html) variable
-as shown in the following example.
+and an
+[environment](https://www.gnu.org/software/bash/manual/html_node/Environment.html)
+variable as shown in the following example.
 
 ```bash
 $ touch ~/.vault_password.sh


### PR DESCRIPTION
This is a suggestion of changes I would like to please see in the FAQ section _How can I use a vault password with ansible-navigator_.

relates to #1571 

* When I filed #1559 I was so focused on users not saving a vault password on disk that I overlooked the fact that the last two lines in that example need to be one line for it to function. 3ac92985a447b69169ffdc3f227983518f8dc40c addresses that
* at https://ansible.readthedocs.io/projects/navigator/faq/#how-can-i-use-a-vault-password-with-ansible-navigator the two options end up both being rendered as "1. …". 7b9b62799e528664b126939e1ef698ac70b3b2ad should address that.
* It could be useful to explain the env var option in a bit more depth, 1b4c64f98b8d27199280fda6cf262149510f5960 attempts to address that.
* When giving users 2 options, one of them being more secure, then I prefer the more secure option to be shown first. 80838c9a3a39b0ba9a927d9d79b9e1db5a445d22 addresses that.
* Ideally users are not given an example to copy and paste that saves a password in cleartext on disk. So with 361a51cddae7d0fa1152b48167faad2ed4ea868a that example gets removed. Drop that commit if you feel this is too opinionated.