### PR TITLE
Fix image introspect for PythonPackages

### DIFF
--- a/src/ansible_navigator/data/image_introspect.py
+++ b/src/ansible_navigator/data/image_introspect.py
@@ -283,7 +283,7 @@ class PythonPackages(CmdParser):
         pre = Command(id_="pip_freeze", command="python3 -m pip freeze", parse=self.parse_freeze)
         run_command(pre)
         pre.parse(pre)
-        pkgs = " ".join(pkg for pkg in pre.details[0])
+        pkgs = " ".join(pkg for pkg in pre.details[0]) if pre.details else ""
         return [
             Command(id_="python_packages", command=f"python3 -m pip show {pkgs}", parse=self.parse),
         ]


### PR DESCRIPTION
Related: #1582 #1580

This fixes some of the `:images` related issues with the given EE image: 

```
---
version: 3

images:
  base_image:
    name: quay.io/fedora/python-311:latest

dependencies:
  ansible_core:
    package_pip: ansible-core
  ansible_runner:
    package_pip: ansible-runner
  galaxy:
    collections:
      - community.general
  python:
    - ansible-lint
```    

- Fixes the `list index out of range` error, when there is no entry inside PythonPackages.
- And hence one will be able to browse the other(1-5) entries inside images command like "General Information", "System Packages" etc, even if there is no entry inside "Python Packages".