### PR TITLE
Change the python_exec path to /usr/bin/python3

### DIFF
--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -438,7 +438,7 @@ class Action(ActionBase):
 
         if self._args.execution_environment:
             self._logger.debug("running collections command with execution environment enabled")
-            python_exec_path = "python3"
+            python_exec_path = "/usr/bin/python3"
             utils_lib = os.path.join(
                 os.path.dirname(__file__),
                 "..",

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -551,7 +551,7 @@ class Action(ActionBase):
         """
         cache_path = self._args.internals.cache_path
         container_volume_mounts = [f"{cache_path}:{cache_path}"]
-        python_exec_path = "python3"
+        python_exec_path = "/usr/bin/python3"
 
         kwargs = {
             "cmdline": [f"{cache_path}/image_introspect.py"],

--- a/src/ansible_navigator/data/image_introspect.py
+++ b/src/ansible_navigator/data/image_introspect.py
@@ -280,12 +280,18 @@ class PythonPackages(CmdParser):
 
         :returns: The defined command
         """
-        pre = Command(id_="pip_freeze", command="python3 -m pip freeze", parse=self.parse_freeze)
+        pre = Command(
+            id_="pip_freeze", command="/usr/bin/python3 -m pip freeze", parse=self.parse_freeze
+        )
         run_command(pre)
         pre.parse(pre)
         pkgs = " ".join(pkg for pkg in pre.details[0]) if pre.details else ""
         return [
-            Command(id_="python_packages", command=f"python3 -m pip show {pkgs}", parse=self.parse),
+            Command(
+                id_="python_packages",
+                command=f"/usr/bin/python3 -m pip show {pkgs}",
+                parse=self.parse,
+            ),
         ]
 
     def parse(self, command):


### PR DESCRIPTION
Change the python_exec_path to `/usr/bin/python3`, so that python interpreter can find the site packages.

Fixes: https://github.com/ansible/ansible-navigator/issues/1582 and https://github.com/ansible/ansible-navigator/issues/1580
Related: https://github.com/ansible/ansible-builder/issues/589