### PR TITLE
Contributing guidelines: improve

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -80,8 +80,8 @@ along with its additional dependencies required for testing.
 pip install -e .\[test]
 ```
 
-In case of any errors, try to run `pip install --upgrade pip`.
-Then run the above command again.
+In case of any errors, try to run `pip install --upgrade pip`. Then run the
+above command again.
 
 [virtual environment]: https://docs.python.org/3/library/venv.html
 
@@ -228,4 +228,4 @@ It is also integrated with [Read The Docs](https://readthedocs.org/) that builds
 and publishes each commit to the main branch and generates live docs previews
 for each pull request.
 
-[docs source]:https://github.com/ansible/ansible-navigator/tree/main/docs
+[docs source]: https://github.com/ansible/ansible-navigator/tree/main/docs

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -80,6 +80,9 @@ along with its additional dependencies required for testing.
 pip install -e .\[test]
 ```
 
+In case of any errors, try to run `pip install --upgrade pip`.
+Then run the above command again.
+
 [virtual environment]: https://docs.python.org/3/library/venv.html
 
 ### Testing process and examples
@@ -208,6 +211,9 @@ modify accordingly if needed.
 
 ## Contributing docs
 
+The documentation source code is located under the [docs][docs source] directory
+in the repository's root.
+
 We use [mkdocs](https://www.mkdocs.org/) to generate our docs website. You can
 trigger the process locally by executing:
 
@@ -221,3 +227,5 @@ $ tox -e docs
 It is also integrated with [Read The Docs](https://readthedocs.org/) that builds
 and publishes each commit to the main branch and generates live docs previews
 for each pull request.
+
+[docs source]:https://github.com/ansible/ansible-navigator/tree/main/docs

--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ A demo of the interface can be found [on YouTube][YT demo].
 
 [//]: # (DO-NOT-REMOVE-docs-intro-END)
 
+## Contributing
+
+Any kind of contribution to this project is very welcome and appreciated,
+whether it is a documentation improvement, [bug report][issue],
+[pull request][pull request] review, or a patch.
+
+See the [Contributing guidelines][contributing guidelines] for details.
+
+[issue]:https://github.com/ansible/ansible-navigator/issues
+[pull request]:https://github.com/ansible/ansible-navigator/pulls
+[contributing guidelines]:
+https://ansible.readthedocs.io/projects/navigator/contributing/guidelines/
+
 ## Quick start
 
 ### Installing


### PR DESCRIPTION
- Add the Contributing section to README
- Add a hint where docs source code is located
- CONTRIBUTING.md: add a hint

This solves an error I got when trying to run `pip install -e .\[test]`:
```
ERROR: File "setup.py" not found. Directory cannot be installed in editable mode: /home/aklychko/ansible-navigator
(A "pyproject.toml" file was found, but editable mode currently requires a setup.py based build.)
```
