### PR TITLE
Improve test execution on macos (tmux)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,9 @@ enable = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-n=auto --dist=loadfile --maxfail=10 --durations=30 --showlocals"
+# do not add xdist options here as this will make running of a single test and
+# debugging hard.
+addopts = "--maxfail=10 --durations=30 --showlocals"
 filterwarnings = [
   "error",
   # https://github.com/ansible/ansible-runner/issues/1246

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands =
   # most coverage options are kept in pyproject.toml
   # pytest params are kept in pyproject.toml
   # if one wants to control parallelism define PYTEST_XDIST_AUTO_NUM_WORKERS
-  coverage run -m pytest {posargs}
+  coverage run -m pytest {posargs:-n=auto --dist=loadfile}
   sh -c "coverage combine -q .tox/.coverage.* && coverage xml || true && coverage report"
 setenv =
   COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}


### PR DESCRIPTION
This change address a problem seen on MacOS where sequences of sendkeys() happens too quickly and causing failures.

On GHA we were not able to spot this issue, but on newer M1+ machines this seems to be a major source of test failures.