### PR TITLE
pytest: remove flaky reruns

### DIFF
--- a/tests/integration/actions/images/test_direct_interactive_noee.py
+++ b/tests/integration/actions/images/test_direct_interactive_noee.py
@@ -26,7 +26,6 @@ initial_steps = (
 steps = add_indices(initial_steps + base_steps)
 
 
-@pytest.mark.flaky(reruns=4)
 @pytest.mark.parametrize("step", steps, ids=step_id_padded)
 class Test(BaseClass):
     """Run the tests for images from CLI, interactive, without an EE."""

--- a/tests/integration/actions/lint/base.py
+++ b/tests/integration/actions/lint/base.py
@@ -45,7 +45,6 @@ class BaseClass:
         with TmuxSession(**params) as tmux_session:
             yield tmux_session
 
-    @pytest.mark.flaky(reruns=2)
     def test(
         self, request: pytest.FixtureRequest, tmux_session: TmuxSession, step: UiTestStep
     ) -> None:

--- a/tests/integration/actions/run_unicode/base.py
+++ b/tests/integration/actions/run_unicode/base.py
@@ -61,7 +61,6 @@ class BaseClass:
         with TmuxSession(**params) as tmux_session:
             yield tmux_session
 
-    @pytest.mark.flaky(reruns=2)
     def test(
         self,
         request: pytest.FixtureRequest,

--- a/tests/unit/logger/test_time_zone.py
+++ b/tests/unit/logger/test_time_zone.py
@@ -68,7 +68,6 @@ test_data = (
 )
 
 
-@pytest.mark.flaky(reruns=2)
 @pytest.mark.parametrize("data", test_data)
 def test_tz_support(
     data: Scenario,


### PR DESCRIPTION
Reason: not really effective, especially for the UI multi-step tests.