### PR TITLE
Address ruff `ANN`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,21 +260,14 @@ exclude = ["tests/fixtures/**", ".git"]
 
 [tool.ruff.lint]
 ignore = [
+  'ANN101', # This rule is deprecated and will be removed in a future release.
+  'ANN102', # This rule is deprecated and will be removed in a future release.
   'ERA001', # [*] Found commented-out code
   'INP001', # File `docs/_ext/regenerate_docs.py` is part of an implicit namespace package. Add an `__init__.py`.
   'PLW2901', # `for` loop variable `info_name` overwritten by assignment target
   "RET504", # Unnecessary variable assignment before `return` statement
   # temporary disabled until we fix them:
-  'ANN001', # Missing type annotation for function argument `output`
-  'ANN002', # Missing type annotation for `*args`
-  'ANN003', # Missing type annotation for `**kwargs`
-  'ANN101', # Missing type annotation for `self` in method
-  'ANN102', # Missing type annotation for `cls` in classmethod
-  'ANN201', # Missing return type annotation for public function `notify_none`
-  'ANN202', # Missing return type annotation for private function `_build_main_menu`
   'ANN204', # [*] Missing return type annotation for special method `__init__`
-  'ANN205', # Missing return type annotation for staticmethod `run_single_process`
-  'ANN206', # Missing return type annotation for classmethod `_missing_`
   'ANN401', # Dynamically typed expressions (typing.Any) are disallowed in `cls`
   'ARG001', # Unused function argument: `colno`
   'ARG002', # Unused method argument: `app`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,7 +267,6 @@ ignore = [
   'PLW2901', # `for` loop variable `info_name` overwritten by assignment target
   "RET504", # Unnecessary variable assignment before `return` statement
   # temporary disabled until we fix them:
-  'ANN204', # [*] Missing return type annotation for special method `__init__`
   'ANN401', # Dynamically typed expressions (typing.Any) are disallowed in `cls`
   'ARG001', # Unused function argument: `colno`
   'ARG002', # Unused method argument: `app`

--- a/src/ansible_navigator/action_base.py
+++ b/src/ansible_navigator/action_base.py
@@ -28,7 +28,9 @@ class ActionBase:
     # pylint: disable=too-many-instance-attributes
     """Base class for actions."""
 
-    def __init__(self, args: ApplicationConfiguration, name: str, logger_name: str = __name__):
+    def __init__(
+        self, args: ApplicationConfiguration, name: str, logger_name: str = __name__
+    ) -> None:
         """Initialize the App class.
 
         :param args: The current application configuration

--- a/src/ansible_navigator/actions/back.py
+++ b/src/ansible_navigator/actions/back.py
@@ -19,7 +19,7 @@ class Action:
 
     KEGEX = r"^\^\[|\x1b|back$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:back`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/builder.py
+++ b/src/ansible_navigator/actions/builder.py
@@ -24,7 +24,7 @@ class Action(ActionBase):
 
     KEGEX = "^b(?:uilder)?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the action.
 
         :param args: The current application configuration

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -90,7 +90,7 @@ class Action(ActionBase):
 
     KEGEX = r"^collections(\s(?P<params>.*))?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``collections`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -84,7 +84,7 @@ class Action(ActionBase):
 
     KEGEX = r"^config(\s(?P<params>.*))?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:config`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -31,7 +31,7 @@ class Action(ActionBase):
 
     KEGEX = r"^d(?:oc)?(\s(?P<params>.*))?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``doc`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/exec.py
+++ b/src/ansible_navigator/actions/exec.py
@@ -74,7 +74,7 @@ class Action(ActionBase):
 
     KEGEX = "^e(?:xec)?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:exec`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/filter.py
+++ b/src/ansible_navigator/actions/filter.py
@@ -15,7 +15,7 @@ class Action:
 
     KEGEX = r"^f(ilter)?(\s(?P<regex>.*))?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:filter`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/help_doc.py
+++ b/src/ansible_navigator/actions/help_doc.py
@@ -16,7 +16,7 @@ class Action(ActionBase):
 
     KEGEX = r"^h(?:elp)?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:help`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -55,7 +55,7 @@ class Action(ActionBase):
 
     KEGEX = r"^im(?:ages)?(\s(?P<params>.*))?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:images`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -106,7 +106,7 @@ class Action(ActionBase):
 
     KEGEX = r"^i(?:nventory)?(\s(?P<params>.*))?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:images`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/lint.py
+++ b/src/ansible_navigator/actions/lint.py
@@ -179,7 +179,7 @@ class Action(ActionBase):
 
     KEGEX = r"^lint(\s(?P<params>.*))?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the action.
 
         :param args: The current application configuration

--- a/src/ansible_navigator/actions/log.py
+++ b/src/ansible_navigator/actions/log.py
@@ -15,7 +15,7 @@ class Action(ActionBase):
 
     KEGEX = r"^l(?:og)?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:log`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/open_file.py
+++ b/src/ansible_navigator/actions/open_file.py
@@ -57,7 +57,7 @@ class Action:
 
     KEGEX = r"^o(?:pen)?(\s(?P<requested>.*))?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:open`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/quit.py
+++ b/src/ansible_navigator/actions/quit.py
@@ -15,7 +15,7 @@ class Action:
 
     KEGEX = r"q(?:uit)?(?P<exclamation>!)?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:quit`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/refresh.py
+++ b/src/ansible_navigator/actions/refresh.py
@@ -15,7 +15,7 @@ class Action:
 
     KEGEX = r"^KEY_F\(5\)$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the refresh action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/rerun.py
+++ b/src/ansible_navigator/actions/rerun.py
@@ -16,7 +16,7 @@ class Action:
 
     KEGEX = r"^rr|rerun?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:rerun`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -199,7 +199,7 @@ class Action(ActionBase):
             (\s(?P<params_run>.*))?)
             $"""
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:run`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/sample_form.py
+++ b/src/ansible_navigator/actions/sample_form.py
@@ -91,7 +91,7 @@ class Action(ActionBase):
 
     KEGEX = r"^sample_form$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:sample_form`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/sample_notification.py
+++ b/src/ansible_navigator/actions/sample_notification.py
@@ -36,7 +36,7 @@ class Action(ActionBase):
 
     KEGEX = r"^sample_notification$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:sample_notification`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/sample_working.py
+++ b/src/ansible_navigator/actions/sample_working.py
@@ -17,7 +17,7 @@ class Action(ActionBase):
 
     KEGEX = r"^sample_working$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:sample_working`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/save.py
+++ b/src/ansible_navigator/actions/save.py
@@ -15,7 +15,7 @@ class Action:
 
     KEGEX = r"^s(?:ave)?\s(?P<filename>.*)$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:save`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/select.py
+++ b/src/ansible_navigator/actions/select.py
@@ -19,7 +19,7 @@ class Action:
 
     KEGEX = r"^\d+$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the select action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/serialize_json.py
+++ b/src/ansible_navigator/actions/serialize_json.py
@@ -16,7 +16,7 @@ class Action:
 
     KEGEX = r"^j(?:son)?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:json`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/serialize_yaml.py
+++ b/src/ansible_navigator/actions/serialize_yaml.py
@@ -16,7 +16,7 @@ class Action:
 
     KEGEX = r"^y(?:aml)?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:yaml`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/settings.py
+++ b/src/ansible_navigator/actions/settings.py
@@ -84,7 +84,7 @@ class Action(ActionBase):
 
     KEGEX = r"^se(?:ttings)?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:settings`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/stdout.py
+++ b/src/ansible_navigator/actions/stdout.py
@@ -15,7 +15,7 @@ class Action(ActionBase):
 
     KEGEX = r"^st(?:dout)?$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:stdout`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/template.py
+++ b/src/ansible_navigator/actions/template.py
@@ -27,7 +27,7 @@ class Action(ActionBase):
 
     KEGEX = r"^{{\s*(?P<params>.*?)\s*}}$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the template action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/welcome.py
+++ b/src/ansible_navigator/actions/welcome.py
@@ -21,7 +21,7 @@ class Action(ActionBase):
 
     KEGEX = r"^welcome$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:welcome`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/actions/write_file.py
+++ b/src/ansible_navigator/actions/write_file.py
@@ -23,7 +23,7 @@ class Action:
 
     KEGEX = r"^w(?:rite)?(?P<force>!)?\s+(?P<append>>>)?\s*(?P<filename>.+)$"
 
-    def __init__(self, args: ApplicationConfiguration):
+    def __init__(self, args: ApplicationConfiguration) -> None:
         """Initialize the ``:write`` action.
 
         :param args: The current settings for the application

--- a/src/ansible_navigator/configuration_subsystem/configurator.py
+++ b/src/ansible_navigator/configuration_subsystem/configurator.py
@@ -35,7 +35,7 @@ class Configurator:
         application_configuration: ApplicationConfiguration,
         apply_previous_cli_entries: list[str] | C = C.NONE,
         skip_roll_back: bool = False,
-    ):
+    ) -> None:
         """Initialize the configuration variables.
 
         :param params: A list of parameters e.g. ['-x', 'value']

--- a/src/ansible_navigator/configuration_subsystem/parser.py
+++ b/src/ansible_navigator/configuration_subsystem/parser.py
@@ -18,7 +18,7 @@ from .definitions import SettingsEntry
 class Parser:
     """Build the args."""
 
-    def __init__(self, config: ApplicationConfiguration):
+    def __init__(self, config: ApplicationConfiguration) -> None:
         """Initialize the command line interface parameter parser.
 
         :param config: The current settings for the application

--- a/src/ansible_navigator/data/catalog_collections.py
+++ b/src/ansible_navigator/data/catalog_collections.py
@@ -53,7 +53,7 @@ PROCESSES = (multiprocessing.cpu_count() - 1) or 1
 class CollectionCatalog:
     """A collection cataloger."""
 
-    def __init__(self, directories: list[Path]):
+    def __init__(self, directories: list[Path]) -> None:
         """Initialize the collection cataloger.
 
         :param directories: A list of directories that may contain collections

--- a/src/ansible_navigator/diagnostics.py
+++ b/src/ansible_navigator/diagnostics.py
@@ -179,7 +179,7 @@ class DiagnosticsCollector:
         args: ApplicationConfiguration,
         messages: list[LogMessage],
         exit_messages: list[ExitMessage],
-    ):
+    ) -> None:
         """Initialize the ShowTech class.
 
         :param args: The current settings

--- a/src/ansible_navigator/image_manager/puller.py
+++ b/src/ansible_navigator/image_manager/puller.py
@@ -39,7 +39,7 @@ class ImagePuller:
         image: str,
         arguments: Constants | list[str],
         pull_policy: str,
-    ):
+    ) -> None:
         """Initialize the container image puller.
 
         :param container_engine: The name of the container engine

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -45,7 +45,7 @@ CURSES_STYLES = {
 class ColorSchema:
     """A storage mechanism for the schema (theme)."""
 
-    def __init__(self, schema: dict[str, str | list[Any] | dict[Any, Any]]):
+    def __init__(self, schema: dict[str, str | list[Any] | dict[Any, Any]]) -> None:
         """Initialize the ColorSchema class.
 
         :param schema: The color scheme, theme to use
@@ -87,7 +87,7 @@ class ColorSchema:
 class Colorize:
     """Functionality for coloring."""
 
-    def __init__(self, grammar_dir: Traversable, theme_path: Traversable):
+    def __init__(self, grammar_dir: Traversable, theme_path: Traversable) -> None:
         """Initialize the colorizer.
 
         :param grammar_dir: The directory in which the grammars reside

--- a/src/ansible_navigator/ui_framework/curses_window.py
+++ b/src/ansible_navigator/ui_framework/curses_window.py
@@ -47,7 +47,7 @@ class CursesWindow:
     # pylint: disable=too-many-instance-attributes
     """Abstraction for a curses window."""
 
-    def __init__(self, ui_config: UIConfig):
+    def __init__(self, ui_config: UIConfig) -> None:
         """Initialize a curses window.
 
         :param ui_config: The current user interface configuration

--- a/src/ansible_navigator/ui_framework/menu_builder.py
+++ b/src/ansible_navigator/ui_framework/menu_builder.py
@@ -30,7 +30,7 @@ class MenuBuilder:
         number_colors: int,
         color_menu_item: Callable[..., Any],
         ui_config: UIConfig,
-    ):
+    ) -> None:
         """Initialize the menu builder.
 
         :param progress_bar_width:  The width of the progress bar

--- a/src/ansible_navigator/utils/key_value_store.py
+++ b/src/ansible_navigator/utils/key_value_store.py
@@ -27,7 +27,7 @@ class KVSValuesView(ValuesView[str]):
 class KeyValueStore(MutableMapping[str, str]):
     """An interface to use a sqlite database as a key-value store."""
 
-    def __init__(self, filename: str | Path):
+    def __init__(self, filename: str | Path) -> None:
         """Initialize the key-value store.
 
         :param filename: The full path to the sqlite database file

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -69,7 +69,7 @@ class CliRunner:
     def __init__(
         self,
         request: pytest.FixtureRequest,
-    ):
+    ) -> None:
         """Initialize the class.
 
         :param request: The current test request.


### PR DESCRIPTION
Moved [ANN101](https://docs.astral.sh/ruff/rules/missing-type-self/) and [ANN102](https://docs.astral.sh/ruff/rules/missing-type-cls/) at the top because these ruff rules are deprecated and supposed to be removed in a future release. So we can avoid fixing them.