### PR TITLE
Refactor codecov to perform single coverage upload

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -83,38 +83,76 @@ jobs:
         continue-on-error: ${{ matrix.devel || false }}
         run: python3 -m tox -e no-test-deps
 
-      - name: Upload coverage data
-        if: ${{ startsWith(matrix.passed_name, 'py') }}
-        uses: codecov/codecov-action@v4
-        with:
-          name: ${{ matrix.passed_name }}
-          fail_ci_if_error: true
-          verbose: true # optional (default = false)
-          use_oidc: true # cspell:ignore oidc
-      - name: Archive logs
+      - name: Archive logs and coverage data
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: logs-${{ matrix.name }}.zip
-          path: .tox/**/log/
+          path: |
+            .tox/**/log/
+            .tox/**/.coverage*
+            .tox/**/coverage.xml
 
       - name: Change accessibility for cache
         if: ${{ startsWith(matrix.passed_name, 'py') }}
         run: podman unshare chmod -R 755 ~/.local/share/containers/
 
-  check: # This job does nothing and is only used for the branch protection
-    if: always()
+      - name: Report failure if git reports dirty status
+        run: |
+          if [[ -n $(git status -s) ]]; then
+            # shellcheck disable=SC2016
+            echo -n '::error file=git-status::'
+            printf '### Failed as git reported modified and/or untracked files\n```\n%s\n```\n' "$(git status -s)" | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 99
+          fi
+        # https://github.com/actions/toolkit/issues/193
 
+  check:
+    if: always()
+    permissions:
+      id-token: write
+      checks: read
     needs:
       - tox
     runs-on: ubuntu-22.04
     steps:
+      # checkout needed for codecov action which needs codecov.yml file
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip3 install 'coverage>=7.5.1'
+
       - name: Merge logs into a single archive
         uses: actions/upload-artifact/merge@v4
         with:
           name: logs.zip
-          pattern: logs*.zip
-          delete-merged: true
+          pattern: logs-*.zip
+          separate-directories: true
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: logs.zip
+          path: .
+
+      - name: Check for expected number of coverage.xml reports
+        run: |
+          JOBS_PRODUCING_COVERAGE=5
+          if [ "$(find . -name coverage.xml | wc -l | bc)" -ne "${JOBS_PRODUCING_COVERAGE}" ]; then
+            echo "::error::Number of coverage.xml files was not the expected one (${JOBS_PRODUCING_COVERAGE}): $(find . -name coverage.xml |xargs echo)"
+            exit 1
+          fi
+
+      - name: Upload coverage data
+        uses: codecov/codecov-action@v4
+        with:
+          name: ${{ matrix.passed_name }}
+          fail_ci_if_error: true
+          use_oidc: true # cspell:ignore oidc
 
       - name: Check codecov.io status
         if: github.event_name == 'pull_request'
@@ -124,3 +162,15 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+
+      - name: Delete Merged Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          delete-merged: true
+
+      - name: Notify repository owners about changes affecting them
+        uses: sourcegraph/codenotify@v0.6.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # https://github.com/sourcegraph/codenotify/issues/19
+        continue-on-error: true

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -84,7 +84,6 @@ jobs:
         run: python3 -m tox -e no-test-deps
 
       - name: Archive logs and coverage data
-        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: logs-${{ matrix.name }}.zip

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -89,7 +89,6 @@ jobs:
           name: logs-${{ matrix.name }}.zip
           path: |
             .tox/**/log/
-            .tox/**/.coverage*
             .tox/**/coverage.xml
 
       - name: Change accessibility for cache

--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,9 @@ dmypy.json
 /src/ansible_navigator/_version.py
 out
 
+# Coverage files
+*.lcov
+
 # other
 .DS_Store
 .envrc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ show_missing = true
 [tool.coverage.run]
 # branch = true
 concurrency = ["multiprocessing", "thread"]
-data_file = ".tox/.coverage"
 parallel = true
 source_pkgs = ["ansible_navigator"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,12 @@ commands =
   # pytest params are kept in pyproject.toml
   # if one wants to control parallelism define PYTEST_XDIST_AUTO_NUM_WORKERS
   coverage run -m pytest {posargs:-n=auto --dist=loadfile}
-  sh -c "coverage combine -q {toxworkdir}/.coverage.* && coverage xml || true && coverage report"
+  {py,py310,py311,py312,py313}: sh -c " \
+    coverage combine -q --data-file={envdir}/.coverage {envdir}/.coverage.* && \
+    coverage xml --data-file={envdir}/.coverage -o {envdir}/coverage.xml --ignore-errors --fail-under=0 && \
+    COVERAGE_FILE={envdir}/.coverage coverage lcov --fail-under=0 --ignore-errors -q && \
+    COVERAGE_FILE={envdir}/.coverage coverage report --ignore-errors \
+    "
 setenv =
   COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
   COVERAGE_PROCESS_START={toxinidir}/pyproject.toml

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands =
     COVERAGE_FILE={envdir}/.coverage coverage report --ignore-errors \
     "
 setenv =
-  COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
+  COVERAGE_FILE = {env:COVERAGE_FILE:{envdir}/.coverage.{envname}}
   COVERAGE_PROCESS_START={toxinidir}/pyproject.toml
   FORCE_COLOR = 1
   PIP_CONSTRAINT = {toxinidir}/.config/constraints.txt


### PR DESCRIPTION
- Archive coverage report from each job
- Combine coverage reports inside check job
- Make a single upload to codecov.io

[AAP-24264](https://issues.redhat.com/browse/AAP-24264)
