### PR TITLE
Address ruff `PIE810` and `N806`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -291,7 +291,6 @@ ignore = [
   'N817', # CamelCase `Constants` imported as acronym `C`
   'PERF203', # `try`-`except` within a loop incurs performance overhead
   'PGH003', # Use specific rule codes when ignoring type issues
-  'PIE810', # [*] Call `startswith` once with a `tuple`
   'PD011', # https://github.com/astral-sh/ruff/issues/2229
   'PLR0911', # Too many return statements (8 > 6)
   'PLR0912', # Too many branches (13 > 12)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,7 +284,6 @@ ignore = [
   'FBT001', # Boolean positional arg in function definition
   'FBT002', # Boolean default value in function definition
   'FBT003', # Boolean positional value in function call
-  'N806', # Variable `FType` in function should be lowercase
   'N812', # Lowercase `__version_collection_doc_cache__` imported as non-lowercase `VERSION_CDC`
   'N813', # Camelcase `Action` imported as lowercase `stdout_action`
   'N817', # CamelCase `Constants` imported as acronym `C`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,7 +284,6 @@ ignore = [
   'FBT001', # Boolean positional arg in function definition
   'FBT002', # Boolean default value in function definition
   'FBT003', # Boolean positional value in function call
-  'N802', # Function name `formatTime` should be lowercase
   'N806', # Variable `FType` in function should be lowercase
   'N812', # Lowercase `__version_collection_doc_cache__` imported as non-lowercase `VERSION_CDC`
   'N813', # Camelcase `Action` imported as lowercase `stdout_action`

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -431,7 +431,7 @@ class Action(ActionBase):
             return False
 
         version = data.get("version", "")
-        if version.startswith("1.") or version.startswith("2."):
+        if version.startswith(("1.", "2.")):
             try:
                 stdout = data["stdout"]
                 if self.mode == "interactive":

--- a/src/ansible_navigator/logger.py
+++ b/src/ansible_navigator/logger.py
@@ -33,7 +33,11 @@ class Formatter(logging.Formatter):
         self._time_zone = kwargs.pop("time_zone")
         super().__init__(*args, **kwargs)
 
-    def formatTime(self, record: logging.LogRecord, _datefmt: str | None = None) -> str:
+    def formatTime(  # noqa: N802
+        self,
+        record: logging.LogRecord,
+        _datefmt: str | None = None,
+    ) -> str:
         """Format the log timestamp.
 
         :param record: The log record

--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -27,7 +27,7 @@ def id_func(param: Any) -> str:
     :return: Returns a string.
     """
     result = ""
-    _AUTO_ID_COUNTER = 0
+    auto_id_counter = 0
     if isinstance(param, str):
         result = param
     elif hasattr(param, "value") and isinstance(param.value, str):  # covers for Enums too
@@ -49,7 +49,7 @@ def id_func(param: Any) -> str:
                     args.append(str(part))
             result = "-".join(args)
     else:
-        result = str(_AUTO_ID_COUNTER)
-        _AUTO_ID_COUNTER += 1
+        result = str(auto_id_counter)
+        auto_id_counter += 1
     result = result.lower().replace(" ", "-")
     return result

--- a/tests/unit/actions/run/test_runner_async.py
+++ b/tests/unit/actions/run/test_runner_async.py
@@ -132,15 +132,17 @@ def test_runner_args(mocker: MockerFixture, data: Scenario) -> None:
     args.entry("ansible_runner_timeout").value.current = data.timeout
     args.entry("ansible_runner_write_job_events").value.current = data.write_job_events
 
-    TestRunnerException = Exception
+    class TestRunnerError(Exception):
+        """Test runner exception."""
+
     command_async = mocker.patch(
         "ansible_navigator.actions.run.CommandAsync",
-        side_effect=TestRunnerException,
+        side_effect=TestRunnerError,
     )
 
     run = action(args=args)
     run._queue = TEST_QUEUE  # pylint: disable=protected-access
-    with pytest.raises(TestRunnerException):
+    with pytest.raises(TestRunnerError):
         run._run_runner()  # pylint: disable=protected-access
 
     command_async.assert_called_once_with(**data.expected)


### PR DESCRIPTION
Additionally addresses `N802` via a noqa, because function name `formatTime` can't be changed to a lowercase. Since its been derived from the class logging.LogRecord