### PR TITLE
Docs: change Getting started EE guide reference to point to the relevant location

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,7 +10,7 @@ An execution environment is a container image serving as an Ansible control
 node.
 
 See the
-[Getting started with Execution Environments guide](https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html)
+[Getting started with Execution Environments guide](https://docs.ansible.com/ansible/devel/getting_started_ee/index.html)
 for details.
 
 ## The `ansible.cfg` file

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ A demo of the interface can be found [on YouTube][yt demo].
 
 To learn how to easily start leveraging the container technology with
 `ansible-navigator`, see the
-[Getting started with Execution Environments guide](https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html).
+[Getting started with Execution Environments guide](https://docs.ansible.com/ansible/devel/getting_started_ee/index.html).
 
 - [Installation](installation.md)
 - [Settings](settings.md)


### PR DESCRIPTION
Docs: change Getting started EE guide reference to point to the relevant location. The stuff was moved yesterday.
The old one currently refers to a 404 page