### PR TITLE
Allow images subcommand to display the resulting output in JSON format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
     ignore:
       # prevent ansible-core from being updated until test fixtures are updated
       - dependency-name: ansible-core
+      - dependency-name: "codecov/codecov-action"
+        versions: ["4.6.0"]
     groups:
       dependencies:
         patterns:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -159,7 +159,7 @@ jobs:
           fi
 
       - name: Upload coverage data
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4.5.0
         with:
           name: ${{ matrix.name }}
           fail_ci_if_error: true

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -193,7 +193,7 @@ class Action(ActionBase):
         details["image_name"] = image_name
         print_to_stdout(
             content=details,
-            content_format=ContentFormat.YAML,
+            content_format=getattr(ContentFormat, self._args.format.upper()),
             use_color=self._args.display_color,
         )
         return RunStdoutReturn(message="", return_code=0)


### PR DESCRIPTION
Fixes: https://github.com/ansible/ansible-navigator/issues/1857 

The given command output before and after adding support for all available output formats:

```
ansible-navigator images --execution-environment-image community-ansible-dev-tools:latest --details system_packages --format json
```

Before: 
![Screenshot 2024-11-12 at 12 03 07 PM](https://github.com/user-attachments/assets/8a5fd4a4-c754-4364-af5d-cb6bd5ac9bb5)

After: 
![Screenshot 2024-11-12 at 11 55 24 AM](https://github.com/user-attachments/assets/9ea89f01-08ef-4c24-9373-255b77c0c5f5)