### PR TITLE
[AAP-36287] fixing the end line code to revert the color

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ to this document for the greater community!
 
 ## License
 
-ansible-navigator is released under the Apache License version 2. See the
+ansible-navigator is released under the Apache License version 2. See
 [LICENSE] file for more details.
 
 [LICENSE]: https://github.com/ansible/ansible-navigator/blob/main/LICENSE

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ to this document for the greater community!
 
 ## License
 
-ansible-navigator is released under the Apache License version 2. See
+ansible-navigator is released under the Apache License version 2. See the
 [LICENSE] file for more details.
 
 [LICENSE]: https://github.com/ansible/ansible-navigator/blob/main/LICENSE

--- a/src/ansible_navigator/utils/print.py
+++ b/src/ansible_navigator/utils/print.py
@@ -70,7 +70,7 @@ def color_lines(term_color_bits: int, tokenized: list[list[SimpleLinePart]]) -> 
                     number_of_colors = 2**term_color_bits
                     ansi_color = rgb_to_ansi(red, green, blue, number_of_colors)
                 ansi_code = f"\033[38;5;{ansi_color}m"
-            printable += f"{ansi_code}{line_part.chars}\033[1m"
+            printable += f"{ansi_code}{line_part.chars}\033[m"
         lines.append(printable)
     return "".join(lines)
 


### PR DESCRIPTION
This is a very small correction in the print.py file to avoid after running `ansible-navigator images -m stdout` to have the prompt changed into colored and bold.

The issue is basically the following: when running the command from a linux machine with bash the prompt changes from this:

![Screenshot From 2024-11-28 13-33-48](https://github.com/user-attachments/assets/db1f2476-0220-47b0-99d2-8aaef8de601e)

To this:

![Screenshot From 2024-11-28 13-32-46](https://github.com/user-attachments/assets/908784e7-50e8-46b8-b63f-0e69d48cac03)


Related JIRA: https://issues.redhat.com/browse/AAP-36287

