### PR TITLE
Fix CI: Update libtmux to the newer version

### DIFF
--- a/.config/constraints.txt
+++ b/.config/constraints.txt
@@ -52,7 +52,7 @@ jinja2==3.1.5
 jsmin==3.0.1
 jsonschema==4.23.0
 jsonschema-specifications==2024.10.1
-libtmux==0.40.1
+libtmux==0.42.1
 linkchecker==10.5.0
 lockfile==0.12.2
 markdown==3.7

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ out
 # other
 .DS_Store
 .envrc
+
+# Ansible
+.ansible/


### PR DESCRIPTION
This PR updates `libtmux` to its latest version and also adds ansible temp directory (.ansible) to gitignore.

Related libtmux PR with the fix: https://github.com/tmux-python/libtmux/pull/562