### PR TITLE
Update ruff to latest

### DIFF
--- a/.config/pydoclint-baseline.txt
+++ b/.config/pydoclint-baseline.txt
@@ -420,12 +420,6 @@ src/ansible_navigator/utils/json_schema.py
 src/ansible_navigator/utils/key_value_store.py
     DOC501: Method `KeyValueStore.__len__` has raise/assert statements, but the docstring does not have a "Raises" section
     DOC503: Method `KeyValueStore.__len__` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: []. Raised exceptions in the body: ['TypeError'].
-    DOC402: Method `KeyValueStore.iterkeys` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Method `KeyValueStore.iterkeys` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC402: Method `KeyValueStore.itervalues` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Method `KeyValueStore.itervalues` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC402: Method `KeyValueStore.iteritems` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Method `KeyValueStore.iteritems` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
 --------------------
 src/ansible_navigator/utils/packaged_data.py
     DOC601: Class `ImageEntry`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
@@ -458,12 +452,6 @@ src/ansible_navigator/utils/version_migration/v1_v2_settings_file.py
     DOC603: Class `V1V2SettingsFile`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [migration_type: MigrationType, name: ]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
 --------------------
 tests/conftest.py
-    DOC402: Function `locked_directory` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Function `locked_directory` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC402: Function `pullable_image` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Function `pullable_image` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC402: Function `cmd_in_tty` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Function `cmd_in_tty` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
     DOC201: Method `TCmdInTty.__call__` does not have a return section in docstring
     DOC101: Function `is_config_empty`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `is_config_empty`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [filename: Path].
@@ -502,10 +490,6 @@ tests/integration/_tmux_session.py
 tests/integration/actions/collections/base.py
     DOC601: Class `BaseClass`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
     DOC603: Class `BaseClass`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [pane_height: , pane_width: , update_fixtures: ]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
-    DOC402: Method `BaseClass.fixture_tmux_session` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Method `BaseClass.fixture_tmux_session` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC101: Method `BaseClass.test`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `BaseClass.test`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [skip_if_already_failed: None].
     DOC503: Method `BaseClass.test` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: ['ValueError']. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)', 'ValueError'].
 --------------------
 tests/integration/actions/collections/test_direct_interactive_ee.py
@@ -531,10 +515,6 @@ tests/integration/actions/collections/test_welcome_interactive_noee.py
 tests/integration/actions/config/base.py
     DOC601: Class `BaseClass`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
     DOC603: Class `BaseClass`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [PANE_HEIGHT: , PANE_WIDTH: , UPDATE_FIXTURES: ]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
-    DOC402: Method `BaseClass.fixture_tmux_session` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Method `BaseClass.fixture_tmux_session` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC101: Method `BaseClass.test`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `BaseClass.test`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [skip_if_already_failed: None].
     DOC503: Method `BaseClass.test` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: ['ValueError']. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)', 'ValueError'].
 --------------------
 tests/integration/actions/config/test_direct_interactive_ee.py
@@ -568,10 +548,6 @@ tests/integration/actions/config/test_welcome_interactive_specified_config.py
 tests/integration/actions/doc/base.py
     DOC601: Class `BaseClass`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
     DOC603: Class `BaseClass`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [TEST_FOR_MODE: str | None, UPDATE_FIXTURES: ]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
-    DOC402: Method `BaseClass.fixture_tmux_doc_session` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Method `BaseClass.fixture_tmux_doc_session` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC101: Method `BaseClass.test`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `BaseClass.test`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [skip_if_already_failed: bool | None].
     DOC503: Method `BaseClass.test` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: ['ValueError']. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)', 'ValueError'].
 --------------------
 tests/integration/actions/doc/test_direct_interactive_ee.py
@@ -617,21 +593,13 @@ tests/integration/actions/doc/test_welcome_interactive_noee.py
 tests/integration/actions/exec/base.py
     DOC601: Class `BaseClass`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
     DOC603: Class `BaseClass`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [config_file: Path | None, pane_height: , pane_width: , update_fixtures: ]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
-    DOC402: Method `BaseClass.fixture_tmux_session` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Method `BaseClass.fixture_tmux_session` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
     DOC501: Method `BaseClass.fixture_tmux_session` has raise/assert statements, but the docstring does not have a "Raises" section
     DOC503: Method `BaseClass.fixture_tmux_session` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: []. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)'].
-    DOC101: Method `BaseClass.test`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `BaseClass.test`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [skip_if_already_failed: None].
     DOC503: Method `BaseClass.test` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: ['ValueError']. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)', 'ValueError'].
 --------------------
 tests/integration/actions/images/base.py
     DOC601: Class `BaseClass`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
     DOC603: Class `BaseClass`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [UPDATE_FIXTURES: ]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
-    DOC402: Method `BaseClass.fixture_tmux_session` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Method `BaseClass.fixture_tmux_session` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC101: Method `BaseClass.test`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `BaseClass.test`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [skip_if_already_failed: None].
     DOC503: Method `BaseClass.test` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: ['ValueError']. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)', 'ValueError'].
 --------------------
 tests/integration/actions/images/test_direct_interactive_ee.py
@@ -653,10 +621,6 @@ tests/integration/actions/images/test_welcome_interactive_noee.py
 tests/integration/actions/inventory/base.py
     DOC601: Class `BaseClass`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
     DOC603: Class `BaseClass`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [UPDATE_FIXTURES: ]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
-    DOC402: Method `BaseClass.fixture_tmux_session` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Method `BaseClass.fixture_tmux_session` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC101: Method `BaseClass.test`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `BaseClass.test`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [skip_if_already_failed: None].
     DOC503: Method `BaseClass.test` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: ['ValueError']. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)', 'ValueError'].
 --------------------
 tests/integration/actions/inventory/test_direct_interactive_ee.py
@@ -702,10 +666,6 @@ tests/integration/actions/inventory/test_welcome_interactive_noee.py
 tests/integration/actions/lint/base.py
     DOC601: Class `BaseClass`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
     DOC603: Class `BaseClass`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [UPDATE_FIXTURES: ]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
-    DOC402: Method `BaseClass.fixture_tmux_session` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Method `BaseClass.fixture_tmux_session` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC101: Method `BaseClass.test`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `BaseClass.test`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [skip_if_already_failed: None].
     DOC501: Method `BaseClass.test` has raise/assert statements, but the docstring does not have a "Raises" section
     DOC503: Method `BaseClass.test` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: []. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)'].
 --------------------
@@ -732,8 +692,6 @@ tests/integration/actions/lint/test_welcome_interactive_noee.py
 tests/integration/actions/replay/base.py
     DOC601: Class `BaseClass`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
     DOC603: Class `BaseClass`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [UPDATE_FIXTURES: ]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
-    DOC402: Method `BaseClass.fixture_tmux_session` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Method `BaseClass.fixture_tmux_session` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
     DOC501: Method `BaseClass.test` has raise/assert statements, but the docstring does not have a "Raises" section
     DOC503: Method `BaseClass.test` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: []. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)'].
 --------------------
@@ -756,10 +714,6 @@ tests/integration/actions/replay/test_welcome_interactive_noee.py
 tests/integration/actions/run/base.py
     DOC601: Class `BaseClass`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
     DOC603: Class `BaseClass`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [TEST_FOR_MODE: str | None, UPDATE_FIXTURES: ]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
-    DOC402: Method `BaseClass.fixture_tmux_session` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Method `BaseClass.fixture_tmux_session` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC101: Method `BaseClass.test`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `BaseClass.test`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [skip_if_already_failed: None].
     DOC501: Method `BaseClass.test` has raise/assert statements, but the docstring does not have a "Raises" section
     DOC503: Method `BaseClass.test` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: []. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)'].
 --------------------
@@ -790,10 +744,6 @@ tests/integration/actions/run/test_welcome_interactive_noee.py
 tests/integration/actions/run_unicode/base.py
     DOC601: Class `BaseClass`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
     DOC603: Class `BaseClass`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [TEST_FOR_MODE: str | None, UPDATE_FIXTURES: ]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
-    DOC402: Method `BaseClass.fixture_tmux_session` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Method `BaseClass.fixture_tmux_session` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC101: Method `BaseClass.test`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `BaseClass.test`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [skip_if_already_failed: None].
     DOC501: Method `BaseClass.test` has raise/assert statements, but the docstring does not have a "Raises" section
     DOC503: Method `BaseClass.test` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: []. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)'].
 --------------------
@@ -808,10 +758,6 @@ tests/integration/actions/run_unicode/test_direct_interactive_noee.py
 tests/integration/actions/settings/base.py
     DOC601: Class `BaseClass`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
     DOC603: Class `BaseClass`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [PANE_HEIGHT: , PANE_WIDTH: , UPDATE_FIXTURES: ]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
-    DOC402: Method `BaseClass.fixture_tmux_session` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Method `BaseClass.fixture_tmux_session` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC101: Method `BaseClass.test`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `BaseClass.test`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [skip_if_already_failed: None].
     DOC503: Method `BaseClass.test` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: ['ValueError']. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)', 'ValueError'].
 --------------------
 tests/integration/actions/settings/test_direct_interactive_ee.py
@@ -833,10 +779,6 @@ tests/integration/actions/settings/test_welcome_interactive_noee.py
 tests/integration/actions/templar/base.py
     DOC601: Class `BaseClass`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
     DOC603: Class `BaseClass`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [TEST_FOR_MODE: str | None, UPDATE_FIXTURES: ]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
-    DOC402: Method `BaseClass.fixture_tmux_session` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Method `BaseClass.fixture_tmux_session` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC101: Method `BaseClass.test`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `BaseClass.test`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [skip_if_already_failed: None].
     DOC501: Method `BaseClass.test` has raise/assert statements, but the docstring does not have a "Raises" section
     DOC503: Method `BaseClass.test` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: []. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)'].
 --------------------
@@ -862,11 +804,6 @@ tests/integration/actions/templar/test_welcome_interactive_noee.py
 --------------------
 tests/integration/conftest.py
     DOC402: Function `action_run_stdout` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Function `action_run_stdout` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
---------------------
-tests/integration/diagnostics/test_from_cli.py
-    DOC101: Function `test`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `test`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [skip_if_already_failed: None].
 --------------------
 tests/integration/settings_from_cli/test_json_schema_errors.py
     DOC601: Class `Scenario`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
@@ -1215,10 +1152,6 @@ tests/unit/test_catalog_collections.py
     DOC501: Function `test_worker_with_invalid_plugin_path` has raise/assert statements, but the docstring does not have a "Raises" section
     DOC503: Function `test_worker_with_invalid_plugin_path` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: []. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)'].
 --------------------
-tests/unit/test_circular_imports.py
-    DOC402: Function `_discover_path_importables` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Function `_discover_path_importables` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
---------------------
 tests/unit/test_cli.py
     DOC101: Function `test_update_args_general`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `test_update_args_general`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_mf1: Any].
@@ -1286,12 +1219,6 @@ tests/unit/ui_framework/test_progress_bar.py
     DOC503: Function `test_dataclass_running` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: []. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)'].
     DOC501: Function `test_dataclass_complete` has raise/assert statements, but the docstring does not have a "Raises" section
     DOC503: Function `test_dataclass_complete` exceptions in the "Raises" section in the docstring do not match those in the function body. Raised exceptions in the docstring: []. Raised exceptions in the body: ['AssertionError (implicitly from the `assert` statement)'].
---------------------
-tests/unit/utils/conftest.py
-    DOC402: Function `empty_kvs` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Function `empty_kvs` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC402: Function `kvs` has "yield" statements, but the docstring does not have a "Yields" section
-    DOC404: Function `kvs` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
 --------------------
 tests/unit/utils/test_dict_merge.py
     DOC501: Function `test_in_place_list_replace_basic` has raise/assert statements, but the docstring does not have a "Raises" section

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
       - id: toml-sort-fix
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.9.10"
+    rev: "v0.11.2"
     hooks:
       - id: ruff
         args:

--- a/docs/_ext/regenerate_docs.py
+++ b/docs/_ext/regenerate_docs.py
@@ -101,7 +101,6 @@ def md_settings_dump() -> str:
 
 
 def _params_row_for_entry(entry: SettingsEntry) -> tuple[str, ...]:
-    # pylint: disable=too-many-branches
     """Create a row entry for one settings parameter.
 
     :param entry: The settings entry for which the row will be generated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ allow-init-docstring = true
 arg-type-hints-in-docstring = false
 baseline = ".config/pydoclint-baseline.txt"
 check-return-types = false
+check-yield-types = false
 exclude = '\.git|\.test_logs|\.tox|build|out|tests/fixtures|venv'
 should-document-private-class-attributes = true
 show-filenames-in-every-violation-message = true
@@ -122,100 +123,184 @@ disable = [
   "fixme",
   "too-few-public-methods",
   "unsubscriptable-object",
+  "unknown-option-value",
   # https://gist.github.com/cidrblock/ec3412bacfeb34dbc2d334c1d53bef83
   "C0103", # invalid-name / ruff N815
+  "C0105", # typevar-name-incorrect-variance / ruff PLC0105
   "C0112", # empty-docstring / ruff D419
+  "C0113", # unneeded-not / ruff SIM208
   "C0114", # missing-module-docstring / ruff D100
   "C0115", # missing-class-docstring / ruff D101
   "C0116", # missing-function-docstring / ruff D103
   "C0121", # singleton-comparison / ruff PLC0121
   "C0123", # unidiomatic-typecheck / ruff E721
-  # "C0198", # bad-docstring-quotes / ruff Q002
-  # "C0199", # docstring-first-line-empty / ruff D210
+  "C0131", # typevar-double-variance / ruff PLC0131
+  "C0132", # typevar-name-mismatch / ruff PLC0132
+  "C0198", # bad-docstring-quotes / ruff Q002
+  "C0199", # docstring-first-line-empty / ruff D210
+  "C0201", # consider-iterating-dictionary / ruff SIM118
   "C0202", # bad-classmethod-argument / ruff PLC0202
+  "C0205", # single-string-used-for-slots / ruff PLC0205
+  "C0206", # consider-using-dict-items / ruff PLC0206
+  "C0208", # use-sequence-for-iteration / ruff PLC0208
   "C0301", # line-too-long / ruff E501
+  "C0303", # trailing-whitespace / ruff W291
   "C0304", # missing-final-newline / ruff W292
-  "C0325", # superfluous-parens / ruff UP034
+  "C0305", # trailing-newlines / ruff W391
+  "C0321", # multiple-statements / ruff PLC0321
   "C0410", # multiple-imports / ruff E401
   "C0411", # wrong-import-order / ruff I001
   "C0412", # ungrouped-imports / ruff I001
   "C0413", # wrong-import-position / ruff E402
   "C0414", # useless-import-alias / ruff PLC0414
-  # "C0501", # consider-using-any-or-all / ruff PLC0501
-  # "C2201", # misplaced-comparison-constant / ruff SIM300
-  "C3001", # unnecessary-lambda-assignment / ruff PLC3001
+  "C0415", # import-outside-toplevel / ruff PLC0415
+  "C0501", # consider-using-any-or-all / ruff PLC0501
+  "C1802", # use-implicit-booleaness-not-len / ruff PLC1802
+  "C1901", # compare-to-empty-string / ruff PLC1901
+  "C2201", # misplaced-comparison-constant / ruff SIM300
+  "C2401", # non-ascii-name / ruff PLC2401
+  "C2403", # non-ascii-module-import / ruff PLC2403
+  "C2701", # import-private-name / ruff PLC2701
+  "C2801", # unnecessary-dunder-call / ruff PLC2801
+  "C3001", # unnecessary-lambda-assignment / ruff E731
   "C3002", # unnecessary-direct-lambda-call / ruff PLC3002
-  "E0001", # syntax-error / ruff E999
+  "E0001", # syntax-error / ruff PLE0001
+  "E0100", # init-is-generator / ruff PLE0100
   "E0101", # return-in-init / ruff PLE0101
   "E0102", # function-redefined / ruff F811
   "E0103", # not-in-loop / ruff PLE0103
   "E0104", # return-outside-function / ruff F706
   "E0105", # yield-outside-function / ruff F704
   "E0107", # nonexistent-operator / ruff B002
+  "E0112", # too-many-star-expressions / ruff F622
+  "E0115", # nonlocal-and-global / ruff PLE0115
   "E0116", # continue-in-finally / ruff PLE0116
   "E0117", # nonlocal-without-binding / ruff PLE0117
   "E0118", # used-prior-global-declaration / ruff PLE0118
-  "E0211", # no-method-argument / ruff N805
   "E0213", # no-self-argument / ruff N805
+  "E0237", # assigning-non-slot / ruff PLE0237
+  "E0241", # duplicate-bases / ruff PLE0241
+  "E0302", # unexpected-special-method-signature / ruff PLE0302
+  "E0303", # invalid-length-returned / ruff PLE0303
+  "E0304", # invalid-bool-returned / ruff PLE0304
+  "E0305", # invalid-index-returned / ruff PLE0305
+  "E0308", # invalid-bytes-returned / ruff PLE0308
+  "E0309", # invalid-hash-returned / ruff PLE0309
+  "E0402", # relative-beyond-top-level / ruff TID252
+  "E0601", # used-before-assignment / ruff F821
   "E0602", # undefined-variable / ruff F821
+  "E0603", # undefined-all-variable / ruff F822
   "E0604", # invalid-all-object / ruff PLE0604
   "E0605", # invalid-all-format / ruff PLE0605
+  "E0643", # potential-index-error / ruff PLE0643
+  "E0704", # misplaced-bare-raise / ruff PLE0704
   "E0711", # notimplemented-raised / ruff F901
-  "E1133", # not-an-iterable
+  "E1132", # repeated-keyword / ruff PLE1132
   "E1142", # await-outside-async / ruff PLE1142
   "E1205", # logging-too-many-args / ruff PLE1205
   "E1206", # logging-too-few-args / ruff PLE1206
+  "E1300", # bad-format-character / ruff PLE1300
   "E1301", # truncated-format-string / ruff F501
   "E1302", # mixed-format-string / ruff F506
   "E1303", # format-needs-mapping / ruff F502
   "E1304", # missing-format-string-key / ruff F524
+  "E1305", # too-many-format-args / ruff F522
+  "E1306", # too-few-format-args / ruff F524
   "E1307", # bad-string-format-type / ruff PLE1307
   "E1310", # bad-str-strip-call / ruff PLE1310
+  "E1519", # singledispatch-method / ruff PLE1519
+  "E1520", # singledispatchmethod-function / ruff PLE1520
+  "E1700", # yield-inside-async-function / ruff PLE1700
   "E2502", # bidirectional-unicode / ruff PLE2502
   "E2510", # invalid-character-backspace / ruff PLE2510
   "E2512", # invalid-character-sub / ruff PLE2512
   "E2513", # invalid-character-esc / ruff PLE2513
   "E2514", # invalid-character-nul / ruff PLE2514
   "E2515", # invalid-character-zero-width-space / ruff PLE2515
+  "E4703", # modified-iterating-set / ruff PLE4703
   "R0123", # literal-comparison / ruff F632
+  "R0124", # comparison-with-itself / ruff PLR0124
   "R0133", # comparison-of-constants / ruff PLR0133
+  "R0202", # no-classmethod-decorator / ruff PLR0202
+  "R0203", # no-staticmethod-decorator / ruff PLR0203
   "R0205", # useless-object-inheritance / ruff UP004
+  "R0206", # property-with-parameters / ruff PLR0206
+  "R0402", # consider-using-from-import / ruff PLR0402
+  "R0904", # too-many-public-methods / ruff PLR0904
   "R0911", # too-many-return-statements / ruff PLR0911
   "R0912", # too-many-branches / ruff PLR0912
+  "R0913", # too-many-arguments / ruff PLR0913
+  "R0914", # too-many-locals / ruff PLR0914
   "R0915", # too-many-statements / ruff PLR0915
-  # "R1260", # too-complex / ruff C901
-  "R1701", # consider-merging-isinstance / ruff PLR1701
-  "R1706", # consider-using-ternary / ruff SIM108
+  "R0916", # too-many-boolean-expressions / ruff PLR0916
+  "R1260", # too-complex / ruff C901
+  "R1701", # consider-merging-isinstance / ruff SIM101
+  "R1702", # too-many-nested-blocks / ruff PLR1702
+  "R1703", # simplifiable-if-statement / ruff SIM108
+  "R1704", # redefined-argument-from-local / ruff PLR1704
+  "R1705", # no-else-return / ruff RET505
   "R1707", # trailing-comma-tuple / ruff COM818
   "R1710", # inconsistent-return-statements / ruff PLR1710
   "R1711", # useless-return / ruff PLR1711
+  "R1714", # consider-using-in / ruff PLR1714
   "R1715", # consider-using-get / ruff SIM401
   "R1717", # consider-using-dict-comprehension / ruff C402
   "R1718", # consider-using-set-comprehension / ruff C401
-  "R1721", # unnecessary-comprehension / ruff PLR1721
+  "R1719", # simplifiable-if-expression / ruff PLR1719
+  "R1720", # no-else-raise / ruff RET506
+  "R1721", # unnecessary-comprehension / ruff C416
   "R1722", # consider-using-sys-exit / ruff PLR1722
+  "R1723", # no-else-break / ruff RET508
+  "R1724", # no-else-continue / ruff RET507
   "R1725", # super-with-arguments / ruff UP008
   "R1728", # consider-using-generator / ruff C417
-  "R1729", # use-a-generator / ruff C417
+  "R1729", # use-a-generator / ruff C419
+  "R1730", # consider-using-min-builtin / ruff PLR1730
+  "R1731", # consider-using-max-builtin / ruff PLR1730
+  "R1732", # consider-using-with / ruff SIM115
+  "R1733", # unnecessary-dict-index-lookup / ruff PLR1733
+  "R1734", # use-list-literal / ruff C405
   "R1734", # use-list-literal / ruff C405
   "R1735", # use-dict-literal / ruff C406
-  # "R2004", # magic-value-comparison / ruff PLR2004
-  # "R5501", # else-if-used / ruff PLR5501
-  # "R6002", # consider-using-alias / ruff UP006
-  # "R6003", # consider-alternative-union-syntax / ruff UP007
+  "R2004", # magic-value-comparison / ruff PLR2004
+  "R2044", # empty-comment / ruff PLR2044
+  "R5501", # else-if-used / ruff PLR5501
+  "R6002", # consider-using-alias / ruff UP006
+  "R6003", # consider-alternative-union-syntax / ruff UP007
+  "R6104", # consider-using-augmented-assign / ruff PLR6104
+  "R6201", # use-set-for-membership / ruff PLR6201
+  "R6301", # no-self-use / ruff PLR6301
   "W0102", # dangerous-default-value / ruff B006
   "W0104", # pointless-statement / ruff B018
   "W0106", # expression-not-assigned / ruff B018
+  "W0107", # unnecessary-pass / ruff PIE790
+  "W0108", # unnecessary-lambda / ruff PLW0108
   "W0109", # duplicate-key / ruff F601
   "W0120", # useless-else-on-loop / ruff PLW0120
+  "W0122", # exec-used / ruff S102
+  "W0123", # eval-used / ruff S307
+  "W0127", # self-assigning-variable / ruff PLW0127
   "W0129", # assert-on-string-literal / ruff PLW0129
-  # "W0160", # consider-ternary-expression / ruff SIM108
+  "W0130", # duplicate-value / ruff B033
+  "W0131", # named-expr-without-context / ruff PLW0131
+  "W0133", # pointless-exception-statement / ruff PLW0133
+  "W0150", # lost-exception / ruff B012
+  "W0160", # consider-ternary-expression / ruff SIM108
+  "W0177", # nan-comparison / ruff PLW0177
   "W0199", # assert-on-tuple / ruff F631
+  "W0211", # bad-staticmethod-argument / ruff PLW0211
+  "W0212", # protected-access / ruff SLF001
+  "W0245", # super-without-brackets / ruff PLW0245
+  "W0301", # unnecessary-semicolon / ruff E703
+  "W0311", # bad-indentation / ruff E111
   "W0401", # wildcard-import / ruff F403
+  "W0404", # reimported / ruff F811
   "W0406", # import-self / ruff PLW0406
   "W0410", # misplaced-future / ruff F404
+  "W0511", # fixme / ruff PLW0511
   "W0602", # global-variable-not-assigned / ruff PLW0602
   "W0603", # global-statement / ruff PLW0603
+  "W0604", # global-at-module-level / ruff PLW0604
   "W0611", # unused-import / ruff F401
   "W0612", # unused-variable / ruff F841
   "W0613", # unused-argument / ruff ARG001
@@ -223,19 +308,40 @@ disable = [
   "W0640", # cell-var-from-loop / ruff B023
   "W0702", # bare-except / ruff E722
   "W0705", # duplicate-except / ruff B014
+  "W0706", # try-except-raise / ruff TRY302
+  "W0707", # raise-missing-from / ruff B904
   "W0711", # binary-op-exception / ruff PLW0711
-  "W0718", # broad-exception-caught / ruff PLW0718
-  "W1300", # bad-format-string-key / ruff PLW1300
+  "W0718", # broad-exception-caught / ruff BLE001
+  "W0719", # broad-exception-raised / ruff TRY002
+  "W1113", # keyword-arg-before-vararg / ruff B026
+  "W1201", # logging-not-lazy / ruff G002
+  "W1202", # logging-format-interpolation / ruff G001
+  "W1203", # logging-fstring-interpolation / ruff G004
   "W1301", # unused-format-string-key / ruff F504
-  "W1302", # bad-format-string / ruff PLW1302
+  "W1302", # bad-format-string / ruff F521
+  "W1303", # missing-format-argument-key / ruff F524
   "W1304", # unused-format-string-argument / ruff F507
-  "W1308", # duplicate-string-formatting-argument / ruff PLW1308
+  "W1305", # format-combined-specification / ruff F525
   "W1309", # f-string-without-interpolation / ruff F541
-  "W1310", # format-string-without-interpolation / ruff PLW1310
+  "W1310", # format-string-without-interpolation / ruff F541
   "W1401", # anomalous-backslash-in-string / ruff W605
+  "W1404", # implicit-str-concat / ruff ISC001
   "W1405", # inconsistent-quotes / ruff Q000
+  "W1406", # redundant-u-string-prefix / ruff UP025
+  "W1501", # bad-open-mode / ruff PLW1501
   "W1508", # invalid-envvar-default / ruff PLW1508
-  "W1515" # forgotten-debug-statement / ruff T100
+  "W1509", # subprocess-popen-preexec-fn / ruff PLW1509
+  "W1510", # subprocess-run-check / ruff PLW1510
+  "W1514", # unspecified-encoding / ruff PLW1514
+  "W1515", # forgotten-debug-statement / ruff T100
+  "W1518", # method-cache-max-size-none / ruff B019
+  "W1641", # eq-without-hash / ruff PLW1641
+  "W2101", # useless-with-lock / ruff PLW2101
+  "W2301", # unnecessary-ellipsis / ruff PLW2301
+  "W2402", # non-ascii-file-name / ruff N999
+  "W2901", # redefined-loop-name / ruff PLW2901
+  "W3201", # bad-dunder-name / ruff PLW3201
+  "W3301" # nested-min-max / ruff PLW3301
 ]
 enable = [
   "useless-suppression" # Identify unneeded pylint disable statements
@@ -282,10 +388,6 @@ ignore = [
   'ARG005', # Unused lambda argument: `args`
   'B006', # Do not use mutable data structures for argument defaults
   'C901', # `_params_row_for_entry` is too complex (11 > 10)
-  'D100', # Missing docstring in public module
-  'D101', # Missing docstring in public class
-  'D102', # Missing docstring in public method
-  'D103', # Missing docstring in public function
   'FBT001', # Boolean positional arg in function definition
   'FBT002', # Boolean default value in function definition
   'FBT003', # Boolean positional value in function call
@@ -328,9 +430,10 @@ lines-between-types = 1 # Separate import/from with 1 line
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["SLF001", "S101", "S602"]
 "tests/integration/actions/collections/__init__.py" = ["A005"]
+"src/ansible_navigator/tm_tokenize/*" = ["D100", "D101", "D102", "D103"]
 
 [tool.ruff.lint.pydocstyle]
-convention = "pep257"
+convention = "google"
 
 [tool.setuptools.dynamic]
 dependencies = {file = [".config/requirements.in"]}

--- a/src/ansible_navigator/action_runner.py
+++ b/src/ansible_navigator/action_runner.py
@@ -80,7 +80,6 @@ class ActionRunner(ActionBase):
         )
 
     def run(self, _screen: Window) -> None:
-        # pylint: disable=protected-access
         """Run the app.
 
         Initialize the UI.

--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -668,7 +668,6 @@ class Action(ActionBase):
         return plugins_details
 
     def _parse_collection_info_stdout(self) -> dict[str, Any]:
-        # pylint: disable=too-many-nested-blocks
         """Parse collection information from catalog collection cache.
 
         Returns:

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -385,7 +385,7 @@ class Action(ActionBase):
                     menu_entry["__taxonomy"] = taxonomy
                     menu_entry["__type"] = "group"
                     if hosts:
-                        menu_entry.update({c: "" for c in self._show_columns})
+                        menu_entry.update(dict.fromkeys(self._show_columns, ""))
                     menu.append(menu_entry)
 
             return Step(

--- a/src/ansible_navigator/actions/select.py
+++ b/src/ansible_navigator/actions/select.py
@@ -1,5 +1,3 @@
-# noqa: A005
-
 """Menu selection implementation.
 
 Processor of a menu selection from a numeric key press

--- a/src/ansible_navigator/configuration_subsystem/defs_presentable.py
+++ b/src/ansible_navigator/configuration_subsystem/defs_presentable.py
@@ -10,6 +10,8 @@ from typing import ClassVar
 from typing import NewType
 from typing import TypeVar
 
+from typing_extensions import Self
+
 from ansible_navigator.content_defs import ContentBase
 
 from .definitions import CliParameters
@@ -41,10 +43,10 @@ class PresentableCliParameters:
 
     @classmethod
     def from_cli_params(
-        cls: type[CliT],
+        cls,
         cli_parameters: CliParameters | None,
         name_dashed: str,
-    ) -> CliT:
+    ) -> Self:
         """Create an ``_HRCliParameters`` based on an entry's cli parameters.
 
         Args:
@@ -117,11 +119,11 @@ class PresentableSettingsEntry(ContentBase[Any]):
 
     @classmethod
     def for_settings_file(
-        cls: type[EntT],
+        cls,
         all_subcommands: list[str],
         application_name: str,
         internals: Internals,
-    ) -> EntT:
+    ) -> Self:
         """Create an ``PresentableSettingsEntry`` containing the details for the settings file.
 
         Args:
@@ -154,12 +156,12 @@ class PresentableSettingsEntry(ContentBase[Any]):
 
     @classmethod
     def from_settings_entry(
-        cls: type[EntT],
+        cls,
         all_subcommands: list[str],
         application_name_dashed: str,
         entry: SettingsEntry,
         settings_file_path: str,
-    ) -> EntT:
+    ) -> Self:
         """Create an ``PresentableSettingsEntry`` containing the details for one settings entry.
 
         Args:

--- a/src/ansible_navigator/configuration_subsystem/defs_presentable.py
+++ b/src/ansible_navigator/configuration_subsystem/defs_presentable.py
@@ -10,8 +10,6 @@ from typing import ClassVar
 from typing import NewType
 from typing import TypeVar
 
-from typing_extensions import Self
-
 from ansible_navigator.content_defs import ContentBase
 
 from .definitions import CliParameters
@@ -46,7 +44,7 @@ class PresentableCliParameters:
         cls,
         cli_parameters: CliParameters | None,
         name_dashed: str,
-    ) -> Self:
+    ) -> PresentableCliParameters:
         """Create an ``_HRCliParameters`` based on an entry's cli parameters.
 
         Args:
@@ -123,7 +121,7 @@ class PresentableSettingsEntry(ContentBase[Any]):
         all_subcommands: list[str],
         application_name: str,
         internals: Internals,
-    ) -> Self:
+    ) -> PresentableSettingsEntry:
         """Create an ``PresentableSettingsEntry`` containing the details for the settings file.
 
         Args:
@@ -161,7 +159,7 @@ class PresentableSettingsEntry(ContentBase[Any]):
         application_name_dashed: str,
         entry: SettingsEntry,
         settings_file_path: str,
-    ) -> Self:
+    ) -> PresentableSettingsEntry:
         """Create an ``PresentableSettingsEntry`` containing the details for one settings entry.
 
         Args:

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -80,7 +80,6 @@ PostProcessorReturn = tuple[list[LogMessage], list[ExitMessage]]
 
 
 class NavigatorPostProcessor:
-    # pylint:disable=too-many-public-methods
     """Application post processor."""
 
     def __init__(self) -> None:

--- a/src/ansible_navigator/data/catalog_collections.py
+++ b/src/ansible_navigator/data/catalog_collections.py
@@ -622,7 +622,6 @@ def run_command(cmd: list[str]) -> dict[str, str]:
 
 
 def main() -> dict[Any, Any]:
-    # pylint: disable=protected-access
     # pylint: disable=possibly-used-before-assignment
     """Run the collection catalog process.
 

--- a/src/ansible_navigator/tm_tokenize/compiler.py
+++ b/src/ansible_navigator/tm_tokenize/compiler.py
@@ -50,18 +50,17 @@ class Compiler:
     ) -> tuple[list[str], tuple[_Rule, ...]]:
         if s == "$self":
             return self._patterns(grammar, grammar.patterns)
-        elif s == "$base":
+        if s == "$base":
             grammar = self._grammars.grammar_for_scope(self._root_scope)
             return self._include(grammar, grammar.repository, "$self")
-        elif s.startswith("#"):
+        if s.startswith("#"):
             return self._patterns(grammar, (repository[s[1:]],))
-        elif "#" not in s:
+        if "#" not in s:
             grammar = self._grammars.grammar_for_scope(s)
             return self._include(grammar, grammar.repository, "$self")
-        else:
-            scope, _, s = s.partition("#")
-            grammar = self._grammars.grammar_for_scope(scope)
-            return self._include(grammar, grammar.repository, f"#{s}")
+        scope, _, s = s.partition("#")
+        grammar = self._grammars.grammar_for_scope(scope)
+        return self._include(grammar, grammar.repository, f"#{s}")
 
     @functools.cache  # noqa: B019
     def _patterns(
@@ -103,7 +102,7 @@ class Compiler:
         if rule.match is not None:
             captures_ref = self._captures_ref(grammar, rule.captures)
             return MatchRule(rule.name, captures_ref)
-        elif rule.begin is not None and rule.end is not None:
+        if rule.begin is not None and rule.end is not None:
             regs, rules = self._patterns(grammar, rule.patterns)
             return EndRule(
                 rule.name,
@@ -114,7 +113,7 @@ class Compiler:
                 make_regset(*regs),
                 rules,
             )
-        elif rule.begin is not None and rule.while_ is not None:
+        if rule.begin is not None and rule.while_ is not None:
             regs, rules = self._patterns(grammar, rule.patterns)
             return WhileRule(
                 rule.name,
@@ -125,9 +124,8 @@ class Compiler:
                 make_regset(*regs),
                 rules,
             )
-        else:
-            regs, rules = self._patterns(grammar, rule.patterns)
-            return PatternRule(rule.name, make_regset(*regs), rules)
+        regs, rules = self._patterns(grammar, rule.patterns)
+        return PatternRule(rule.name, make_regset(*regs), rules)
 
     def compile_rule(self, rule: _Rule) -> CompiledRule:
         try:

--- a/src/ansible_navigator/tm_tokenize/grammars.py
+++ b/src/ansible_navigator/tm_tokenize/grammars.py
@@ -54,7 +54,7 @@ class Grammars:
             Path(filename).stem: Path(directory) / filename
             for directory in directories
             if Path(directory).exists()
-            for filename in sorted(os.listdir(directory))
+            for filename in sorted(os.listdir(directory))  # noqa: PTH208
             if filename.endswith(".json")
         }
 

--- a/src/ansible_navigator/tm_tokenize/rules.py
+++ b/src/ansible_navigator/tm_tokenize/rules.py
@@ -31,8 +31,7 @@ Captures = tuple[tuple[int, "_Rule"], ...]  # declared later
 def _split_name(s: str | None) -> tuple[str, ...]:
     if s is None:
         return ()
-    else:
-        return tuple(s.split())
+    return tuple(s.split())
 
 
 class CompiledRule(Protocol):
@@ -176,15 +175,13 @@ class EndRule(NamedTuple):
         end_match = state.cur.reg.search(line, pos, first_line, boundary)
         if end_match is not None and end_match.start() == pos:
             return self._end_ret(compiler, state, pos, end_match)
-        elif end_match is None:
+        if end_match is None:
             idx, match = self.regset.search(line, pos, first_line, boundary)
             return do_regset(idx, match, self, compiler, state, pos)
-        else:
-            idx, match = self.regset.search(line, pos, first_line, boundary)
-            if match is None or end_match.start() <= match.start():
-                return self._end_ret(compiler, state, pos, end_match)
-            else:
-                return do_regset(idx, match, self, compiler, state, pos)
+        idx, match = self.regset.search(line, pos, first_line, boundary)
+        if match is None or end_match.start() <= match.start():
+            return self._end_ret(compiler, state, pos, end_match)
+        return do_regset(idx, match, self, compiler, state, pos)
 
 
 @uniquely_constructed

--- a/src/ansible_navigator/tm_tokenize/tokenize.py
+++ b/src/ansible_navigator/tm_tokenize/tokenize.py
@@ -1,4 +1,4 @@
-from __future__ import annotations  # noqa: A005
+from __future__ import annotations
 
 from typing import TYPE_CHECKING
 

--- a/src/ansible_navigator/ui_framework/form.py
+++ b/src/ansible_navigator/ui_framework/form.py
@@ -200,16 +200,15 @@ class FormPresenter(CursesWindow):
 
             elif isinstance(form_field, FieldInformation):
                 information_lines = self._generate_information(form_field)
-                for line in information_lines:
+                for line in information_lines:  # pylint: disable=not-an-iterable
                     lines.append((self._line_number, line))
                     self._line_number += 1
 
             elif isinstance(form_field, FieldWorking):
                 message_lines = self._generate_messages(form_field)
-                for line in message_lines:
+                for line in message_lines:  # pylint: disable=not-an-iterable
                     lines.append((self._line_number, line))
                     self._line_number += 1
-            # pylint: enable=not-an-iterable
 
             elif isinstance(form_field, FieldText):
                 prompt = self._generate_prompt(form_field)

--- a/src/ansible_navigator/ui_framework/form_handler_options.py
+++ b/src/ansible_navigator/ui_framework/form_handler_options.py
@@ -58,7 +58,6 @@ class FormHandlerOptions(CursesWindow):
             )
 
     def handle(self, idx: int, form_fields: list[FieldText]) -> tuple[FieldText, int]:
-        # pylint: disable=too-many-nested-blocks
         """Handle the check box field.
 
         Args:

--- a/src/ansible_navigator/ui_framework/form_utils.py
+++ b/src/ansible_navigator/ui_framework/form_utils.py
@@ -45,7 +45,7 @@ def dict_to_form(form_data: dict[str, Any]) -> Form:
     else:
         form = Form(type_=FormType.FORM)
 
-    form._dict = form_data  # pylint: disable=protected-access  # noqa: SLF001
+    form._dict = form_data  # noqa: SLF001
     form.title = form_data["title"]
     form.title_color = form_data.get("title_color", 0)
 
@@ -110,7 +110,7 @@ def form_to_dict(form: Form, key_on_name: bool = False) -> dict[str, Any]:
     Returns:
         form as type dict
     """
-    res = form._dict  # pylint: disable=protected-access  # noqa: SLF001
+    res = form._dict  # noqa: SLF001
     res["cancelled"] = form.cancelled
     res["submitted"] = form.submitted
     for field_idx, field in enumerate(form.fields):

--- a/src/ansible_navigator/utils/key_value_store.py
+++ b/src/ansible_navigator/utils/key_value_store.py
@@ -80,7 +80,8 @@ class KeyValueStore(MutableMapping[str, str]):
     def iterkeys(self) -> Iterator[str]:
         """Yield keys from the key-value store one by one.
 
-        :yields: The keys in the key-value store
+        Yields:
+            The keys in the key-value store
         """
         cursor = self.conn.cursor()
         for row in cursor.execute("SELECT key FROM kv"):
@@ -89,7 +90,8 @@ class KeyValueStore(MutableMapping[str, str]):
     def itervalues(self) -> Iterator[str]:
         """Yield values from the key-value store one by one.
 
-        :yields: The values in the key-value store
+        Yields:
+            The values in the key-value store
         """
         cursor = self.conn.cursor()
         for row in cursor.execute("SELECT value FROM kv"):
@@ -98,7 +100,8 @@ class KeyValueStore(MutableMapping[str, str]):
     def iteritems(self) -> Iterator[tuple[str, str]]:
         """Yield items from the key-value store one by one.
 
-        :yields: The key-value store as items (key, value)
+        Yields:
+            The key-value store as items (key, value)
         """
         cursor = self.conn.cursor()
         for row in cursor.execute("SELECT key, value FROM kv"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,7 +124,9 @@ def locked_directory(tmpdir: str) -> Generator[str]:
 
     Args:
         tmpdir: Fixture for temporary directory
-    :yields: The temporary directory
+
+    Yields:
+        The temporary directory
     """
     Path(tmpdir).chmod(0o000)
     yield tmpdir
@@ -137,7 +139,9 @@ def pullable_image(valid_container_engine: str) -> Generator[str]:
 
     Args:
         valid_container_engine: Fixture for a valid container engine
-    :yields: The image name
+
+    Yields:
+        The image name
     """
     image = ImageEntry.PULLABLE_IMAGE.get(app_name=APP_NAME)
     yield image
@@ -328,7 +332,8 @@ def _cmd_in_tty(
 def cmd_in_tty() -> Generator[Callable[..., tuple[str, str, int]]]:
     """Provide the cmd in tty function as a fixture.
 
-    :yields: The cmd_in_tty function
+    Yields:
+        The cmd_in_tty function
     """
     yield _cmd_in_tty
 

--- a/tests/integration/_common.py
+++ b/tests/integration/_common.py
@@ -230,7 +230,7 @@ def copytree(
     Raises:
         Error: If an error occurs
     """
-    names = os.listdir(src)
+    names = os.listdir(src)  # noqa: PTH208
     ignored_names = ignore(src, names) if ignore is not None else set()
 
     dst.mkdir(parents=True, exist_ok=dirs_exist_ok)

--- a/tests/integration/actions/builder/base.py
+++ b/tests/integration/actions/builder/base.py
@@ -36,7 +36,9 @@ class BaseClass:
 
         Args:
             request: A fixture providing details about the test caller
-        :yields: A tmux session
+
+        Yields:
+            A tmux session
         """
         with TmuxSession(
             setup_commands=["export ANSIBLE_CACHE_PLUGIN_TIMEOUT=42", "export PAGER=cat"],
@@ -59,6 +61,7 @@ class BaseClass:
             request: A fixture providing details about the test caller
             tmux_session: The tmux session to use
             step: The commands to issue and content to look for
+            skip_if_already_failed: Fixture that stops parametrized tests running on first failure.
 
         Raises:
             ValueError: When the test mode is not set

--- a/tests/integration/actions/collections/base.py
+++ b/tests/integration/actions/collections/base.py
@@ -102,7 +102,9 @@ class BaseClass:
         Args:
             request: The request for this fixture
             os_independent_tmp: An OS independent tmp directory
-        :yields: A tmux session
+
+        Yields:
+            A tmux session
         """
         tmp_coll_dir = Path(os_independent_tmp) / request.node.name / ""
         Path(tmp_coll_dir).mkdir(parents=True, exist_ok=True)
@@ -141,6 +143,7 @@ class BaseClass:
             request: The request for this fixture
             step: The UI test step
             tmux_session: A tmux session
+            skip_if_already_failed: Fixture that stops parametrized tests running on first failure.
 
         Raises:
             ValueError: If test mode is not set

--- a/tests/integration/actions/config/base.py
+++ b/tests/integration/actions/config/base.py
@@ -57,7 +57,9 @@ class BaseClass:
 
         Args:
             request: A fixture providing details about the test caller
-        :yields: A tmux session
+
+        Yields:
+            A tmux session
         """
         with TmuxSession(
             setup_commands=["export ANSIBLE_CACHE_PLUGIN_TIMEOUT=42", "export PAGER=cat"],
@@ -81,6 +83,7 @@ class BaseClass:
             request: A fixture providing details about the test caller
             tmux_session: The tmux session to use
             step: The commands to issue and content to look for
+            skip_if_already_failed: Fixture that stops parametrized tests running on first failure.
 
         Raises:
             ValueError: When the test mode is not set

--- a/tests/integration/actions/doc/base.py
+++ b/tests/integration/actions/doc/base.py
@@ -34,7 +34,9 @@ class BaseClass:
 
         Args:
             request: A fixture providing details about the test caller
-        :yields: Tmux session
+
+        Yields:
+            A tmux session
         """
         with TmuxSession(
             pane_height=2000,
@@ -71,6 +73,7 @@ class BaseClass:
             comment: Comment to add to the fixture
             testname: Name of test
             expected_in_output: A list of strings or string to find
+            skip_if_already_failed: Fixture that stops parametrized tests running on first failure.
 
         Raises:
             ValueError: When the test mode is not set

--- a/tests/integration/actions/doc/test_stdout_subprocess.py
+++ b/tests/integration/actions/doc/test_stdout_subprocess.py
@@ -122,6 +122,7 @@ def test(
         data: The test data
         exec_env: Whether to use the exec environment
         cmd_in_tty: The tty command runner
+        skip_if_already_failed: Fixture that stops parametrized tests running on first failure.
 
     Raises:
         AssertionError: When test fails

--- a/tests/integration/actions/exec/base.py
+++ b/tests/integration/actions/exec/base.py
@@ -44,7 +44,9 @@ class BaseClass:
 
         Args:
             request: The request for this fixture
-        :yields: A tmux session
+
+        Yields:
+            A tmux session
         """
         params: TmuxSessionKwargs = {
             "request": request,
@@ -71,6 +73,7 @@ class BaseClass:
             request: The test request
             tmux_session: The tmux session
             step: A step within a series of tests
+            skip_if_already_failed: Fixture that stops parametrized tests running on first failure.
 
         Raises:
             ValueError: If test mode isn't set

--- a/tests/integration/actions/images/base.py
+++ b/tests/integration/actions/images/base.py
@@ -68,7 +68,9 @@ class BaseClass:
 
         Args:
             request: A fixture providing details about the test caller
-        :yields: Tmux session
+
+        Yields:
+            Tmux session
         """
         with TmuxSession(request=request) as tmux_session:
             yield tmux_session
@@ -86,6 +88,7 @@ class BaseClass:
             request: A fixture providing details about the test caller
             tmux_session: The tmux session to use
             step: Step index to use
+            skip_if_already_failed: Fixture that stops parametrized tests running on first failure.
 
         Raises:
             ValueError: When the test mode is not set

--- a/tests/integration/actions/inventory/base.py
+++ b/tests/integration/actions/inventory/base.py
@@ -64,7 +64,9 @@ class BaseClass:
 
         Args:
             request: A fixture providing details about the test caller
-        :yields: Tmux session
+
+        Yields:
+            Tmux session
         """
         with TmuxSession(
             setup_commands=[
@@ -91,6 +93,7 @@ class BaseClass:
             request: A fixture providing details about the test caller
             tmux_session: The tmux session to use
             step: Step index to use
+            skip_if_already_failed: Fixture that stops parametrized tests running on first failure.
 
         Raises:
             ValueError: When the test mode is not set

--- a/tests/integration/actions/lint/base.py
+++ b/tests/integration/actions/lint/base.py
@@ -37,7 +37,9 @@ class BaseClass:
 
         Args:
             request: Pytest request object
-        :yields: TmuxSession object
+
+        Yields:
+            TmuxSession object
         """
         params: TmuxSessionKwargs = {
             "request": request,
@@ -58,6 +60,7 @@ class BaseClass:
             request: Pytest request object
             tmux_session: TmuxSession fixture
             step: UiTestStep object
+            skip_if_already_failed: Fixture that stops parametrized tests running on first failure.
         """
         search_within_response: str | list[str]
         if step.search_within_response is SearchFor.HELP:

--- a/tests/integration/actions/replay/base.py
+++ b/tests/integration/actions/replay/base.py
@@ -31,7 +31,9 @@ class BaseClass:
 
         Args:
             request: A fixture providing details about the test caller
-        :yields: Tmux session
+
+        Yields:
+            Tmux session
         """
         with TmuxSession(
             config_path=Path(TEST_CONFIG_FILE),

--- a/tests/integration/actions/run/base.py
+++ b/tests/integration/actions/run/base.py
@@ -60,7 +60,9 @@ class BaseClass:
 
         Args:
             request: A fixture providing details about the test caller
-        :yields: A tmux session
+
+        Yields:
+            A tmux session
         """
         params: TmuxSessionKwargs = {
             "pane_height": 1000,
@@ -87,6 +89,7 @@ class BaseClass:
             request: A fixture providing details about the test caller
             tmux_session: The tmux session to use
             step: The commands to issue and content to look for
+            skip_if_already_failed: Fixture that stops parametrized tests running on first failure.
         """
         search_within_response: str | list[str]
         if step.search_within_response is SearchFor.HELP:

--- a/tests/integration/actions/run_unicode/base.py
+++ b/tests/integration/actions/run_unicode/base.py
@@ -53,7 +53,9 @@ class BaseClass:
 
         Args:
             request: The request for this fixture from a test
-        :yields: A tmux session
+
+        Yields:
+            A tmux session
         """
         params: TmuxSessionKwargs = {
             "pane_height": 100,
@@ -79,6 +81,7 @@ class BaseClass:
             request: The request for a test
             tmux_session: The tmux session
             step: A step within a series of tests
+            skip_if_already_failed: Fixture that stops parametrized tests running on first failure.
         """
         search_within_response: str | list[str]
         if step.search_within_response is SearchFor.HELP:

--- a/tests/integration/actions/settings/base.py
+++ b/tests/integration/actions/settings/base.py
@@ -55,7 +55,9 @@ class BaseClass:
 
         Args:
             request: Used for generating test id
-        :yields: tmux_session object
+
+        Yields:
+            tmux_session object
         """
         with TmuxSession(
             setup_commands=[
@@ -82,6 +84,8 @@ class BaseClass:
             request: Used for generating test id
             tmux_session: tmux_session object
             step: UiTestStep object
+            skip_if_already_failed: Fixture that stops parametrized tests running on first failure.
+
 
         Raises:
             ValueError: If HELP or PROMPT aren't found

--- a/tests/integration/actions/stdout/base.py
+++ b/tests/integration/actions/stdout/base.py
@@ -32,7 +32,9 @@ class BaseClass:
 
         Args:
             request: A fixture providing details about the test caller
-        :yields: Tmux session
+
+        Yields:
+            Tmux session
         """
         params: TmuxSessionKwargs = {
             "config_path": Path(TEST_CONFIG_FILE),
@@ -66,6 +68,7 @@ class BaseClass:
             user_input: Value to send to the tmux session
             comment: Comment to add to the fixture
             search_within_response: A list of strings or string to find
+            skip_if_already_failed: Fixture that stops parametrized tests running on first failure.
         """
         assert ANSIBLE_PLAYBOOK.exists()
         assert TEST_CONFIG_FILE.exists()

--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -76,7 +76,9 @@ class BaseClass:
 
         Args:
             request: A fixture providing details about the test caller
-        :yields: A tmux session
+
+        Yields:
+            A tmux session
         """
         params: TmuxSessionKwargs = {
             "pane_height": 1000,
@@ -104,6 +106,7 @@ class BaseClass:
             request: A fixture providing details about the test caller
             tmux_session: The tmux session to use
             step: The commands to issue and content to look for
+            skip_if_already_failed: Fixture that stops parametrized tests running on first failure.
         """
         search_within_response: str | list[str]
         if step.search_within_response is SearchFor.HELP:

--- a/tests/integration/diagnostics/test_from_cli.py
+++ b/tests/integration/diagnostics/test_from_cli.py
@@ -29,6 +29,7 @@ def test(
         monkeypatch: Fixture for patching
         settings_env_var_to_full: The pytest subtest fixture
         tmp_path: The pytest tmp_path fixture
+        skip_if_already_failed: Fixture that stops parametrized tests running on first failure.
 
     Raises:
         AssertionError: When tests fails

--- a/tests/unit/actions/run/test_runner_async.py
+++ b/tests/unit/actions/run/test_runner_async.py
@@ -143,8 +143,8 @@ def test_runner_args(mocker: MockerFixture, data: Scenario) -> None:
     )
 
     run = action(args=args)
-    run._queue = TEST_QUEUE  # pylint: disable=protected-access
+    run._queue = TEST_QUEUE
     with pytest.raises(TestRunnerError):
-        run._run_runner()  # pylint: disable=protected-access
+        run._run_runner()
 
     command_async.assert_called_once_with(**data.expected)

--- a/tests/unit/actions/test_config.py
+++ b/tests/unit/actions/test_config.py
@@ -107,7 +107,6 @@ def test_parse_and_merge(
     dump_output: str,
     expected_config: list[str],
 ) -> None:
-    # pylint: disable=protected-access
     """Test _parse_and_merge method of config class."""
     args = deepcopy(NavigatorConfiguration)
     run_action = action(args=args)

--- a/tests/unit/configuration_subsystem/test_mode_subcommand_action.py
+++ b/tests/unit/configuration_subsystem/test_mode_subcommand_action.py
@@ -14,9 +14,6 @@ from ansible_navigator.configuration_subsystem.navigator_post_processor import (
 )
 
 
-# pylint: disable=protected-access
-
-
 def test_import_error() -> None:
     """Ensure an error for invalid action_package."""
     test_config = ApplicationConfiguration(

--- a/tests/unit/configuration_subsystem/test_presentable.py
+++ b/tests/unit/configuration_subsystem/test_presentable.py
@@ -82,9 +82,12 @@ def test_settings_file_entry(
         settings_file_dict: The expected settings as a dictionary
     """
     configurator = Configurator(params=[], application_configuration=sample_settings)
-    configurator._post_process()  # pylint: disable=protected-access
+    configurator._post_process()
     presentable = to_presentable(sample_settings)
-    assert all(isinstance(p, PresentableSettingsEntry) for p in presentable)
+    assert all(
+        isinstance(p, PresentableSettingsEntry)
+        for p in presentable  # pylint: disable=not-an-iterable
+    )
     assert asdict(presentable[0]) == settings_file_dict
 
 
@@ -112,9 +115,12 @@ def test_settings_entry(
     )
     sample_settings.entries = [entry]
     configurator = Configurator(params=[], application_configuration=sample_settings)
-    configurator._post_process()  # pylint: disable=protected-access
+    configurator._post_process()
     presentable = to_presentable(sample_settings)
-    assert all(isinstance(p, PresentableSettingsEntry) for p in presentable)
+    assert all(
+        isinstance(p, PresentableSettingsEntry)
+        for p in presentable  # pylint: disable=not-an-iterable
+    )
     assert asdict(presentable[0]) == settings_file_dict
     entry_dict = {
         "choices": ["choice_1", "choice_2"],

--- a/tests/unit/configuration_subsystem/test_sample_configurations.py
+++ b/tests/unit/configuration_subsystem/test_sample_configurations.py
@@ -19,9 +19,6 @@ from ansible_navigator.configuration_subsystem.navigator_post_processor import (
 from ansible_navigator.configuration_subsystem.parser import Parser
 
 
-# pylint: disable=protected-access
-
-
 def test_cmdline_source_not_set() -> None:
     """Ensure a configuration without a ``subparser`` entry fails."""
     test_config = ApplicationConfiguration(

--- a/tests/unit/image_manager/test_image_puller.py
+++ b/tests/unit/image_manager/test_image_puller.py
@@ -180,8 +180,8 @@ def test_tag_parsing(image: str, expected_tag: str) -> None:
         arguments=Constants.NOT_SET,
         pull_policy="tag",
     )
-    image_puller._extract_tag()  # pylint: disable=protected-access
-    assert image_puller._image_tag == expected_tag  # pylint: disable=protected-access
+    image_puller._extract_tag()
+    assert image_puller._image_tag == expected_tag
 
 
 def test_pull_with_args() -> None:
@@ -192,7 +192,7 @@ def test_pull_with_args() -> None:
         arguments=["--tls-verify false"],
         pull_policy="tag",
     )
-    result = image_puller._generate_pull_command()  # pylint: disable=protected-access
+    result = image_puller._generate_pull_command()
     expected_string = "podman pull --tls-verify false my_image"
     assert result == expected_string
     expected_list = ["podman", "pull", "--tls-verify", "false", "my_image"]
@@ -207,7 +207,7 @@ def test_pull_with_env_arg() -> None:
         arguments=["--authfile", "${XDG_RUNTIME_DIR}/containers/auth.json"],
         pull_policy="tag",
     )
-    result = image_puller._generate_pull_command()  # pylint: disable=protected-access
+    result = image_puller._generate_pull_command()
     cmd_to_run = f"echo {result}"
     proc = subprocess.run(
         cmd_to_run,

--- a/tests/unit/test_circular_imports.py
+++ b/tests/unit/test_circular_imports.py
@@ -58,7 +58,9 @@ def _discover_path_importables(
     Args:
         pkg_pth: The path to the package to walk
         pkg_name: The name of the package
-    :yields: Package directory paths
+
+    Yields:
+        Package directory paths
     """
     for dir_path, _dir_names, file_names in os.walk(pkg_pth):
         pkg_dir_path = Path(dir_path)

--- a/tests/unit/ui_framework/test_progress_bar.py
+++ b/tests/unit/ui_framework/test_progress_bar.py
@@ -55,7 +55,7 @@ def test_dataclass_running() -> None:
     test_data = ContentTest(progress="30%")
     convert_percentage(content=test_data, columns=["progress"], progress_bar_width=10)
     assert test_data.progress == "▇▇▇       "
-    assert test_data._progress == "30%"  # pylint: disable=protected-access
+    assert test_data._progress == "30%"
     assert test_data.other == "test_value"
 
 
@@ -64,5 +64,5 @@ def test_dataclass_complete() -> None:
     test_data = ContentTest(progress="100%")
     convert_percentage(content=test_data, columns=["progress"], progress_bar_width=10)
     assert test_data.progress == " Complete "
-    assert test_data._progress == "100%"  # pylint: disable=protected-access
+    assert test_data._progress == "100%"
     assert test_data.other == "test_value"

--- a/tests/unit/utils/conftest.py
+++ b/tests/unit/utils/conftest.py
@@ -14,7 +14,9 @@ def empty_kvs(tmp_path: Path) -> Generator[KeyValueStore, None, None]:
 
     Args:
         tmp_path: Path to a temporary directory
-    :yields: The temporary KVS
+
+    Yields:
+        The temporary KVS
     """
     database_path = tmp_path / "basic_kvs_usage.db"
     yield KeyValueStore(database_path)
@@ -26,7 +28,9 @@ def kvs(tmp_path: Path) -> Generator[KeyValueStore, None, None]:
 
     Args:
         tmp_path: Path to a temporary directory
-    :yields: The temporary KVS
+
+    Yields:
+        The temporary KVS
     """
     database_path = tmp_path / "basic_kvs_usage.db"
     key_value_store = KeyValueStore(database_path)


### PR DESCRIPTION
- Change ruff doc style to google
- Update ruff to latest in precommit
- Update pylint disable based on latest ruff version
- Remove unneeded supression for newly disabled pylint messages
- Fix new ruff messages since upgrade
- Move ruff DOC disable into perfile for only tm_tokenize directory
- Add some missing docstring attributes
- Replace `:yields:1 docstring entries for google style
- Disable yield type checking for pydoclint
- Update pydoclint baseline based on changes
- Allow ruff to fix new fixables in latest version