### PR TITLE
Fix the lint subcommand failure: (KeyError: 'lines')

### DIFF
--- a/src/ansible_navigator/actions/lint.py
+++ b/src/ansible_navigator/actions/lint.py
@@ -179,8 +179,13 @@ def massage_issue(issue: dict[Any, Any]) -> dict[Any, Any]:
     else:
         massaged["__message"] = issue["description"]
     massaged["__path"] = expand_path(issue["location"]["path"])
-    if isinstance(issue["location"]["lines"]["begin"], Mapping):
+    if "lines" in issue["location"] and isinstance(issue["location"]["lines"]["begin"], Mapping):
         massaged["__line"] = issue["location"]["lines"]["begin"]["line"]
+    elif "positions" in issue["location"] and isinstance(
+        issue["location"]["positions"]["begin"],
+        Mapping,
+    ):
+        massaged["__line"] = issue["location"]["positions"]["begin"]
     else:
         massaged["__line"] = issue["location"]["lines"]["begin"]
     massaged["issue_path"] = f"{massaged['__path']}:{massaged['__line']}"


### PR DESCRIPTION
### SUMMARY

**Affected navigator command -** `ansible-navigator lint tests/fixtures/integration/actions/lint`

**Problem -** In certain cases the 'location' dictionary contains a `positions` key instead of a `lines` key. This discrepancy raises a KeyError when trying to access issue["location"]["lines"]


**Fix -** The updated code now checks if the 'location' dictionary contains either the lines or positions key before attempting to access them. This prevents a `KeyError`

Related failures can be seen in these PRs: https://github.com/ansible/ansible-navigator/pull/1938, https://github.com/ansible/ansible-navigator/pull/1940