### PR TITLE
Log and ignore malformed plugin doc string.

### DIFF
--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -653,8 +653,14 @@ class Action(ActionBase):
                         short_name = plugin["doc"]["name"]
                     else:
                         short_name = plugin["doc"][plugin_type]
-                except KeyError:
+                except (KeyError, TypeError) as exc:
                     short_name = None
+                    self._logger.exception(
+                        "Error getting short name from plugin doc %s",
+                        plugin_docs["path"],
+                    )
+                    self._logger.debug("error was %s", str(exc))
+                    self._logger.debug(plugin)
                 if short_name is None:
                     plugin_docs["full_name"] = selected_collection["known_as"]
                 else:


### PR DESCRIPTION
Handle a case where the `doc` is a string and not a dictionary. 

Fixes: #1943 
Related: https://github.com/oVirt/ovirt-ansible-collection/issues/760

Here is the additional log information:

```
2025-04-08T14:34:37.777771+00:00 ERROR 'ansible_navigator.actions.collections._get_collection_plugins_details' Error getting short name from plugin doc /usr/share/ansible/collections/ansible_collections/redhat/rhv/plugins/test/ovirt_proxied_check.py
Traceback (most recent call last):
  File "/home/bthornto/github/ansible-navigator/src/ansible_navigator/actions/collections.py", line 655, in _get_collection_plugins_details
    short_name = plugin["doc"][plugin_type]
                 ~~~~~~~~~~~~~^^^^^^^^^^^^^
TypeError: string indices must be integers, not 'str'
2025-04-08T14:34:37.779031+00:00 DEBUG 'ansible_navigator.actions.collections._get_collection_plugins_details' error was string indices must be integers, not 'str'
2025-04-08T14:34:37.779118+00:00 DEBUG 'ansible_navigator.actions.collections._get_collection_plugins_details' {'doc': 'Check if un URL will be accessed through a proxy', 'examples': None, 'returndocs': None, 'metadata': None}
2025-04-08T14:34:37.909855+00:00 DEBUG 'ansible_navigator.runner.base.__del__' delete temporary ansible-runner private_data_dir at path /tmp/ansible-navigator_s9v1d7e6
```

