### PR TITLE
Enable junit.xml reporting to codecov.io

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,8 +37,8 @@ jobs:
   tox:
     name: ${{ matrix.name }} / python ${{ matrix.python_version }}
     permissions:
-      id-token: write
-      checks: read
+      id-token: write # codecov actions
+      checks: read # codecov actions
     runs-on: ubuntu-24.04
     needs: pre
     strategy:
@@ -101,6 +101,16 @@ jobs:
           path: |
             .tox/**/log/
             .tox/**/coverage.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && hashFiles('junit.xml') != '' }}
+        uses: codecov/test-results-action@v1
+        with:
+          fail_ci_if_error: true
+          name: ${{ matrix.name }}
+          # unable to use wildcards yet due to https://github.com/codecov/test-results-action/issues/110
+          flags: ${{ matrix.python_version }},${{ matrix.os }}
+          use_oidc: true
 
       - name: Change accessibility for cache
         if: ${{ startsWith(matrix.name, 'py') }}

--- a/.gitignore
+++ b/.gitignore
@@ -49,18 +49,19 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
+.cache
 .coverage
 .coverage.*
-.cache
-nosetests.xml
-coverage.xml
+.hypothesis/
+.nox/
+.pytest_cache/
+.tox/
 *.cover
 *.py,cover
-.hypothesis/
-.pytest_cache/
+coverage.xml
+htmlcov/
+junit.xml
+nosetests.xml
 
 # Translations
 *.mo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -361,6 +361,7 @@ filterwarnings = [
   "ignore::pytest.PytestUnraisableExceptionWarning",
   "ignore::DeprecationWarning:ansible_runner"
 ]
+junit_family = "legacy" # see https://docs.codecov.com/docs/test-analytics
 
 [tool.pytest_env]
 PYTEST_CHECK_TEST_DUPLICATE = 0

--- a/tools/report-coverage
+++ b/tools/report-coverage
@@ -1,0 +1,7 @@
+#!/bin/bash
+# cspell: ignore exuo
+set -exuo pipefail
+coverage combine -q "--data-file=${TOX_ENV_DIR}/.coverage" "${TOX_ENV_DIR}"/.coverage.*
+coverage xml "--data-file=${TOX_ENV_DIR}/.coverage" -o "${TOX_ENV_DIR}/coverage.xml" --ignore-errors --fail-under=0
+COVERAGE_FILE="${TOX_ENV_DIR}/.coverage" coverage lcov --fail-under=0 --ignore-errors -q
+COVERAGE_FILE="${TOX_ENV_DIR}/.coverage" coverage report --ignore-errors

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ allowlist_externals =
   rm
   sh
   pre-commit
+  ./tools/report-coverage
 package = editable
 extras =
   test
@@ -41,15 +42,11 @@ commands =
   # most coverage options are kept in pyproject.toml
   # pytest params are kept in pyproject.toml
   # if one wants to control parallelism define PYTEST_XDIST_AUTO_NUM_WORKERS
-  coverage run -m pytest {posargs:-n=auto --dist=loadfile --junitxml={envdir}/.coverage}
-  {py,py310,py311,py312,py313}: sh -c " \
-    coverage combine -q --data-file={envdir}/.coverage {envdir}/.coverage.* && \
-    coverage xml --data-file={envdir}/.coverage -o {envdir}/coverage.xml --ignore-errors --fail-under=0 && \
-    COVERAGE_FILE={envdir}/.coverage coverage lcov --fail-under=0 --ignore-errors -q && \
-    COVERAGE_FILE={envdir}/.coverage coverage report --ignore-errors \
-    "
-setenv =
-  COVERAGE_FILE = {env:COVERAGE_FILE:{envdir}/.coverage.{envname}}
+  coverage run -m pytest {posargs:-n=auto --dist=loadfile --junitxml=./junit.xml}
+commands_post =
+  {py,py310,py311,py312,py313}: ./tools/report-coverage
+set_env =
+  COVERAGE_FILE = {env:COVERAGE_FILE:{env_dir}/.coverage.{envname}}
   COVERAGE_PROCESS_START={toxinidir}/pyproject.toml
   FORCE_COLOR = 1
   PIP_CONSTRAINT = {toxinidir}/.config/constraints.txt
@@ -57,7 +54,7 @@ setenv =
   TERM = xterm-256color
   update-fixtures: ANSIBLE_NAVIGATOR_UPDATE_TEST_FIXTURES=true
   update-fixtures: PYTEEST_ADDOPST=--maxfail=0
-passenv =
+pass_env =
   ANSIBLE_NAVIGATOR_UPDATE_TEST_FIXTURES
   CI
   CONTAINER_*
@@ -89,6 +86,7 @@ setenv =
   PIP_CONSTRAINT = /dev/null
 commands =
   pip-compile -q --upgrade --no-annotate --all-extras --output-file=.config/constraints.txt --strip-extras pyproject.toml
+commands_post =
 
 [testenv:report]
 description = Produce coverage report
@@ -106,6 +104,7 @@ commands =
   pre-commit run {posargs:--show-diff-on-failure \
     --hook-stage manual \
     --all-files}
+commands_post =
 deps =
   pre-commit
   pre-commit-uv
@@ -129,7 +128,7 @@ deps =
   ansible-core
 commands =
   python3 -m unittest tests/smoke/no_test_dependencies.py
-
+commands_post =
 
 [testenv:docs]
 deps =
@@ -140,8 +139,9 @@ commands_pre =
   rm -rf .cache/plugin
 commands =
   mkdocs {posargs:build --strict}
+commands_post =
 isolated_build = true
-passenv =
+pass_env =
   SSH_AUTH_SOCK
 skip_install = false
 usedevelop = true
@@ -173,3 +173,4 @@ commands =
   ansible-navigator --version
   # Uninstall package
   pip uninstall -y ansible-navigator
+commands_post =


### PR DESCRIPTION
- **Refactor tox.ini file**
- **Report test results to codecov analytics**

Note that we are forced to generate `./junit.xml` in the root of the repository due to https://github.com/codecov/test-results-action/issues/110

AAP-43336