### PR TITLE
Increase container engine timeout

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def valid_ce() -> str:
             # the habit of getting stuck.
             try:
                 cmd = [engine, "info"]
-                subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=10)
+                subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=15)
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
                 msg = f"Container engine is broken, fail to run: {' '.join(cmd)}: {exc}"
                 continue


### PR DESCRIPTION
Due to multiple failures in the last days, we increase the timeout for this check.

See: https://github.com/ansible/ansible-navigator/actions/runs/14445957215/job/40506558418?pr=1952
