### PR TITLE
Make coverage file number check a warning

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -179,8 +179,7 @@ jobs:
         run: |
           JOBS_PRODUCING_COVERAGE=6
           if [ "$(find . -name coverage.xml | wc -l | bc)" -ne "${JOBS_PRODUCING_COVERAGE}" ]; then
-            echo "::error::Number of coverage.xml files was not the expected one (${JOBS_PRODUCING_COVERAGE}): $(find . -name coverage.xml |xargs echo)"
-            exit 1
+            echo "::warning::Number of coverage.xml files was not the expected one (${JOBS_PRODUCING_COVERAGE}): $(find . -name coverage.xml | xargs echo)"
           fi
 
       - name: Check codecov.io status


### PR DESCRIPTION
Previous implementation was failing on job reruns because we already merged existing reports.
