### PR TITLE
[DO-NOT-MERGE] Add `contents:read` permissions to tox workflow

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -38,6 +38,7 @@ jobs:
   tox:
     name: ${{ matrix.name }} / python ${{ matrix.python_version }}
     permissions:
+      contents: read
       id-token: write # codecov actions
       checks: read # codecov actions
     runs-on: ubuntu-24.04


### PR DESCRIPTION
**To fix**: `Codecov: Failed to get OIDC token with url: https://codecov.io./ Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env`

Related CI failure: https://github.com/ansible/ansible-navigator/actions/runs/14475535640/job/40600202341?pr=1957