### PR TITLE
Improve path normalization with a fallback for non-existent paths

### DIFF
--- a/src/ansible_navigator/cli.py
+++ b/src/ansible_navigator/cli.py
@@ -58,10 +58,10 @@ logger = logging.getLogger(PKG_NAME)
 def cache_scripts() -> None:
     """Cache the scripts used to introspect the container image."""
     scripts = ("catalog_collections.py", "image_introspect.py", "python_latest.sh")
+    cache_path = generate_cache_path(app_name=APP_NAME)
+    cache_path.mkdir(parents=True, exist_ok=True)
     for script in scripts:
         src = path_to_file(filename=script)
-        cache_path = generate_cache_path(app_name=APP_NAME)
-        cache_path.mkdir(parents=True, exist_ok=True)
         dst = cache_path / script
         message = f"No update required for {src} to {dst}"
         try:

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -647,7 +647,15 @@ class NavigatorPostProcessor:
         exit_messages: list[ExitMessage] = []
 
         if entry.value.current is not C.NOT_SET:
-            normalized = Path(entry.value.current).resolve().as_posix()
+            try:
+                normalized = Path(entry.value.current).resolve(strict=strict_resolve).as_posix()
+            except FileNotFoundError:
+                message = (
+                    f"Path `{entry.value.current}` does not exist."
+                    " Falling back to non-strict resolution."
+                )
+                messages.append(LogMessage(level=logging.WARNING, message=message))
+                normalized = Path(entry.value.current).resolve().as_posix()
             if normalized != entry.value.current:
                 entry.value.current = normalized
                 message = f"`{entry.name} was normalized to {entry.value}."

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -649,7 +649,7 @@ class NavigatorPostProcessor:
         if entry.value.current is not C.NOT_SET:
             try:
                 normalized = Path(entry.value.current).resolve(strict=strict_resolve).as_posix()
-            except FileNotFoundError:
+            except FileNotFoundError:  # pragma: no cover
                 message = (
                     f"Path `{entry.value.current}` does not exist."
                     " Falling back to non-strict resolution."

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -647,8 +647,7 @@ class NavigatorPostProcessor:
         exit_messages: list[ExitMessage] = []
 
         if entry.value.current is not C.NOT_SET:
-            entry_value = entry.value.current.replace("$PWD", str(Path.cwd()))
-            normalized = Path(entry_value).resolve(strict=strict_resolve).as_posix()
+            normalized = Path(entry.value.current).resolve().as_posix()
             if normalized != entry.value.current:
                 entry.value.current = normalized
                 message = f"`{entry.name} was normalized to {entry.value}."

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -647,7 +647,8 @@ class NavigatorPostProcessor:
         exit_messages: list[ExitMessage] = []
 
         if entry.value.current is not C.NOT_SET:
-            normalized = Path(entry.value.current).resolve(strict=strict_resolve).as_posix()
+            entry_value = entry.value.current.replace("$PWD", str(Path.cwd()))
+            normalized = Path(entry_value).resolve(strict=strict_resolve).as_posix()
             if normalized != entry.value.current:
                 entry.value.current = normalized
                 message = f"`{entry.name} was normalized to {entry.value}."


### PR DESCRIPTION
### SUMMARY

- Fixes the `FileNotFoundError` for paths that do not exist.

- Moves the cache path generation outside of the loop (unrelated to the above error, just found and corrected it)