### PR TITLE
Ignore the untracked files in the codecov scan

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,4 @@ coverage:
     patch: true # we want github annotations
 ignore:
   - "src/ansible_navigator/actions"
+  - "src/ansible_navigator/data/catalog_collections.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,5 @@
 coverage:
   status:
     patch: true # we want github annotations
+ignore:
+  - "src/ansible_navigator/actions"

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,9 @@
 coverage:
   status:
     patch: true # we want github annotations
+# The given ignore files are either not tested/tracked currently or cannot be tested at all
+# therefore adding them to the ignore list
 ignore:
   - "src/ansible_navigator/actions"
   - "src/ansible_navigator/data/catalog_collections.py"
+  - "src/ansible_navigator/version.py"


### PR DESCRIPTION
- This PR adds an ignore section in codecov.yml to exclude some listed file and folder from its coverage analysis.
- This prevents the low coverage in caching scripts to negatively impact the overall coverage metrics in Codecov.