### PR TITLE
Allow overriding podman user ID with --container-option (#2079)

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -48,9 +48,11 @@ maxsplit
 mergeable
 mkdocstrings
 mqueue              # https://github.com/ansible/ansible-runner/issues/984
+myuser
 myproject
 netcommon           # Ansible network collection, seen in tests and README
 netconf
+nofile
 nonblocking
 oldmask
 oneline

--- a/src/ansible_navigator/runner/base.py
+++ b/src/ansible_navigator/runner/base.py
@@ -108,8 +108,7 @@ class Base:
         # when the ce is podman, set the container user to root unless already specified
         if self._ce == "podman":
             has_user_flag = any(
-                opt.startswith(("--user", "-u=", "-u ")) or opt == "-u"
-                for opt in container_options
+                opt.startswith(("--user", "-u=", "-u ")) or opt == "-u" for opt in container_options
             )
             if not has_user_flag:
                 container_options.append("--user=root")

--- a/tests/unit/runner/test_base.py
+++ b/tests/unit/runner/test_base.py
@@ -154,7 +154,7 @@ def test_podman_other_u_flags_dont_match() -> None:
 
 def test_podman_user_space_separated() -> None:
     """Test that space-separated user flags are detected (as separate list items)."""
-    # When passed as --container-options="-u myuser", the parser may split this into ["-u", "myuser"]
+    # When passed as --container-options="-u myuser", the parser may split into ["-u", "myuser"]
     base = Base(
         container_engine="podman",
         execution_environment=True,


### PR DESCRIPTION
ansible-navigator hard-codes `--user=root` for podman, even if the user has set a different user id with a command line option like `--container-option="--user=$UID"`.

Check the list of container options passed by the user, and avoid setting `--user` if the user has already done so.

This allows running an EE with `--userns=keep-id --user=$UID"`, which is necessary in order to access th DBus session bus.

Fixes #2079.

To make this actually work, additional container options are necessary.

If `--userns=keep-id` is set and the user in question doesn't exist in the container, podman automatically adds an /etc/passwd entry setting HOME to the container's workdir, which causes the EE's ssh setup to fail. To fix that, the `--passwd-entry` option must be passed to podman (see https://github.com/containers/podman/pull/13616), using a user-writable directory that should exist and must be mounted into the container in the default HOME location (/home/runner). The user's actual home directory can't be used for this purpose, because SELinux prevents relabeling it.

Sample command line with which my test from #2079 actually succeeds:

```
CONT_HOME=/tmp/runner
mkdir -p "$CONT_HOME"
python3 -m ansible_navigator run test.yml \
     --execution-environment-image ee_with_keyring:latest \
     --pull-policy missing \
     --mode stdout \
     -i inventory \
     --eev "/run/user/$UID/bus:/run/user/$UID/bus" \
     --penv DBUS_SESSION_BUS_ADDRESS \
     --container-options="--userns=keep-id" \
     --container-options="--user=$UID" \
     --container-options="--security-opt=label=disable" \
     --eev "$CONT_HOME:/home/runner" \
     --container-options=--passwd-entry='$USERNAME:x:$UID:0:$NAME:/home/runner:/bin/sh'
```
