### PR TITLE
fix: handle missing tag key in images subcommand

### DIFF
--- a/src/ansible_navigator/image_manager/inspector.py
+++ b/src/ansible_navigator/image_manager/inspector.py
@@ -94,7 +94,7 @@ class ImagesList:
             local_images = [
                 dict(zip(headers, re_2omo.split(line), strict=False)) for line in images
             ]
-            valid_images = [image for image in local_images if image["tag"] != "<none>"]
+            valid_images = [image for image in local_images if image.get("tag") != "<none>"]
             command.details = valid_images
 
 


### PR DESCRIPTION
## Summary
Fixes a `KeyError: 'tag'` exception when running the `images` subcommand on systems where some container images have missing or incomplete metadata.

## Problem
The images subcommand crashes with a KeyError when processing images that don't have a 'tag' field in their metadata. This can occur after operations like `docker system prune -a` or with certain intermediate/dangling images.

Error:
```python
KeyError: 'tag'
  File ".../ansible_navigator/image_manager/inspector.py", line 97, in parse
    valid_images = [image for image in local_images if image["tag"] != "<none>"]
```

## Solution
Changed from dictionary key access `image["tag"]` to the safer `.get()` method: `image.get("tag")`, which returns `None` for missing keys instead of raising a KeyError.

## Testing
Reproducible with the steps provided in the issue - after creating an image without a tag, the images subcommand now completes successfully instead of crashing.

Fixes #2089