### PR TITLE
ci: Fix CI, assisted by AI

### DIFF
--- a/tests/integration/actions/exec/test_stdout_cli.py
+++ b/tests/integration/actions/exec/test_stdout_cli.py
@@ -48,7 +48,7 @@ stdout_tests = (
             cmdline="'echo $PATH'",
             execution_environment=True,
         ).join(),
-        present=["/sbin"],
+        present=["/usr/bin"],
     ),
     ShellCommand(
         comment="exec echo check no path via shell",


### PR DESCRIPTION
Fix tox runs:

The failures were caused by an EE image content change in ghcr.io/ansible/community-ansible-dev-tools:latest. 
● The related test checks that /sbin is in the $PATH inside the EE. The EE image (ghcr.io/ansible/community-ansible-dev-tools:latest) was updated between the  last passing main run and our PR run, and the new image no longer has /sbin in its PATH.
● The fix is straightforward — use /usr/bin which is always present