### PR TITLE
fix(runner): resolve SSH_AUTH_SOCK symlink on macOS Tahoe before container mount

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -4,6 +4,7 @@ argnames
 argparser
 argspec
 argvalues
+automounts
 autorefs
 basesystem
 caplog
@@ -54,6 +55,7 @@ netcommon           # Ansible network collection, seen in tests and README
 netconf
 nofile
 nonblocking
+normalises
 oldmask
 oneline
 onigurumacffi
@@ -70,6 +72,7 @@ rocannon's
 scap
 scrollback
 somevalue
+statfs
 stripspaces
 subaction
 subschema

--- a/src/ansible_navigator/runner/base.py
+++ b/src/ansible_navigator/runner/base.py
@@ -124,6 +124,25 @@ class Base:
             # Prepend to existing container options to allow overriding this fix.
             container_options = ssh_agent_socket_opts + container_options
 
+        # On macOS Tahoe (>26.3), the launchd SSH agent socket moved from
+        # /private/tmp to /var/run. Since /var/run is a symlink to /private/var/run,
+        # container runtimes require the resolved real path when building volume mount
+        # arguments. ansible-runner normalises mount paths with os.path.abspath(), which
+        # does not resolve symlinks, causing the container engine to fail with:
+        #   Error: statfs /var/run/com.apple.launchd.xxxxxxxxx: no such file or directory
+        # Resolving SSH_AUTH_SOCK to its real path here — before ansible-runner reads it
+        # from os.environ in _handle_automounts() — ensures the correct path is passed to
+        # the container engine regardless of which CE is in use.
+        if sys.platform == "darwin" and "SSH_AUTH_SOCK" in os.environ:
+            _real_sock = os.path.realpath(os.environ["SSH_AUTH_SOCK"])
+            if _real_sock != os.environ["SSH_AUTH_SOCK"]:
+                self._logger.debug(
+                    "macOS SSH_AUTH_SOCK symlink resolved: %s -> %s",
+                    os.environ["SSH_AUTH_SOCK"],
+                    _real_sock,
+                )
+                os.environ["SSH_AUTH_SOCK"] = _real_sock
+
         if self._ee:
             self._runner_args.update(
                 {

--- a/tests/unit/runner/test_base.py
+++ b/tests/unit/runner/test_base.py
@@ -1,5 +1,6 @@
 """Unit tests for the Base runner class."""
 
+import os
 import sys
 
 import pytest
@@ -196,3 +197,87 @@ def test_podman_user_quoted_with_space() -> None:
 
     assert "--user=root" not in opts
     assert "-u myuser" in opts
+
+
+# ---------------------------------------------------------------------------
+# SSH_AUTH_SOCK symlink resolution — macOS Tahoe (issue #2113)
+# ---------------------------------------------------------------------------
+
+
+def test_ssh_auth_sock_symlink_resolved_on_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SSH_AUTH_SOCK is resolved to its real path on macOS when it is a symlink.
+
+    On macOS Tahoe (>26.3) the launchd socket moved from /private/tmp to
+    /var/run, which is a symlink to /private/var/run. Container runtimes need
+    the resolved path for volume mounts.
+
+    Args:
+        monkeypatch: The monkeypatch fixture
+    """
+    symlink_path = "/var/run/com.apple.launchd.XXXXXXXX/Listeners"
+    real_path = "/private/var/run/com.apple.launchd.XXXXXXXX/Listeners"
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setenv("SSH_AUTH_SOCK", symlink_path)
+    monkeypatch.setattr(os.path, "realpath", lambda p: real_path if p == symlink_path else p)
+
+    Base(container_engine="podman", execution_environment=True)
+
+    assert os.environ["SSH_AUTH_SOCK"] == real_path
+
+
+def test_ssh_auth_sock_already_real_path_unchanged_on_macos(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SSH_AUTH_SOCK is not modified when it is already a real path on macOS.
+
+    When the path contains no symlinks os.path.realpath returns the same value,
+    so os.environ should not be updated.
+
+    Args:
+        monkeypatch: The monkeypatch fixture
+    """
+    real_path = "/private/tmp/com.apple.launchd.XXXXXXXX/Listeners"
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setenv("SSH_AUTH_SOCK", real_path)
+    monkeypatch.setattr(os.path, "realpath", lambda p: p)  # no-op — already real
+
+    Base(container_engine="podman", execution_environment=True)
+
+    assert os.environ["SSH_AUTH_SOCK"] == real_path
+
+
+def test_ssh_auth_sock_not_modified_on_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SSH_AUTH_SOCK symlink resolution is skipped entirely on Linux.
+
+    The macOS Tahoe symlink issue does not affect Linux. The fix must not
+    touch SSH_AUTH_SOCK on non-darwin platforms even if the path looks like
+    it contains a symlink.
+
+    Args:
+        monkeypatch: The monkeypatch fixture
+    """
+    original_path = "/run/user/1000/keyring/ssh"
+    resolved_path = "/some/other/path"  # would be wrong to use this on Linux
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("SSH_AUTH_SOCK", original_path)
+    monkeypatch.setattr(os.path, "realpath", lambda p: resolved_path)
+
+    Base(container_engine="podman", execution_environment=True)
+
+    assert os.environ["SSH_AUTH_SOCK"] == original_path
+
+
+def test_ssh_auth_sock_missing_env_var_no_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No error is raised when SSH_AUTH_SOCK is not set in the environment.
+
+    Args:
+        monkeypatch: The monkeypatch fixture
+    """
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.delenv("SSH_AUTH_SOCK", raising=False)
+
+    # Should not raise
+    Base(container_engine="podman", execution_environment=True)


### PR DESCRIPTION
## Summary

Fixes #2113

On macOS Tahoe (>26.3), the launchd SSH agent socket moved from `/private/tmp` to `/var/run`. Since `/var/run` is a symlink to `/private/var/run`, container runtimes (Podman, Docker) fail to mount the socket when given the unresolved symlink path, producing:

```
Error: statfs /var/run/com.apple.launchd.xxxxxxxxx: no such file or directory
```

### Root Cause

`ansible-runner`'s `_handle_automounts()` reads `SSH_AUTH_SOCK` from `os.environ` and passes it to `_update_volume_mount_paths()`, which normalises paths using `os.path.abspath()`. `os.path.abspath()` does **not** resolve symlinks, so the container engine receives the unresolvable `/var/run/...` path unchanged.

### Fix

In `Base.__init__()`, call `os.path.realpath()` on `SSH_AUTH_SOCK` before `ansible-runner` reads it from `os.environ`. This resolves `/var/run/com.apple.launchd.xxx/Listeners` → `/private/var/run/com.apple.launchd.xxx/Listeners`, which the container engine can mount.

The fix:
- Applies to all container engines on macOS (Docker already has its own hardcoded proxy socket override; this covers Podman and any future engines)
- Is a no-op on Linux (guard is `sys.platform == "darwin"`)
- Is a no-op on pre-Tahoe macOS where `SSH_AUTH_SOCK` already points to a real path (guard checks `realpath != original`)

## Test plan

- [x] `test_ssh_auth_sock_symlink_resolved_on_macos` — symlink path is rewritten to real path on darwin
- [x] `test_ssh_auth_sock_already_real_path_unchanged_on_macos` — non-symlink path is not modified
- [x] `test_ssh_auth_sock_not_modified_on_linux` — fix does not run on Linux
- [x] `test_ssh_auth_sock_missing_env_var_no_error` — no crash when `SSH_AUTH_SOCK` is unset
- [x] All 20 unit tests pass: `python3 -m pytest tests/unit/runner/test_base.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)