### PR TITLE
Add unit tests to improve coverage across utility modules

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -8,6 +8,7 @@ automounts
 autorefs
 basesystem
 caplog
+capsys
 cliconf             # Ansible network cli abstraction plugin
 codeclimate
 colname
@@ -60,6 +61,7 @@ oldmask
 oneline
 onigurumacffi
 oxfordcomma
+pathobj
 preclear
 precommand
 premanent

--- a/.config/pydoclint-baseline.txt
+++ b/.config/pydoclint-baseline.txt
@@ -868,3 +868,149 @@ tests/unit/utils/test_serialize_dataclass.py
     DOC601: Class `ContentTestOverride`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
     DOC603: Class `ContentTestOverride`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [attr_01: bool, attr_02: int, attr_03: str]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
 --------------------
+tests/unit/ui_framework/test_validators.py
+    DOC101: Method `TestFieldValidatorsValidFilePath.test_valid_file`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestFieldValidatorsValidFilePath.test_valid_file`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
+    DOC101: Method `TestFieldValidatorsValidFilePath.test_directory_not_file`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestFieldValidatorsValidFilePath.test_directory_not_file`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
+    DOC101: Method `TestFieldValidatorsValidPath.test_valid_directory`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestFieldValidatorsValidPath.test_valid_directory`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
+    DOC101: Method `TestFieldValidatorsValidPathOrNone.test_valid_path`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestFieldValidatorsValidPathOrNone.test_valid_path`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
+    DOC601: Class `MockCheckbox`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
+    DOC603: Class `MockCheckbox`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [checked: bool]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
+--------------------
+tests/unit/utils/test_ansi.py
+    DOC101: Function `test_changed_with_color`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_changed_with_color`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str]].
+    DOC101: Function `test_changed_without_color`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_changed_without_color`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str]].
+    DOC101: Function `test_failed_with_color`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_failed_with_color`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str]].
+    DOC101: Function `test_failed_without_color`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_failed_without_color`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str]].
+    DOC101: Function `test_info_with_color`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_info_with_color`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str]].
+    DOC101: Function `test_info_without_color`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_info_without_color`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str]].
+    DOC101: Function `test_subtle_with_color`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_subtle_with_color`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str]].
+    DOC101: Function `test_subtle_without_color`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_subtle_without_color`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str]].
+    DOC101: Function `test_success_with_color`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_success_with_color`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str]].
+    DOC101: Function `test_success_without_color`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_success_without_color`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str]].
+    DOC101: Function `test_warning_with_color`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_warning_with_color`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str]].
+    DOC101: Function `test_warning_without_color`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_warning_without_color`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str]].
+    DOC101: Function `test_working_with_color`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_working_with_color`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str]].
+    DOC101: Function `test_working_without_color`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_working_without_color`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str]].
+    DOC101: Function `test_blank_line`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_blank_line`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str]].
+    DOC101: Function `test_prompt_enter`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_prompt_enter`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [monkeypatch: pytest.MonkeyPatch].
+    DOC101: Function `test_prompt_enter_keyboard_interrupt`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_prompt_enter_keyboard_interrupt`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [monkeypatch: pytest.MonkeyPatch].
+    DOC101: Function `test_prompt_yn_yes`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_prompt_yn_yes`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [monkeypatch: pytest.MonkeyPatch].
+    DOC101: Function `test_prompt_yn_empty`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_prompt_yn_empty`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [monkeypatch: pytest.MonkeyPatch].
+    DOC101: Function `test_prompt_yn_no`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_prompt_yn_no`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [monkeypatch: pytest.MonkeyPatch].
+    DOC101: Function `test_prompt_yn_keyboard_interrupt`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_prompt_yn_keyboard_interrupt`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [monkeypatch: pytest.MonkeyPatch].
+--------------------
+tests/unit/utils/test_functions_extended.py
+    DOC101: Function `test_check_for_ansible_found`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_check_for_ansible_found`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [monkeypatch: pytest.MonkeyPatch].
+    DOC101: Function `test_check_for_ansible_not_found`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_check_for_ansible_not_found`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [monkeypatch: pytest.MonkeyPatch].
+    DOC101: Function `test_check_playbook_type_file`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_check_playbook_type_file`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
+    DOC101: Function `test_clear_screen_vscode`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_clear_screen_vscode`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch].
+    DOC101: Function `test_clear_screen_normal`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_clear_screen_normal`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch].
+    DOC101: Function `test_time_stamp_for_file_exists`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_time_stamp_for_file_exists`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
+--------------------
+tests/unit/utils/test_key_value_store_extended.py
+    DOC101: Function `test_path_property`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_path_property`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_set_and_get`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_set_and_get`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_get_missing_key`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_get_missing_key`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_overwrite_value`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_overwrite_value`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_delete_key`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_delete_key`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_delete_missing_key`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_delete_missing_key`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_contains`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_contains`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_len_empty`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_len_empty`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_len_with_items`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_len_with_items`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_iterkeys`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_iterkeys`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_itervalues`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_itervalues`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_iteritems`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_iteritems`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_keys_view`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_keys_view`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_values_view`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_values_view`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_items_view`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_items_view`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_iter`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_iter`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_repr_empty`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_repr_empty`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_repr_with_items`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_repr_with_items`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_close_and_reopen`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_close_and_reopen`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
+    DOC101: Function `test_open_method`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_open_method`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [kvs: KeyValueStore].
+    DOC101: Function `test_init_with_path_object`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_init_with_path_object`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
+--------------------
+tests/unit/utils/test_print.py
+    DOC101: Method `TestColorBits.test_truecolor`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestColorBits.test_truecolor`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [monkeypatch: pytest.MonkeyPatch].
+    DOC101: Method `TestColorBits.test_24bit`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestColorBits.test_24bit`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [monkeypatch: pytest.MonkeyPatch].
+    DOC101: Method `TestColorBits.test_256color_term`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestColorBits.test_256color_term`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [monkeypatch: pytest.MonkeyPatch].
+    DOC101: Method `TestColorBits.test_16color_term`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestColorBits.test_16color_term`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [monkeypatch: pytest.MonkeyPatch].
+    DOC101: Method `TestColorBits.test_no_env_vars`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestColorBits.test_no_env_vars`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [monkeypatch: pytest.MonkeyPatch].
+    DOC101: Method `TestColorBits.test_plain_term`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestColorBits.test_plain_term`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [monkeypatch: pytest.MonkeyPatch].
+--------------------
+tests/unit/utils/test_serialize_extended.py
+    DOC101: Method `TestWriteDiagnosticsJson.test_creates_file`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestWriteDiagnosticsJson.test_creates_file`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
+    DOC101: Method `TestWriteDiagnosticsJson.test_file_content`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestWriteDiagnosticsJson.test_file_content`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
+    DOC101: Method `TestWriteDiagnosticsJson.test_file_permissions`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestWriteDiagnosticsJson.test_file_permissions`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
+    DOC101: Method `TestWriteDiagnosticsJson.test_umask_restored`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestWriteDiagnosticsJson.test_umask_restored`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
+    DOC101: Method `TestSerializeWriteFile.test_write_json`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestSerializeWriteFile.test_write_json`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
+    DOC101: Method `TestSerializeWriteFile.test_write_yaml`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TestSerializeWriteFile.test_write_yaml`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
+--------------------
+tests/unit/test_content_defs.py
+    DOC601: Class `SampleContent`: Class docstring contains fewer class attributes than actual class attributes.  (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
+    DOC603: Class `SampleContent`: Class docstring attributes are different from actual class attributes. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Attributes in the class definition but not in the docstring: [name: str, value: int]. (Please read https://jsh9.github.io/pydoclint/checking_class_attributes.html on how to correctly document class attributes.)
+--------------------

--- a/tests/unit/test_content_defs.py
+++ b/tests/unit/test_content_defs.py
@@ -1,0 +1,110 @@
+"""Tests for the content_defs module."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ansible_navigator.content_defs import ContentBase
+from ansible_navigator.content_defs import ContentFormat
+from ansible_navigator.content_defs import ContentView
+from ansible_navigator.content_defs import SerializationFormat
+
+
+class TestContentView:
+    """Tests for the ContentView enum."""
+
+    def test_full(self) -> None:
+        """Test FULL value."""
+        assert ContentView.FULL.value == "full"
+
+    def test_normal(self) -> None:
+        """Test NORMAL value."""
+        assert ContentView.NORMAL.value == "normal"
+
+
+class TestSerializationFormat:
+    """Tests for the SerializationFormat enum."""
+
+    def test_yaml(self) -> None:
+        """Test YAML value."""
+        assert SerializationFormat.YAML.value == "YAML"
+
+    def test_json(self) -> None:
+        """Test JSON value."""
+        assert SerializationFormat.JSON.value == "JSON"
+
+
+class TestCFormat:
+    """Tests for the CFormat dataclass."""
+
+    def test_json_format(self) -> None:
+        """Test JSON content format properties."""
+        fmt = ContentFormat.JSON.value
+        assert fmt.scope == "source.json"
+        assert fmt.file_extension == ".json"
+        assert fmt.serialization == SerializationFormat.JSON
+
+    def test_yaml_format(self) -> None:
+        """Test YAML content format properties."""
+        fmt = ContentFormat.YAML.value
+        assert fmt.scope == "source.yaml"
+        assert fmt.file_extension == ".yml"
+        assert fmt.serialization == SerializationFormat.YAML
+
+    def test_ansi_format(self) -> None:
+        """Test ANSI content format has no serialization."""
+        fmt = ContentFormat.ANSI.value
+        assert fmt.serialization is None
+
+    def test_log_format(self) -> None:
+        """Test LOG content format."""
+        fmt = ContentFormat.LOG.value
+        assert fmt.file_extension == ".log"
+
+    def test_txt_format(self) -> None:
+        """Test TXT content format."""
+        fmt = ContentFormat.TXT.value
+        assert fmt.file_extension == ".txt"
+
+    def test_markdown_format(self) -> None:
+        """Test MARKDOWN content format."""
+        fmt = ContentFormat.MARKDOWN.value
+        assert fmt.file_extension == ".md"
+
+
+@dataclass
+class SampleContent(ContentBase[dict[str, str]]):
+    """A sample content dataclass for testing."""
+
+    name: str = "test"
+    value: int = 42
+
+
+class TestContentBase:
+    """Tests for the ContentBase class."""
+
+    def test_asdict_normal_json(self) -> None:
+        """Test asdict with normal JSON view."""
+        content = SampleContent()
+        result = content.asdict(ContentView.NORMAL, SerializationFormat.JSON)
+        assert result["name"] == "test"
+        assert result["value"] == 42
+
+    def test_asdict_full_yaml(self) -> None:
+        """Test asdict with full YAML view."""
+        content = SampleContent()
+        result = content.asdict(ContentView.FULL, SerializationFormat.YAML)
+        assert result["name"] == "test"
+
+    def test_get(self) -> None:
+        """Test get method returns attribute."""
+        content = SampleContent()
+        assert content.get("name") == "test"
+        assert content.get("value") == 42
+
+    def test_items(self) -> None:
+        """Test items method returns ItemsView."""
+        content = SampleContent()
+        items = dict(content.items())
+        assert items["name"] == "test"
+        assert items["value"] == 42

--- a/tests/unit/test_image_introspection_parsers.py
+++ b/tests/unit/test_image_introspection_parsers.py
@@ -1,0 +1,203 @@
+"""Tests for the image introspect parsers."""
+
+from __future__ import annotations
+
+from ansible_navigator.data.image_introspect import AnsibleCollections
+from ansible_navigator.data.image_introspect import AnsibleVersion
+from ansible_navigator.data.image_introspect import CmdParser
+from ansible_navigator.data.image_introspect import Command
+from ansible_navigator.data.image_introspect import OsRelease
+from ansible_navigator.data.image_introspect import RedhatRelease
+from ansible_navigator.data.image_introspect import SystemPackages
+
+
+class TestCmdParserStrip:
+    """Tests for CmdParser._strip."""
+
+    def test_strip_quotes(self) -> None:
+        """Test stripping double quotes."""
+        assert CmdParser._strip('"hello"') == "hello"
+
+    def test_strip_single_quotes(self) -> None:
+        """Test stripping single quotes."""
+        assert CmdParser._strip("'hello'") == "hello"
+
+    def test_strip_whitespace(self) -> None:
+        """Test stripping whitespace."""
+        assert CmdParser._strip("  hello  ") == "hello"
+
+    def test_strip_combined(self) -> None:
+        """Test stripping quotes then whitespace."""
+        assert CmdParser._strip('"hello"') == "hello"
+
+
+class TestCmdParserRePartition:
+    """Tests for CmdParser.re_partition."""
+
+    def test_basic_partition(self) -> None:
+        """Test basic partitioning."""
+        key, delim, content = CmdParser.re_partition("key=value", "=")
+        assert key == "key"
+        assert delim == "="
+        assert content == "value"
+
+    def test_no_separator(self) -> None:
+        """Test when no separator is found."""
+        key, delim, content = CmdParser.re_partition("no separator", "=")
+        assert key == ""
+        assert delim == ""
+        assert content == "no separator"
+
+    def test_leading_space(self) -> None:
+        """Test with leading space in content."""
+        key, delim, content = CmdParser.re_partition(" key=value", "=")
+        assert key == ""
+        assert delim == ""
+        assert content == " key=value"
+
+    def test_regex_separator(self) -> None:
+        """Test with regex separator."""
+        key, _delim, content = CmdParser.re_partition("key: value", r":\s+")
+        assert key == "key"
+        assert content == "value"
+
+
+class TestCmdParserSplitter:
+    """Tests for CmdParser.splitter."""
+
+    def test_simple_key_value(self) -> None:
+        """Test simple key=value splitting."""
+        parser = CmdParser()
+        lines = ["name=test", "version=1.0"]
+        result = parser.splitter(lines, "=")
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["name"] == "test"
+        assert result[0]["version"] == "1.0"
+
+    def test_with_section_delim(self) -> None:
+        """Test splitting with section delimiter."""
+        parser = CmdParser()
+        lines = ["name=pkg1", "version=1.0", "---", "name=pkg2", "version=2.0"]
+        result = parser.splitter(lines, "=", section_delim="---")
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    def test_continuation_line(self) -> None:
+        """Test continuation line (no delimiter)."""
+        parser = CmdParser()
+        lines = ["name: test value", " continued value"]
+        result = parser.splitter(lines, r":\s+")
+        assert isinstance(result, list)
+        assert "continued" in result[0]["name"]
+
+
+class TestAnsibleCollections:
+    """Tests for AnsibleCollections parser."""
+
+    def test_commands_property(self) -> None:
+        """Test commands property returns command list."""
+        collector = AnsibleCollections()
+        cmds = collector.commands
+        assert len(cmds) == 1
+        assert cmds[0].id_ == "ansible_collections"
+
+    def test_parse_normal_output(self) -> None:
+        """Test parsing normal collection list output."""
+        cmd = Command(id_="test", command="test", parse=lambda x: None)
+        cmd.stdout = (
+            "# /usr/share/ansible/collections\n"
+            "Collection        Version\n"
+            "----------------- -------\n"
+            "ansible.builtin   2.14.0\n"
+            "community.general 6.0.0\n"
+        )
+        cmd.stderr = ""
+        AnsibleCollections.parse(cmd)
+        assert isinstance(cmd.details, dict)
+        assert cmd.details["ansible.builtin"] == "2.14.0"  # pylint: disable=invalid-sequence-index
+        assert cmd.details["community.general"] == "6.0.0"  # pylint: disable=invalid-sequence-index
+
+    def test_parse_ansible29_error(self) -> None:
+        """Test parsing ansible 2.9 error."""
+        cmd = Command(id_="test", command="test", parse=lambda x: None)
+        cmd.stdout = ""
+        cmd.stderr = "invalid choice: 'list'"
+        AnsibleCollections.parse(cmd)
+        assert "not supported" in cmd.details
+
+    def test_parse_empty_output(self) -> None:
+        """Test parsing empty output."""
+        cmd = Command(id_="test", command="test", parse=lambda x: None)
+        cmd.stdout = ""
+        cmd.stderr = ""
+        AnsibleCollections.parse(cmd)
+        assert not cmd.details
+
+
+class TestAnsibleVersion:
+    """Tests for AnsibleVersion parser."""
+
+    def test_commands_property(self) -> None:
+        """Test commands property."""
+        collector = AnsibleVersion()
+        cmds = collector.commands
+        assert len(cmds) == 1
+        assert cmds[0].id_ == "ansible_version"
+
+    def test_parse(self) -> None:
+        """Test parsing version output."""
+        cmd = Command(id_="test", command="test", parse=lambda x: None)
+        cmd.stdout = "ansible [core 2.14.0]\n  config file = /etc/ansible/ansible.cfg"
+        AnsibleVersion.parse(cmd)
+        assert cmd.details == "ansible [core 2.14.0]"
+
+
+class TestOsRelease:
+    """Tests for OsRelease parser."""
+
+    def test_commands_property(self) -> None:
+        """Test commands property."""
+        collector = OsRelease()
+        cmds = collector.commands
+        assert len(cmds) == 1
+        assert cmds[0].id_ == "os_release"
+
+    def test_parse(self) -> None:
+        """Test parsing os-release output."""
+        collector = OsRelease()
+        cmd = Command(id_="test", command="test", parse=lambda x: None)
+        cmd.stdout = 'NAME="Fedora"\nVERSION="38"\nID=fedora'
+        collector.parse(cmd)
+        assert isinstance(cmd.details, (dict, list))
+
+
+class TestRedhatRelease:
+    """Tests for RedhatRelease parser."""
+
+    def test_parse(self) -> None:
+        """Test parsing redhat-release content."""
+        cmd = Command(id_="test", command="test", parse=lambda x: None)
+        cmd.stdout = "Red Hat Enterprise Linux release 9.1 (Plow)"
+        RedhatRelease.parse(cmd)
+        assert "Red Hat" in cmd.details
+
+
+class TestSystemPackages:
+    """Tests for SystemPackages parser."""
+
+    def test_commands_property(self) -> None:
+        """Test commands property."""
+        collector = SystemPackages()
+        cmds = collector.commands
+        assert len(cmds) == 1
+        assert cmds[0].id_ == "system_packages"
+
+
+class TestCmdParserCommands:
+    """Tests for CmdParser base class."""
+
+    def test_default_commands(self) -> None:
+        """Test default commands property returns empty list."""
+        parser = CmdParser()
+        assert not parser.commands

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -1,0 +1,223 @@
+"""Tests for the steps module."""
+
+from __future__ import annotations
+
+import pytest
+
+from ansible_navigator.steps import Step
+from ansible_navigator.steps import Steps
+from ansible_navigator.steps import StepType
+from ansible_navigator.steps import TypedStep
+
+
+class TestStep:
+    """Tests for the Step class."""
+
+    def test_constructor_defaults(self) -> None:
+        """Test Step constructor with defaults."""
+        step = Step(name="test", step_type="menu", value=[])
+        assert step.name == "test"
+        assert step.type == "menu"
+        assert step.value == []
+        assert step.columns == []
+        assert step.index is None
+        assert step.select_func is None
+        assert step.show_func is None
+        assert step.next is None
+        assert step.previous is None
+
+    def test_changed_false_initially(self) -> None:
+        """Test changed is False initially."""
+        step = Step(name="test", step_type="menu", value=[])
+        assert step.changed is False
+
+    def test_changed_after_index_set(self) -> None:
+        """Test changed is True after index changes."""
+        step = Step(name="test", step_type="menu", value=[{"a": "1"}])
+        step.index = 0
+        assert step.changed is True
+
+    def test_changed_after_value_set(self) -> None:
+        """Test changed is True after value changes."""
+        step = Step(name="test", step_type="menu", value=[])
+        step.value = [{"a": "1"}]
+        assert step.changed is True
+
+    def test_changed_setter(self) -> None:
+        """Test changed setter resets both flags."""
+        step = Step(name="test", step_type="menu", value=[{"a": "1"}])
+        step.index = 0
+        step.changed = False
+        assert step.changed is False
+
+    def test_changed_setter_type_error(self) -> None:
+        """Test changed setter with invalid type."""
+        step = Step(name="test", step_type="menu", value=[])
+        with pytest.raises(TypeError):
+            step.changed = "not a bool"  # type: ignore[assignment]
+
+    def test_index_setter(self) -> None:
+        """Test index setter."""
+        step = Step(name="test", step_type="menu", value=[{"a": "1"}])
+        step.index = 0
+        assert step.index == 0
+
+    def test_index_setter_none(self) -> None:
+        """Test index setter with None."""
+        step = Step(name="test", step_type="menu", value=[{"a": "1"}], index=0)
+        step.index = None
+        assert step.index is None
+
+    def test_index_setter_type_error(self) -> None:
+        """Test index setter with invalid type."""
+        step = Step(name="test", step_type="menu", value=[])
+        with pytest.raises(TypeError):
+            step.index = "bad"  # type: ignore[assignment]
+
+    def test_value_setter(self) -> None:
+        """Test value setter."""
+        step = Step(name="test", step_type="menu", value=[])
+        new_val = [{"a": "1"}]
+        step.value = new_val
+        assert step.value == new_val
+
+    def test_value_setter_type_error(self) -> None:
+        """Test value setter with invalid type."""
+        step = Step(name="test", step_type="menu", value=[])
+        with pytest.raises(TypeError):
+            step.value = "not a list"  # type: ignore[assignment]
+
+    def test_selected_none_index(self) -> None:
+        """Test selected returns None when index is None."""
+        step = Step(name="test", step_type="menu", value=[{"a": "1"}])
+        assert step.selected is None
+
+    def test_selected_empty_value(self) -> None:
+        """Test selected returns None when value is empty."""
+        step = Step(name="test", step_type="menu", value=[], index=0)
+        assert step.selected is None
+
+    def test_selected_valid(self) -> None:
+        """Test selected returns correct item."""
+        data = [{"a": "1"}, {"b": "2"}]
+        step = Step(name="test", step_type="menu", value=data, index=1)
+        assert step.selected == {"b": "2"}
+
+    def test_selected_wrap_around(self) -> None:
+        """Test selected wraps around via modulo."""
+        data = [{"a": "1"}, {"b": "2"}]
+        step = Step(name="test", step_type="menu", value=data, index=3)
+        assert step.selected == {"b": "2"}
+
+    def test_value_check_valid(self) -> None:
+        """Test _value_check with valid type."""
+        Step._value_check(42, int)
+
+    def test_value_check_invalid(self) -> None:
+        """Test _value_check with invalid type raises TypeError."""
+        with pytest.raises(TypeError, match="wanted"):
+            Step._value_check("string", int)
+
+    def test_value_check_tuple_types(self) -> None:
+        """Test _value_check with tuple of types."""
+        Step._value_check(None, (int, type(None)))
+
+
+class TestStepType:
+    """Tests for the StepType enum."""
+
+    def test_menu_value(self) -> None:
+        """Test MENU value."""
+        assert StepType.MENU.value == "menu"
+
+    def test_content_value(self) -> None:
+        """Test CONTENT value."""
+        assert StepType.CONTENT.value == "content"
+
+
+class TestTypedStep:
+    """Tests for the TypedStep dataclass."""
+
+    def test_changed_false_initially(self) -> None:
+        """Test changed is False initially."""
+        step = TypedStep[str](name="test", step_type=StepType.MENU)
+        assert step.changed is False
+
+    def test_changed_after_index(self) -> None:
+        """Test changed after index set."""
+        step = TypedStep[str](name="test", step_type=StepType.MENU)
+        step.index = 0
+        assert step.changed is True
+
+    def test_changed_setter(self) -> None:
+        """Test changed setter resets flags."""
+        step = TypedStep[str](name="test", step_type=StepType.MENU)
+        step.index = 0
+        step.changed = False
+        assert step.changed is False
+
+    def test_index_tracks_changes(self) -> None:
+        """Test index tracks whether it changed."""
+        step = TypedStep[str](name="test", step_type=StepType.MENU)
+        step.index = 0
+        assert step._index_changed is True
+        step.index = 0
+        assert step._index_changed is False
+
+    def test_selected_none_index(self) -> None:
+        """Test selected with None index."""
+        step = TypedStep[str](name="test", step_type=StepType.MENU, _value=["a", "b"])
+        assert step.selected is None
+
+    def test_selected_empty_value(self) -> None:
+        """Test selected with empty value."""
+        step = TypedStep[str](name="test", step_type=StepType.MENU, _index=0)
+        assert step.selected is None
+
+    def test_selected_valid(self) -> None:
+        """Test selected with valid index."""
+        step = TypedStep[str](name="test", step_type=StepType.MENU, _value=["a", "b"], _index=1)
+        assert step.selected == "b"
+
+    def test_selected_wrap_around(self) -> None:
+        """Test selected wraps via modulo."""
+        step = TypedStep[str](name="test", step_type=StepType.MENU, _value=["a", "b"], _index=3)
+        assert step.selected == "b"
+
+    def test_value_setter_tracks_changes(self) -> None:
+        """Test value setter tracks changes."""
+        step = TypedStep[str](name="test", step_type=StepType.MENU)
+        step.value = ["a", "b"]
+        assert step._value_changed is True
+        assert step.value == ["a", "b"]
+
+    def test_value_no_change(self) -> None:
+        """Test value setter when value doesn't change."""
+        step = TypedStep[str](name="test", step_type=StepType.MENU, _value=["a"])
+        step.value = ["a"]
+        assert step._value_changed is False
+
+
+class TestSteps:
+    """Tests for the Steps deque."""
+
+    def test_back_one_returns_item(self) -> None:
+        """Test back_one returns the popped item."""
+        steps = Steps([1, 2, 3])
+        assert steps.back_one() == 3
+        assert len(steps) == 2
+
+    def test_back_one_empty(self) -> None:
+        """Test back_one returns None when empty."""
+        steps = Steps()
+        assert steps.back_one() is None
+
+    def test_current(self) -> None:
+        """Test current returns last item."""
+        steps = Steps([1, 2, 3])
+        assert steps.current == 3
+
+    def test_previous(self) -> None:
+        """Test previous returns second-to-last item."""
+        steps = Steps([1, 2, 3])
+        assert steps.previous == 2

--- a/tests/unit/ui_framework/test_validators.py
+++ b/tests/unit/ui_framework/test_validators.py
@@ -1,0 +1,443 @@
+"""Tests for the validators module."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ansible_navigator.ui_framework.sentinels import unknown
+from ansible_navigator.ui_framework.validators import FieldValidators
+from ansible_navigator.ui_framework.validators import FormValidators
+from ansible_navigator.ui_framework.validators import Validation
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestFieldValidatorsHttp:
+    """Tests for the http validator."""
+
+    def test_hint(self) -> None:
+        """Test hint returns a message string."""
+        result = FieldValidators.http(hint=True)
+        assert isinstance(result, str)
+        assert "URL" in result
+
+    def test_valid_http(self) -> None:
+        """Test valid http URL."""
+        result = FieldValidators.http(text="http://example.com")
+        assert isinstance(result, Validation)
+        assert result.error_msg == ""
+
+    def test_valid_https(self) -> None:
+        """Test valid https URL."""
+        result = FieldValidators.http(text="https://example.com/path")
+        assert isinstance(result, Validation)
+        assert result.error_msg == ""
+
+    def test_invalid_url(self) -> None:
+        """Test invalid URL."""
+        result = FieldValidators.http(text="not-a-url")
+        assert isinstance(result, Validation)
+        assert result.error_msg != ""
+
+    def test_empty_text(self) -> None:
+        """Test empty text."""
+        result = FieldValidators.http(text="")
+        assert isinstance(result, Validation)
+        assert result.error_msg != ""
+
+    def test_ftp_scheme(self) -> None:
+        """Test ftp scheme is rejected."""
+        result = FieldValidators.http(text="ftp://example.com")
+        assert isinstance(result, Validation)
+        assert result.error_msg != ""
+
+
+class TestFieldValidatorsMaskedOrNone:
+    """Tests for the masked_or_none validator."""
+
+    def test_hint(self) -> None:
+        """Test hint returns a message string."""
+        result = FieldValidators.masked_or_none(hint=True)
+        assert isinstance(result, str)
+
+    def test_with_text(self) -> None:
+        """Test with text returns masked value."""
+        result = FieldValidators.masked_or_none(text="secret")
+        assert isinstance(result, Validation)
+        assert result.error_msg == ""
+        assert all(c == "*" for c in result.value)
+        assert 15 <= len(result.value) <= 19
+
+    def test_empty_text(self) -> None:
+        """Test empty text returns empty value."""
+        result = FieldValidators.masked_or_none(text="")
+        assert isinstance(result, Validation)
+        assert result.value == ""
+
+
+class TestFieldValidatorsNone:
+    """Tests for the none validator."""
+
+    def test_hint(self) -> None:
+        """Test hint returns a message string."""
+        result = FieldValidators.none(hint=True)
+        assert isinstance(result, str)
+
+    def test_with_text(self) -> None:
+        """Test with text passes through."""
+        result = FieldValidators.none(text="anything")
+        assert isinstance(result, Validation)
+        assert result.value == "anything"
+        assert result.error_msg == ""
+
+
+class TestFieldValidatorsNull:
+    """Tests for the null validator."""
+
+    def test_hint(self) -> None:
+        """Test hint returns empty string."""
+        result = FieldValidators.null(hint=True)
+        assert result == ""
+
+    def test_with_text(self) -> None:
+        """Test with text passes through."""
+        result = FieldValidators.null(text="value")
+        assert isinstance(result, Validation)
+        assert result.error_msg == ""
+
+
+class TestFieldValidatorsOneOf:
+    """Tests for the one_of validator."""
+
+    def test_hint(self) -> None:
+        """Test hint includes choices."""
+        result = FieldValidators.one_of(choices=["a", "b", "c"], hint=True)
+        assert isinstance(result, str)
+        assert "a" in result
+
+    def test_valid_choice(self) -> None:
+        """Test valid choice."""
+        result = FieldValidators.one_of(choices=["yes", "no"], text="yes")
+        assert isinstance(result, Validation)
+        assert result.error_msg == ""
+        assert result.value == "yes"
+
+    def test_case_insensitive(self) -> None:
+        """Test case insensitive matching."""
+        result = FieldValidators.one_of(choices=["Yes", "No"], text="yes")
+        assert isinstance(result, Validation)
+        assert result.value == "Yes"
+        assert result.error_msg == ""
+
+    def test_invalid_choice(self) -> None:
+        """Test invalid choice."""
+        result = FieldValidators.one_of(choices=["a", "b"], text="c")
+        assert isinstance(result, Validation)
+        assert result.error_msg != ""
+
+
+class TestFieldValidatorsSomething:
+    """Tests for the something validator."""
+
+    def test_hint(self) -> None:
+        """Test hint returns message."""
+        result = FieldValidators.something(hint=True)
+        assert isinstance(result, str)
+        assert "required" in result
+
+    def test_with_text(self) -> None:
+        """Test with text passes."""
+        result = FieldValidators.something(text="hello")
+        assert isinstance(result, Validation)
+        assert result.error_msg == ""
+
+    def test_empty_text(self) -> None:
+        """Test empty text fails."""
+        result = FieldValidators.something(text="")
+        assert isinstance(result, Validation)
+        assert result.error_msg != ""
+
+
+class TestFieldValidatorsTrueFalse:
+    """Tests for the true_false validator."""
+
+    def test_hint(self) -> None:
+        """Test hint returns message."""
+        result = FieldValidators.true_false(hint=True)
+        assert isinstance(result, str)
+
+    def test_true(self) -> None:
+        """Test 'true' input."""
+        result = FieldValidators.true_false(text="true")
+        assert isinstance(result, Validation)
+        assert result.value is True
+        assert result.error_msg == ""
+
+    def test_true_prefix(self) -> None:
+        """Test 't' prefix is accepted."""
+        result = FieldValidators.true_false(text="t")
+        assert isinstance(result, Validation)
+        assert result.value is True
+
+    def test_false(self) -> None:
+        """Test 'false' input."""
+        result = FieldValidators.true_false(text="false")
+        assert isinstance(result, Validation)
+        assert result.value is False
+        assert result.error_msg == ""
+
+    def test_false_prefix(self) -> None:
+        """Test 'f' prefix is accepted."""
+        result = FieldValidators.true_false(text="f")
+        assert isinstance(result, Validation)
+        assert result.value is False
+
+    def test_invalid(self) -> None:
+        """Test invalid input."""
+        result = FieldValidators.true_false(text="maybe")
+        assert isinstance(result, Validation)
+        assert result.error_msg != ""
+
+    def test_empty(self) -> None:
+        """Test empty input."""
+        result = FieldValidators.true_false(text="")
+        assert isinstance(result, Validation)
+        assert result.error_msg != ""
+
+
+class TestFieldValidatorsValidFilePath:
+    """Tests for the valid_file_path validator."""
+
+    def test_hint(self) -> None:
+        """Test hint returns message."""
+        result = FieldValidators.valid_file_path(hint=True)
+        assert isinstance(result, str)
+
+    def test_valid_file(self, tmp_path: Path) -> None:
+        """Test with a valid file path."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("content")
+        result = FieldValidators.valid_file_path(text=str(test_file))
+        assert isinstance(result, Validation)
+        assert result.error_msg == ""
+
+    def test_invalid_file(self) -> None:
+        """Test with a nonexistent file."""
+        result = FieldValidators.valid_file_path(text="/nonexistent/file.txt")
+        assert isinstance(result, Validation)
+        assert result.error_msg != ""
+
+    def test_directory_not_file(self, tmp_path: Path) -> None:
+        """Test with a directory path (not a file)."""
+        result = FieldValidators.valid_file_path(text=str(tmp_path))
+        assert isinstance(result, Validation)
+        assert result.error_msg != ""
+
+
+class TestFieldValidatorsValidPath:
+    """Tests for the valid_path validator."""
+
+    def test_hint(self) -> None:
+        """Test hint returns message."""
+        result = FieldValidators.valid_path(hint=True)
+        assert isinstance(result, str)
+
+    def test_valid_directory(self, tmp_path: Path) -> None:
+        """Test with a valid directory path."""
+        result = FieldValidators.valid_path(text=str(tmp_path))
+        assert isinstance(result, Validation)
+        assert result.error_msg == ""
+
+    def test_invalid_path(self) -> None:
+        """Test with a nonexistent path."""
+        result = FieldValidators.valid_path(text="/nonexistent/path")
+        assert isinstance(result, Validation)
+        assert result.error_msg != ""
+
+
+class TestFieldValidatorsValidPathOrNone:
+    """Tests for the valid_path_or_none validator."""
+
+    def test_hint(self) -> None:
+        """Test hint returns message."""
+        result = FieldValidators.valid_path_or_none(hint=True)
+        assert isinstance(result, str)
+
+    def test_empty_is_valid(self) -> None:
+        """Test empty string is valid."""
+        result = FieldValidators.valid_path_or_none(text="")
+        assert isinstance(result, Validation)
+        assert result.error_msg == ""
+
+    def test_valid_path(self, tmp_path: Path) -> None:
+        """Test with a valid path."""
+        result = FieldValidators.valid_path_or_none(text=str(tmp_path))
+        assert isinstance(result, Validation)
+        assert result.error_msg == ""
+
+    def test_invalid_path(self) -> None:
+        """Test with a nonexistent path."""
+        result = FieldValidators.valid_path_or_none(text="/nonexistent")
+        assert isinstance(result, Validation)
+        assert result.error_msg != ""
+
+
+class TestFieldValidatorsYesNo:
+    """Tests for the yes_no validator."""
+
+    def test_hint(self) -> None:
+        """Test hint returns message."""
+        result = FieldValidators.yes_no(hint=True)
+        assert isinstance(result, str)
+
+    def test_yes(self) -> None:
+        """Test 'yes' input."""
+        result = FieldValidators.yes_no(text="yes")
+        assert isinstance(result, Validation)
+        assert result.value == "yes"
+        assert result.error_msg == ""
+
+    def test_yes_prefix(self) -> None:
+        """Test 'y' prefix is accepted."""
+        result = FieldValidators.yes_no(text="y")
+        assert isinstance(result, Validation)
+        assert result.value == "yes"
+
+    def test_no(self) -> None:
+        """Test 'no' input."""
+        result = FieldValidators.yes_no(text="no")
+        assert isinstance(result, Validation)
+        assert result.value == "no"
+        assert result.error_msg == ""
+
+    def test_no_prefix(self) -> None:
+        """Test 'n' prefix is accepted."""
+        result = FieldValidators.yes_no(text="n")
+        assert isinstance(result, Validation)
+        assert result.value == "no"
+
+    def test_invalid(self) -> None:
+        """Test invalid input."""
+        result = FieldValidators.yes_no(text="maybe")
+        assert isinstance(result, Validation)
+        assert result.error_msg != ""
+
+    def test_empty(self) -> None:
+        """Test empty input."""
+        result = FieldValidators.yes_no(text="")
+        assert isinstance(result, Validation)
+        assert result.error_msg != ""
+
+
+@dataclass
+class MockCheckbox:
+    """A mock checkbox for testing some_of_or_none."""
+
+    checked: bool
+
+
+class TestFieldValidatorsSomeOfOrNone:
+    """Tests for the some_of_or_none validator."""
+
+    def test_hint_equal_min_max(self) -> None:
+        """Test hint with equal min and max."""
+        result = FieldValidators.some_of_or_none(min_selected=1, max_selected=1, hint=True)
+        assert isinstance(result, str)
+        assert "1 entry" in result
+
+    def test_hint_range(self) -> None:
+        """Test hint with range."""
+        result = FieldValidators.some_of_or_none(min_selected=1, max_selected=3, hint=True)
+        assert isinstance(result, str)
+        assert "1" in result
+        assert "3" in result
+
+    def test_hint_unlimited(self) -> None:
+        """Test hint with max_selected=-1 (all)."""
+        result = FieldValidators.some_of_or_none(min_selected=1, max_selected=-1, hint=True)
+        assert isinstance(result, str)
+        assert "all" in result
+
+    def test_valid_selection(self) -> None:
+        """Test valid number of selections."""
+        choices = [MockCheckbox(checked=True), MockCheckbox(checked=False)]
+        result = FieldValidators.some_of_or_none(
+            choices=choices,
+            min_selected=1,
+            max_selected=2,
+        )
+        assert isinstance(result, Validation)
+        assert result.error_msg == ""
+
+    def test_too_few_selected(self) -> None:
+        """Test too few selections."""
+        choices = [MockCheckbox(checked=False), MockCheckbox(checked=False)]
+        result = FieldValidators.some_of_or_none(
+            choices=choices,
+            min_selected=1,
+            max_selected=2,
+        )
+        assert isinstance(result, Validation)
+        assert result.error_msg != ""
+
+    def test_type_error(self) -> None:
+        """Test TypeError with wrong types."""
+        with pytest.raises(TypeError):
+            FieldValidators.some_of_or_none(
+                choices=unknown,
+                min_selected=unknown,
+                max_selected=unknown,
+            )
+
+
+class TestFormValidatorsAllTrue:
+    """Tests for the all_true form validator."""
+
+    def test_hint(self) -> None:
+        """Test hint returns message."""
+        result = FormValidators.all_true(hint=True)
+        assert isinstance(result, str)
+
+    def test_all_true(self) -> None:
+        """Test all values are True."""
+        result = FormValidators.all_true(response=[True, True, True])
+        assert isinstance(result, Validation)
+        assert result.error_msg == ""
+
+    def test_not_all_true(self) -> None:
+        """Test not all values are True."""
+        result = FormValidators.all_true(response=[True, False, True])
+        assert isinstance(result, Validation)
+        assert result.error_msg != ""
+
+    def test_empty_list(self) -> None:
+        """Test empty list is valid."""
+        result = FormValidators.all_true(response=[])
+        assert isinstance(result, Validation)
+        assert result.error_msg == ""
+
+    def test_none_response(self) -> None:
+        """Test None response defaults to empty list."""
+        result = FormValidators.all_true(response=None)
+        assert isinstance(result, Validation)
+        assert result.error_msg == ""
+
+
+class TestFormValidatorsNoValidation:
+    """Tests for the no_validation form validator."""
+
+    def test_hint(self) -> None:
+        """Test hint returns empty string."""
+        result = FormValidators.no_validation(hint=True)
+        assert result == ""
+
+    def test_with_response(self) -> None:
+        """Test with response passes through."""
+        result = FormValidators.no_validation(response=[1, 2, 3])
+        assert isinstance(result, Validation)
+        assert result.error_msg == ""

--- a/tests/unit/utils/test_ansi.py
+++ b/tests/unit/utils/test_ansi.py
@@ -1,0 +1,172 @@
+"""Tests for the ansi module."""
+
+from __future__ import annotations
+
+import pytest
+
+from ansible_navigator.utils.ansi import blank_line
+from ansible_navigator.utils.ansi import changed
+from ansible_navigator.utils.ansi import failed
+from ansible_navigator.utils.ansi import info
+from ansible_navigator.utils.ansi import prompt_enter
+from ansible_navigator.utils.ansi import prompt_yn
+from ansible_navigator.utils.ansi import subtle
+from ansible_navigator.utils.ansi import success
+from ansible_navigator.utils.ansi import warning
+from ansible_navigator.utils.ansi import working
+from ansible_navigator.utils.definitions import Color
+
+
+def test_changed_with_color(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test changed output with color enabled."""
+    changed(color=True, message="something changed")
+    captured = capsys.readouterr()
+    assert Color.YELLOW in captured.out
+    assert "something changed" in captured.out
+    assert Color.END in captured.out
+
+
+def test_changed_without_color(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test changed output without color."""
+    changed(color=False, message="something changed")
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "something changed"
+    assert Color.YELLOW not in captured.out
+
+
+def test_failed_with_color(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test failed output with color enabled."""
+    failed(color=True, message="it failed")
+    captured = capsys.readouterr()
+    assert Color.RED in captured.out
+    assert "it failed" in captured.out
+
+
+def test_failed_without_color(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test failed output without color."""
+    failed(color=False, message="it failed")
+    assert capsys.readouterr().out.strip() == "it failed"
+
+
+def test_info_with_color(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test info output with color enabled."""
+    info(color=True, message="some info")
+    captured = capsys.readouterr()
+    assert Color.CYAN in captured.out
+    assert "some info" in captured.out
+
+
+def test_info_without_color(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test info output without color."""
+    info(color=False, message="some info")
+    assert capsys.readouterr().out.strip() == "some info"
+
+
+def test_subtle_with_color(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test subtle output with color enabled."""
+    subtle(color=True, message="subtle msg")
+    captured = capsys.readouterr()
+    assert Color.GREY in captured.out
+    assert "subtle msg" in captured.out
+
+
+def test_subtle_without_color(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test subtle output without color."""
+    subtle(color=False, message="subtle msg")
+    assert capsys.readouterr().out.strip() == "subtle msg"
+
+
+def test_success_with_color(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test success output with color enabled."""
+    success(color=True, message="it worked")
+    captured = capsys.readouterr()
+    assert Color.GREEN in captured.out
+    assert "it worked" in captured.out
+
+
+def test_success_without_color(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test success output without color."""
+    success(color=False, message="it worked")
+    assert capsys.readouterr().out.strip() == "it worked"
+
+
+def test_warning_with_color(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test warning output with color enabled."""
+    warning(color=True, message="be careful")
+    captured = capsys.readouterr()
+    assert Color.YELLOW in captured.out
+    assert "be careful" in captured.out
+
+
+def test_warning_without_color(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test warning output without color."""
+    warning(color=False, message="be careful")
+    assert capsys.readouterr().out.strip() == "be careful"
+
+
+def test_working_with_color(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test working output with color enabled."""
+    working(color=True, message="processing")
+    captured = capsys.readouterr()
+    assert Color.GREY in captured.out
+    assert "processing" in captured.out
+
+
+def test_working_without_color(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test working output without color."""
+    working(color=False, message="processing")
+    assert capsys.readouterr().out.strip() == "processing"
+
+
+def test_blank_line(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test blank line output."""
+    blank_line()
+    assert capsys.readouterr().out == "\n"
+
+
+def test_prompt_enter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test prompt_enter with normal input."""
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    prompt_enter()
+
+
+def test_prompt_enter_keyboard_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test prompt_enter exits on KeyboardInterrupt."""
+
+    def raise_keyboard_interrupt(_: str) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("builtins.input", raise_keyboard_interrupt)
+    with pytest.raises(SystemExit) as exc_info:
+        prompt_enter()
+    assert exc_info.value.code == 0
+
+
+def test_prompt_yn_yes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test prompt_yn returns True for 'y'."""
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    assert prompt_yn("Continue?") is True
+
+
+def test_prompt_yn_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test prompt_yn returns True for empty input (default yes)."""
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    assert prompt_yn("Continue?") is True
+
+
+def test_prompt_yn_no(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test prompt_yn returns False for 'n'."""
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    assert prompt_yn("Continue?") is False
+
+
+def test_prompt_yn_keyboard_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test prompt_yn exits on KeyboardInterrupt."""
+
+    def raise_keyboard_interrupt(_: str) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("builtins.input", raise_keyboard_interrupt)
+    with pytest.raises(SystemExit) as exc_info:
+        prompt_yn("Continue?")
+    assert exc_info.value.code == 0

--- a/tests/unit/utils/test_definitions.py
+++ b/tests/unit/utils/test_definitions.py
@@ -1,0 +1,188 @@
+"""Tests for the definitions module."""
+
+from __future__ import annotations
+
+import logging
+
+from ansible_navigator.utils.definitions import Color
+from ansible_navigator.utils.definitions import Decoration
+from ansible_navigator.utils.definitions import ExitMessage
+from ansible_navigator.utils.definitions import ExitMessages
+from ansible_navigator.utils.definitions import ExitPrefix
+from ansible_navigator.utils.definitions import LogMessage
+
+
+class TestExitPrefix:
+    """Tests for the ExitPrefix enum."""
+
+    def test_error_value(self) -> None:
+        """Test ERROR prefix value."""
+        assert ExitPrefix.ERROR.value == "Error"
+
+    def test_hint_value(self) -> None:
+        """Test HINT prefix value."""
+        assert ExitPrefix.HINT.value == "Hint"
+
+    def test_note_value(self) -> None:
+        """Test NOTE prefix value."""
+        assert ExitPrefix.NOTE.value == "Note"
+
+    def test_warning_value(self) -> None:
+        """Test WARNING prefix value."""
+        assert ExitPrefix.WARNING.value == "Warning"
+
+    def test_str_format(self) -> None:
+        """Test string formatting includes aligned prefix."""
+        result = str(ExitPrefix.ERROR)
+        assert "Error:" in result
+
+    def test_longest_formatted(self) -> None:
+        """Test longest_formatted returns an integer."""
+        result = ExitPrefix.longest_formatted()
+        assert isinstance(result, int)
+        assert result > 0
+
+
+class TestExitMessage:
+    """Tests for the ExitMessage dataclass."""
+
+    def test_default_prefix(self) -> None:
+        """Test default prefix is ERROR."""
+        msg = ExitMessage(message="test")
+        assert msg.prefix == ExitPrefix.ERROR
+
+    def test_color_property(self) -> None:
+        """Test color property returns a color string."""
+        msg = ExitMessage(message="test", prefix=ExitPrefix.ERROR)
+        assert msg.color == Color.RED
+
+    def test_color_hint(self) -> None:
+        """Test hint color."""
+        msg = ExitMessage(message="test", prefix=ExitPrefix.HINT)
+        assert msg.color == Color.CYAN
+
+    def test_color_note(self) -> None:
+        """Test note color."""
+        msg = ExitMessage(message="test", prefix=ExitPrefix.NOTE)
+        assert msg.color == Color.GREEN
+
+    def test_color_warning(self) -> None:
+        """Test warning color."""
+        msg = ExitMessage(message="test", prefix=ExitPrefix.WARNING)
+        assert msg.color == Color.YELLOW
+
+    def test_level_error(self) -> None:
+        """Test level for error messages."""
+        msg = ExitMessage(message="test", prefix=ExitPrefix.ERROR)
+        assert msg.level == logging.ERROR
+
+    def test_level_hint(self) -> None:
+        """Test level for hint messages."""
+        msg = ExitMessage(message="test", prefix=ExitPrefix.HINT)
+        assert msg.level == logging.INFO
+
+    def test_level_warning(self) -> None:
+        """Test level for warning messages."""
+        msg = ExitMessage(message="test", prefix=ExitPrefix.WARNING)
+        assert msg.level == logging.WARNING
+
+    def test_to_lines_with_color(self) -> None:
+        """Test to_lines with color enabled."""
+        msg = ExitMessage(message="test error")
+        lines = msg.to_lines(color=True, width=80, with_prefix=True)
+        assert len(lines) >= 1
+        assert Color.RED in lines[0]
+        assert "test error" in lines[0]
+
+    def test_to_lines_without_color(self) -> None:
+        """Test to_lines without color."""
+        msg = ExitMessage(message="test error")
+        lines = msg.to_lines(color=False, width=80, with_prefix=True)
+        assert len(lines) >= 1
+        assert Color.RED not in lines[0]
+
+    def test_to_lines_without_prefix(self) -> None:
+        """Test to_lines without prefix."""
+        msg = ExitMessage(message="test error")
+        lines = msg.to_lines(color=False, width=80, with_prefix=False)
+        assert len(lines) >= 1
+
+
+class TestExitMessages:
+    """Tests for the ExitMessages container."""
+
+    def test_empty_messages(self) -> None:
+        """Test with no messages."""
+        msgs = ExitMessages()
+        result = msgs.to_strings(color=False, width=80)
+        assert not result
+
+    def test_single_message(self) -> None:
+        """Test with a single message."""
+        msgs = ExitMessages(messages=[ExitMessage(message="error1")])
+        result = msgs.to_strings(color=False, width=80)
+        assert len(result) >= 1
+        assert "error1" in result[0]
+
+    def test_multiple_same_prefix(self) -> None:
+        """Test with multiple messages of same prefix."""
+        msgs = ExitMessages(
+            messages=[
+                ExitMessage(message="err1"),
+                ExitMessage(message="err2"),
+            ]
+        )
+        result = msgs.to_strings(color=False, width=80)
+        assert len(result) >= 2
+
+    def test_different_prefixes_with_separator(self) -> None:
+        """Test messages with different prefixes get separator."""
+        msgs = ExitMessages(
+            messages=[
+                ExitMessage(message="error", prefix=ExitPrefix.ERROR),
+                ExitMessage(message="note", prefix=ExitPrefix.NOTE),
+            ]
+        )
+        result = msgs.to_strings(color=False, width=80)
+        assert "" in result
+
+    def test_hint_follows_without_break(self) -> None:
+        """Test hint after error doesn't get blank line separator."""
+        msgs = ExitMessages(
+            messages=[
+                ExitMessage(message="error", prefix=ExitPrefix.ERROR),
+                ExitMessage(message="try this", prefix=ExitPrefix.HINT),
+            ]
+        )
+        result = msgs.to_strings(color=False, width=80)
+        assert "" not in result
+
+
+class TestLogMessage:
+    """Tests for the LogMessage NamedTuple."""
+
+    def test_creation(self) -> None:
+        """Test creating a log message."""
+        msg = LogMessage(level=logging.INFO, message="test")
+        assert msg.level == logging.INFO
+        assert msg.message == "test"
+
+
+class TestColor:
+    """Tests for Color constants."""
+
+    def test_has_red(self) -> None:
+        """Test RED color exists."""
+        assert Color.RED == "\033[31m"
+
+    def test_has_end(self) -> None:
+        """Test END color exists."""
+        assert Color.END == "\033[0m"
+
+
+class TestDecoration:
+    """Tests for Decoration constants."""
+
+    def test_has_bold(self) -> None:
+        """Test BOLD exists."""
+        assert Decoration.BOLD == "\033[1m"

--- a/tests/unit/utils/test_functions_extended.py
+++ b/tests/unit/utils/test_functions_extended.py
@@ -1,0 +1,360 @@
+"""Tests for additional functions in the functions module."""
+
+from __future__ import annotations
+
+import shutil
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch  # pylint: disable=preferred-module
+
+import pytest
+
+from ansible_navigator.utils.functions import check_for_ansible
+from ansible_navigator.utils.functions import check_playbook_type
+from ansible_navigator.utils.functions import clear_screen
+from ansible_navigator.utils.functions import console_width
+from ansible_navigator.utils.functions import dispatch
+from ansible_navigator.utils.functions import divmod_int
+from ansible_navigator.utils.functions import escape_moustaches
+from ansible_navigator.utils.functions import is_jinja
+from ansible_navigator.utils.functions import pascal_to_snake
+from ansible_navigator.utils.functions import remove_ansi
+from ansible_navigator.utils.functions import remove_dbl_un
+from ansible_navigator.utils.functions import shlex_join
+from ansible_navigator.utils.functions import str2bool
+from ansible_navigator.utils.functions import templar
+from ansible_navigator.utils.functions import time_stamp_for_file
+from ansible_navigator.utils.functions import timestamp_to_iso
+from ansible_navigator.utils.functions import to_list
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_check_for_ansible_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test check_for_ansible when ansible-playbook is found."""
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/ansible-playbook")
+    messages, exit_messages = check_for_ansible()
+    assert len(messages) == 1
+    assert not exit_messages
+    assert "found at" in messages[0].message
+
+
+def test_check_for_ansible_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test check_for_ansible when ansible-playbook is not found."""
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+    messages, exit_messages = check_for_ansible()
+    assert not messages
+    assert len(exit_messages) == 1
+    assert "could not be found" in exit_messages[0].message
+
+
+def test_check_playbook_type_file(tmp_path: Path) -> None:
+    """Test check_playbook_type with an existing file."""
+    playbook = tmp_path / "playbook.yml"
+    playbook.write_text("---")
+    assert check_playbook_type(str(playbook)) == "file"
+
+
+def test_check_playbook_type_missing() -> None:
+    """Test check_playbook_type with a missing file."""
+    assert check_playbook_type("/nonexistent/playbook.yml") == "missing"
+
+
+def test_check_playbook_type_fqcn() -> None:
+    """Test check_playbook_type with an FQCN playbook."""
+    assert check_playbook_type("namespace.collection.playbook") == "fqcn"
+
+
+def test_clear_screen_vscode(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test clear_screen prints blank lines in vscode terminal."""
+    monkeypatch.setenv("TERM_PROGRAM", "vscode")
+    fake_size = type("TermSize", (), {"lines": 5, "columns": 80})()
+    with patch(
+        "ansible_navigator.utils.functions.shutil.get_terminal_size", return_value=fake_size
+    ):
+        clear_screen()
+    captured = capsys.readouterr()
+    assert captured.out.count("\n") == 5
+
+
+def test_clear_screen_normal(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test clear_screen does nothing in normal terminal."""
+    monkeypatch.setenv("TERM_PROGRAM", "xterm")
+    clear_screen()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_console_width_small() -> None:
+    """Test console_width with small terminal."""
+    fake_size = type("TermSize", (), {"columns": 60})()
+    with patch(
+        "ansible_navigator.utils.functions.shutil.get_terminal_size", return_value=fake_size
+    ):
+        assert console_width() == 60
+
+
+def test_console_width_medium() -> None:
+    """Test console_width with medium terminal."""
+    fake_size = type("TermSize", (), {"columns": 120})()
+    with patch(
+        "ansible_navigator.utils.functions.shutil.get_terminal_size", return_value=fake_size
+    ):
+        result = console_width()
+    assert 80 <= result <= 120
+
+
+def test_console_width_large() -> None:
+    """Test console_width with large terminal."""
+    fake_size = type("TermSize", (), {"columns": 200})()
+    with patch(
+        "ansible_navigator.utils.functions.shutil.get_terminal_size", return_value=fake_size
+    ):
+        assert console_width() == 132
+
+
+def test_dispatch_string() -> None:
+    """Test dispatch with string replacement."""
+    result = dispatch("hello world", (("hello", "hi"),))
+    assert result == "hi world"
+
+
+def test_dispatch_list() -> None:
+    """Test dispatch with list."""
+    result = dispatch(["hello", "world"], (("hello", "hi"),))
+    assert result == ["hi", "world"]
+
+
+def test_dispatch_dict() -> None:
+    """Test dispatch with dict."""
+    result = dispatch({"key": "hello"}, (("hello", "hi"),))
+    assert result == {"key": "hi"}
+
+
+def test_dispatch_nested() -> None:
+    """Test dispatch with nested structure."""
+    result = dispatch({"a": ["hello"]}, (("hello", "hi"),))
+    assert result == {"a": ["hi"]}
+
+
+def test_dispatch_non_string() -> None:
+    """Test dispatch with non-string value."""
+    result = dispatch(42, (("hello", "hi"),))
+    assert result == 42
+
+
+def test_escape_moustaches() -> None:
+    """Test escape_moustaches replaces braces."""
+    result = escape_moustaches({"key": "{{ value }}"})
+    assert "U+007B" in str(result)
+    assert "{" not in result["key"]
+
+
+def test_escape_moustaches_nested() -> None:
+    """Test escape_moustaches with nested dict."""
+    result = escape_moustaches({"a": {"b": "{test}"}})
+    assert "U+007B" in str(result)
+
+
+def test_is_jinja_true() -> None:
+    """Test is_jinja with jinja template."""
+    assert is_jinja("{{ variable }}") is True
+
+
+def test_is_jinja_false() -> None:
+    """Test is_jinja with plain string."""
+    assert is_jinja("no jinja here") is False
+
+
+def test_is_jinja_incomplete() -> None:
+    """Test is_jinja with incomplete template."""
+    assert is_jinja("{{ incomplete") is False
+
+
+def test_pascal_to_snake_string() -> None:
+    """Test pascal_to_snake with a plain string (no conversion)."""
+    assert pascal_to_snake("hello") == "hello"
+
+
+def test_pascal_to_snake_dict() -> None:
+    """Test pascal_to_snake with dict keys."""
+    result = pascal_to_snake({"MyKey": "value", "AnotherKey": "val2"})
+    assert result == {"my_key": "value", "another_key": "val2"}
+
+
+def test_pascal_to_snake_list() -> None:
+    """Test pascal_to_snake with list of dicts."""
+    result = pascal_to_snake([{"MyKey": "value"}])
+    assert result == [{"my_key": "value"}]
+
+
+def test_pascal_to_snake_nested() -> None:
+    """Test pascal_to_snake with nested dicts."""
+    result = pascal_to_snake({"OuterKey": {"InnerKey": "value"}})
+    assert result == {"outer_key": {"inner_key": "value"}}
+
+
+def test_remove_ansi() -> None:
+    """Test remove_ansi strips ANSI codes."""
+    ansi_string = "\033[31mred text\033[0m"  # cspell:disable-line
+    assert remove_ansi(ansi_string) == "red text"
+
+
+def test_remove_ansi_no_codes() -> None:
+    """Test remove_ansi with no ANSI codes."""
+    assert remove_ansi("plain text") == "plain text"
+
+
+def test_remove_ansi_complex() -> None:
+    """Test remove_ansi with complex ANSI sequences."""
+    ansi_string = "\033[38;2;255;0;0mcolored\033[m"  # cspell:disable-line
+    assert remove_ansi(ansi_string) == "colored"
+
+
+def test_remove_dbl_un_with_prefix() -> None:
+    """Test remove_dbl_un with __ prefix."""
+    assert remove_dbl_un("__name") == "name"
+
+
+def test_remove_dbl_un_without_prefix() -> None:
+    """Test remove_dbl_un without __ prefix."""
+    assert remove_dbl_un("name") == "name"
+
+
+def test_remove_dbl_un_single_underscore() -> None:
+    """Test remove_dbl_un with single underscore."""
+    assert remove_dbl_un("_name") == "_name"
+
+
+def test_str2bool_true_values() -> None:
+    """Test str2bool with truthy strings."""
+    assert str2bool("yes") is True
+    assert str2bool("true") is True
+    assert str2bool("YES") is True
+    assert str2bool("True") is True
+    assert str2bool(True) is True
+
+
+def test_str2bool_false_values() -> None:
+    """Test str2bool with falsy strings."""
+    assert str2bool("no") is False
+    assert str2bool("false") is False
+    assert str2bool("NO") is False
+    assert str2bool(False) is False
+
+
+def test_str2bool_invalid() -> None:
+    """Test str2bool with invalid value."""
+    with pytest.raises(ValueError):  # noqa: PT011
+        str2bool("maybe")
+
+
+def test_str2bool_int() -> None:
+    """Test str2bool with non-bool non-string."""
+    with pytest.raises(ValueError):  # noqa: PT011
+        str2bool(42)
+
+
+def test_templar_simple() -> None:
+    """Test templar with simple template."""
+    errors, result = templar("Hello {{ name }}", {"name": "world"})
+    assert not errors
+    assert result == "Hello world"
+
+
+def test_templar_error() -> None:
+    """Test templar with undefined variable."""
+    errors, _result = templar("{{ undefined_var }}", {})
+    assert len(errors) > 0
+
+
+def test_templar_with_moustaches_in_vars() -> None:
+    """Test templar with braces in template vars."""
+    errors, result = templar("{{ name }}", {"name": "test", "other": "{{ jinja }}"})
+    assert not errors
+    assert result == "test"
+
+
+def test_timestamp_to_iso_local() -> None:
+    """Test timestamp_to_iso with local timezone."""
+    result = timestamp_to_iso(0, "local")
+    assert result is not None
+    assert "T" in result
+
+
+def test_timestamp_to_iso_utc() -> None:
+    """Test timestamp_to_iso with UTC timezone."""
+    result = timestamp_to_iso(0, "UTC")
+    assert result is not None
+    assert "1970" in result
+
+
+def test_timestamp_to_iso_invalid_tz() -> None:
+    """Test timestamp_to_iso with invalid timezone."""
+    result = timestamp_to_iso(0, "Invalid/Zone")
+    assert result is None
+
+
+def test_time_stamp_for_file_exists(tmp_path: Path) -> None:
+    """Test time_stamp_for_file with existing file."""
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("content")
+    modified, iso_stamp = time_stamp_for_file(str(test_file), "UTC")
+    assert modified is not None
+    assert iso_stamp is not None
+
+
+def test_time_stamp_for_file_missing() -> None:
+    """Test time_stamp_for_file with missing file."""
+    modified, iso_stamp = time_stamp_for_file("/nonexistent/file", "UTC")
+    assert modified is None
+    assert iso_stamp is None
+
+
+def test_to_list_string() -> None:
+    """Test to_list with a string."""
+    assert to_list("hello") == ["hello"]
+
+
+def test_to_list_list() -> None:
+    """Test to_list with a list."""
+    assert to_list([1, 2, 3]) == [1, 2, 3]
+
+
+def test_to_list_tuple() -> None:
+    """Test to_list with a tuple."""
+    assert to_list(("a",)) == ["a"]
+
+
+def test_to_list_set() -> None:
+    """Test to_list with a set."""
+    result = to_list({1})
+    assert result == [1]
+
+
+def test_to_list_none() -> None:
+    """Test to_list with None."""
+    assert not to_list(None)
+
+
+def test_divmod_int() -> None:
+    """Test divmod_int returns integers."""
+    q, r = divmod_int(10.0, 3.0)
+    assert q == 3
+    assert r == 1
+    assert isinstance(q, int)
+    assert isinstance(r, int)
+
+
+def test_shlex_join() -> None:
+    """Test shlex_join concatenates tokens."""
+    result = shlex_join(["echo", "hello world"])
+    assert result == "echo 'hello world'"

--- a/tests/unit/utils/test_json_schema.py
+++ b/tests/unit/utils/test_json_schema.py
@@ -1,0 +1,161 @@
+"""Tests for the json_schema module."""
+
+from __future__ import annotations
+
+import json
+
+from collections import deque
+
+import pytest
+
+from ansible_navigator.utils.definitions import ExitMessage
+from ansible_navigator.utils.json_schema import JsonSchemaError
+from ansible_navigator.utils.json_schema import json_path
+from ansible_navigator.utils.json_schema import to_path
+from ansible_navigator.utils.json_schema import validate
+
+
+class TestToPath:
+    """Tests for the to_path function."""
+
+    def test_list_input(self) -> None:
+        """Test to_path with a list."""
+        assert to_path(["a", "b", "c"]) == "a.b.c"
+
+    def test_deque_input(self) -> None:
+        """Test to_path with a deque."""
+        assert to_path(deque(["a", "b"])) == "a.b"
+
+    def test_mixed_types(self) -> None:
+        """Test to_path with mixed types."""
+        assert to_path(["a", 1, "b"]) == "a.1.b"
+
+    def test_single_element(self) -> None:
+        """Test to_path with single element."""
+        assert to_path(["a"]) == "a"
+
+    def test_empty(self) -> None:
+        """Test to_path with empty sequence."""
+        assert to_path([]) == ""
+
+
+class TestJsonPath:
+    """Tests for the json_path function."""
+
+    def test_string_elements(self) -> None:
+        """Test json_path with string elements."""
+        assert json_path(["foo", "bar"]) == "$.foo.bar"
+
+    def test_integer_elements(self) -> None:
+        """Test json_path with integer elements."""
+        assert json_path([0, 1]) == "$[0][1]"
+
+    def test_mixed_elements(self) -> None:
+        """Test json_path with mixed elements."""
+        assert json_path(["foo", 0, "bar"]) == "$.foo[0].bar"
+
+    def test_empty(self) -> None:
+        """Test json_path with empty path."""
+        assert json_path([]) == "$"
+
+
+class TestJsonSchemaError:
+    """Tests for the JsonSchemaError dataclass."""
+
+    def test_to_friendly(self) -> None:
+        """Test to_friendly returns formatted message."""
+        error = JsonSchemaError(
+            message="is not valid",
+            data_path="a.b",
+            json_path="$.a.b",
+            schema_path="properties.a",
+            relative_schema="{}",
+            expected="string",
+            validator="type",
+            found="42",
+        )
+        assert error.to_friendly() == "In 'a.b': is not valid."
+
+    def test_to_exit_message(self) -> None:
+        """Test to_exit_message returns ExitMessage."""
+        error = JsonSchemaError(
+            message="is not valid",
+            data_path="x",
+            json_path="$.x",
+            schema_path="",
+            relative_schema="",
+            expected="",
+            validator="",
+            found="",
+        )
+        result = error.to_exit_message()
+        assert isinstance(result, ExitMessage)
+        assert "In 'x'" in result.message
+
+
+class TestValidate:
+    """Tests for the validate function."""
+
+    def test_valid_data(self) -> None:
+        """Test validate with valid data returns no errors."""
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+        }
+        errors = validate(schema, {"name": "test"})
+        assert not errors
+
+    def test_invalid_data(self) -> None:
+        """Test validate with invalid data returns errors."""
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+        }
+        errors = validate(schema, {"name": 42})
+        assert len(errors) > 0
+        assert errors[0].validator == "type"
+
+    def test_schema_as_json_string(self) -> None:
+        """Test validate with schema as JSON string."""
+        schema_str = json.dumps(
+            {
+                "type": "object",
+                "properties": {"age": {"type": "integer"}},
+            }
+        )
+        errors = validate(schema_str, {"age": 25})
+        assert not errors
+
+    def test_required_field_missing(self) -> None:
+        """Test validate detects missing required fields."""
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        }
+        errors = validate(schema, {})
+        assert len(errors) > 0
+
+    def test_error_fields_populated(self) -> None:
+        """Test validate populates error fields correctly."""
+        schema = {
+            "type": "object",
+            "properties": {"count": {"type": "integer"}},
+        }
+        errors = validate(schema, {"count": "not-a-number"})
+        assert len(errors) == 1
+        error = errors[0]
+        assert error.data_path == "count"
+        assert error.json_path == "$.count"
+        assert error.message != ""
+
+    def test_bool_schema_raises_type_error(self) -> None:
+        """Test validate raises TypeError on bool schema."""
+        with pytest.raises(TypeError, match="Unexpected schema data"):
+            validate(True, {})  # type: ignore[arg-type]
+
+    def test_invalid_schema(self) -> None:
+        """Test validate with an invalid schema returns schema error."""
+        bad_schema = {"type": "not_a_real_type"}
+        errors = validate(bad_schema, {})
+        assert len(errors) > 0

--- a/tests/unit/utils/test_key_value_store_extended.py
+++ b/tests/unit/utils/test_key_value_store_extended.py
@@ -1,0 +1,174 @@
+"""Tests for the key value store module."""
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ansible_navigator.utils.key_value_store import KeyValueStore
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def kvs(tmp_path: Path) -> KeyValueStore:
+    """Provide a fresh KeyValueStore instance.
+
+    Args:
+        tmp_path: Temporary directory
+
+    Returns:
+        A KeyValueStore instance
+    """
+    return KeyValueStore(tmp_path / "test.db")
+
+
+def test_path_property(kvs: KeyValueStore) -> None:
+    """Test path property returns the database path."""
+    assert kvs.path.endswith("test.db")
+
+
+def test_set_and_get(kvs: KeyValueStore) -> None:
+    """Test setting and getting a value."""
+    kvs["key1"] = "value1"
+    assert kvs["key1"] == "value1"
+
+
+def test_get_missing_key(kvs: KeyValueStore) -> None:
+    """Test getting a missing key raises KeyError."""
+    with pytest.raises(KeyError):
+        kvs["missing"]
+
+
+def test_overwrite_value(kvs: KeyValueStore) -> None:
+    """Test overwriting an existing key."""
+    kvs["key"] = "old"
+    kvs["key"] = "new"
+    assert kvs["key"] == "new"
+
+
+def test_delete_key(kvs: KeyValueStore) -> None:
+    """Test deleting a key."""
+    kvs["key"] = "value"
+    del kvs["key"]
+    assert "key" not in kvs
+
+
+def test_delete_missing_key(kvs: KeyValueStore) -> None:
+    """Test deleting a missing key raises KeyError."""
+    with pytest.raises(KeyError):
+        del kvs["missing"]
+
+
+def test_contains(kvs: KeyValueStore) -> None:
+    """Test the in operator."""
+    kvs["key"] = "value"
+    assert "key" in kvs
+    assert "missing" not in kvs
+
+
+def test_len_empty(kvs: KeyValueStore) -> None:
+    """Test len on empty store."""
+    assert len(kvs) == 0
+
+
+def test_len_with_items(kvs: KeyValueStore) -> None:
+    """Test len with items."""
+    kvs["a"] = "1"
+    kvs["b"] = "2"
+    assert len(kvs) == 2
+
+
+def test_iterkeys(kvs: KeyValueStore) -> None:
+    """Test iterkeys yields all keys."""
+    kvs["a"] = "1"
+    kvs["b"] = "2"
+    assert sorted(kvs.iterkeys()) == ["a", "b"]
+
+
+def test_itervalues(kvs: KeyValueStore) -> None:
+    """Test itervalues yields all values."""
+    kvs["a"] = "1"
+    kvs["b"] = "2"
+    assert sorted(kvs.itervalues()) == ["1", "2"]
+
+
+def test_iteritems(kvs: KeyValueStore) -> None:
+    """Test iteritems yields all items."""
+    kvs["a"] = "1"
+    kvs["b"] = "2"
+    items = sorted(kvs.iteritems())
+    assert items == [("a", "1"), ("b", "2")]
+
+
+def test_keys_view(kvs: KeyValueStore) -> None:
+    """Test keys returns a view."""
+    kvs["a"] = "1"
+    kvs["b"] = "2"
+    keys = kvs.keys()
+    assert "a" in keys
+    assert "b" in keys
+
+
+def test_values_view(kvs: KeyValueStore) -> None:
+    """Test values returns a view."""
+    kvs["a"] = "1"
+    values = kvs.values()
+    assert "1" in values
+
+
+def test_items_view(kvs: KeyValueStore) -> None:
+    """Test items returns a view."""
+    kvs["a"] = "1"
+    items = kvs.items()
+    assert ("a", "1") in items
+
+
+def test_iter(kvs: KeyValueStore) -> None:
+    """Test iterating over the store yields keys."""
+    kvs["a"] = "1"
+    kvs["b"] = "2"
+    assert sorted(kvs) == ["a", "b"]
+
+
+def test_repr_empty(kvs: KeyValueStore) -> None:
+    """Test repr of empty store."""
+    assert repr(kvs) == "KeyValueStore()"
+
+
+def test_repr_with_items(kvs: KeyValueStore) -> None:
+    """Test repr of store with items."""
+    kvs["key"] = "val"
+    result = repr(kvs)
+    assert "KeyValueStore" in result
+    assert "key" in result
+    assert "val" in result
+
+
+def test_close_and_reopen(tmp_path: Path) -> None:
+    """Test closing and reopening the store preserves data."""
+    db_path = tmp_path / "persist.db"
+    kvs = KeyValueStore(db_path)
+    kvs["key"] = "value"
+    kvs.close()
+
+    kvs2 = KeyValueStore(db_path)
+    assert kvs2["key"] == "value"
+    kvs2.close()
+
+
+def test_open_method(kvs: KeyValueStore) -> None:
+    """Test open_ method returns a connection."""
+    conn = kvs.open_()
+    assert conn is not None
+
+
+def test_init_with_path_object(tmp_path: Path) -> None:
+    """Test initialization with a Path object."""
+    kvs = KeyValueStore(tmp_path / "pathobj.db")
+    kvs["test"] = "value"
+    assert kvs["test"] == "value"

--- a/tests/unit/utils/test_print.py
+++ b/tests/unit/utils/test_print.py
@@ -1,0 +1,102 @@
+"""Tests for the print utility module."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ansible_navigator.ui_framework.curses_defs import SimpleLinePart
+from ansible_navigator.utils.print import color_bits
+from ansible_navigator.utils.print import color_lines
+
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class TestColorBits:
+    """Tests for the color_bits function."""
+
+    def test_truecolor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test COLORTERM=truecolor returns 24."""
+        monkeypatch.setenv("COLORTERM", "truecolor")
+        assert color_bits() == 24
+
+    def test_24bit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test COLORTERM=24bit returns 24."""
+        monkeypatch.setenv("COLORTERM", "24bit")
+        assert color_bits() == 24
+
+    def test_256color_term(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test TERM=xterm-256color returns 8."""
+        monkeypatch.delenv("COLORTERM", raising=False)
+        monkeypatch.setenv("TERM", "xterm-256color")
+        assert color_bits() == 8
+
+    def test_16color_term(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test TERM=xterm-16color returns 4."""
+        monkeypatch.delenv("COLORTERM", raising=False)
+        monkeypatch.setenv("TERM", "xterm-16color")
+        assert color_bits() == 4
+
+    def test_no_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test fallback with no color env vars returns 4."""
+        monkeypatch.delenv("COLORTERM", raising=False)
+        monkeypatch.delenv("TERM", raising=False)
+        assert color_bits() == 4
+
+    def test_plain_term(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test TERM=xterm (no color suffix) returns 4."""
+        monkeypatch.delenv("COLORTERM", raising=False)
+        monkeypatch.setenv("TERM", "xterm")
+        assert color_bits() == 4
+
+
+class TestColorLines:
+    """Tests for the color_lines function."""
+
+    def test_24bit_with_color(self) -> None:
+        """Test 24-bit color output."""
+        tokenized = [[SimpleLinePart(chars="red", column=0, color=(255, 0, 0), style=None)]]
+        result = color_lines(24, tokenized)
+        assert "\033[38;2;255;0;0m" in result
+        assert "red" in result
+
+    def test_24bit_none_color(self) -> None:
+        """Test 24-bit with None color defaults to white."""
+        tokenized = [[SimpleLinePart(chars="text", column=0, color=None, style=None)]]
+        result = color_lines(24, tokenized)
+        assert "\033[38;2;255;255;255m" in result
+        assert "text" in result
+
+    def test_8bit_none_color(self) -> None:
+        """Test 8-bit with None color uses ansi_color 1."""
+        tokenized = [[SimpleLinePart(chars="text", column=0, color=None, style=None)]]
+        result = color_lines(8, tokenized)
+        assert "\033[38;5;1m" in result
+
+    def test_multiple_parts(self) -> None:
+        """Test multiple parts in a line."""
+        tokenized = [
+            [
+                SimpleLinePart(chars="red", column=0, color=(255, 0, 0), style=None),
+                SimpleLinePart(chars="green", column=3, color=(0, 255, 0), style=None),
+            ]
+        ]
+        result = color_lines(24, tokenized)
+        assert "red" in result
+        assert "green" in result
+
+    def test_empty_input(self) -> None:
+        """Test empty input."""
+        result = color_lines(24, [])
+        assert result == ""
+
+    def test_multiple_lines(self) -> None:
+        """Test multiple lines."""
+        tokenized = [
+            [SimpleLinePart(chars="line1", column=0, color=(255, 0, 0), style=None)],
+            [SimpleLinePart(chars="line2", column=0, color=(0, 0, 255), style=None)],
+        ]
+        result = color_lines(24, tokenized)
+        assert "line1" in result
+        assert "line2" in result

--- a/tests/unit/utils/test_serialize_extended.py
+++ b/tests/unit/utils/test_serialize_extended.py
@@ -1,0 +1,275 @@
+"""Tests for extended serialize module functionality."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import stat
+
+from pathlib import Path
+
+import yaml
+
+from ansible_navigator.content_defs import ContentFormat
+from ansible_navigator.content_defs import ContentView
+from ansible_navigator.content_defs import SerializationFormat
+from ansible_navigator.utils.serialize import HumanDumper
+from ansible_navigator.utils.serialize import _is_multiline_string
+from ansible_navigator.utils.serialize import _json_dump
+from ansible_navigator.utils.serialize import _json_dumps
+from ansible_navigator.utils.serialize import _text_dump
+from ansible_navigator.utils.serialize import _yaml_dump
+from ansible_navigator.utils.serialize import _yaml_dumps
+from ansible_navigator.utils.serialize import serialize
+from ansible_navigator.utils.serialize import serialize_write_file
+from ansible_navigator.utils.serialize import serialize_write_temp_file
+from ansible_navigator.utils.serialize import write_diagnostics_json
+
+
+class TestSerialize:
+    """Tests for the serialize function."""
+
+    def test_serialize_json(self) -> None:
+        """Test serialize with JSON format."""
+        result = serialize(
+            content={"key": "value"},
+            content_view=ContentView.NORMAL,
+            serialization_format=SerializationFormat.JSON,
+        )
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed == {"key": "value"}
+
+    def test_serialize_yaml(self) -> None:
+        """Test serialize with YAML format."""
+        result = serialize(
+            content={"key": "value"},
+            content_view=ContentView.NORMAL,
+            serialization_format=SerializationFormat.YAML,
+        )
+        assert result is not None
+        assert "key: value" in result
+
+
+class TestJsonDumps:
+    """Tests for the _json_dumps function."""
+
+    def test_simple_dict(self) -> None:
+        """Test JSON dumps with simple dict."""
+        result = _json_dumps({"a": 1, "b": 2})
+        parsed = json.loads(result)
+        assert parsed == {"a": 1, "b": 2}
+
+    def test_non_serializable(self) -> None:
+        """Test JSON dumps with non-serializable object."""
+        result = _json_dumps({"key": {1, 2, 3}})
+        assert "could not be converted" in result
+
+
+class TestJsonDump:
+    """Tests for the _json_dump function."""
+
+    def test_writes_to_file(self) -> None:
+        """Test JSON dump writes to file handle."""
+        fh = io.StringIO()
+        _json_dump({"key": "value"}, fh)
+        content = fh.getvalue()
+        assert '"key": "value"' in content
+        assert content.endswith("\n")
+
+    def test_non_serializable(self) -> None:
+        """Test JSON dump with non-serializable writes error."""
+        fh = io.StringIO()
+        _json_dump({"key": {1, 2}}, fh)
+        content = fh.getvalue()
+        assert "could not be converted" in content
+
+
+class TestYamlDumps:
+    """Tests for the _yaml_dumps function."""
+
+    def test_simple_dict(self) -> None:
+        """Test YAML dumps with simple dict."""
+        result = _yaml_dumps({"key": "value"})
+        assert result is not None
+        assert "key: value" in result
+
+    def test_starts_with_document_marker(self) -> None:
+        """Test YAML starts with document marker."""
+        result = _yaml_dumps({"a": 1})
+        assert result is not None
+        assert result.startswith("---")
+
+
+class TestYamlDump:
+    """Tests for the _yaml_dump function."""
+
+    def test_writes_to_file(self) -> None:
+        """Test YAML dump writes to file handle."""
+        fh = io.StringIO()
+        _yaml_dump({"key": "value"}, fh)
+        content = fh.getvalue()
+        assert "key: value" in content
+
+
+class TestTextDump:
+    """Tests for the _text_dump function."""
+
+    def test_writes_text(self) -> None:
+        """Test text dump writes text."""
+        fh = io.StringIO()
+        _text_dump("hello world", fh)
+        assert fh.getvalue() == "hello world\n"
+
+    def test_no_extra_newline(self) -> None:
+        """Test text dump doesn't add extra newline."""
+        fh = io.StringIO()
+        _text_dump("hello\n", fh)
+        assert fh.getvalue() == "hello\n"
+
+
+class TestIsMultilineString:
+    """Tests for the _is_multiline_string function."""
+
+    def test_newline(self) -> None:
+        """Test detects newline."""
+        assert _is_multiline_string("line1\nline2") is True
+
+    def test_carriage_return(self) -> None:
+        """Test detects carriage return."""
+        assert _is_multiline_string("line1\rline2") is True
+
+    def test_single_line(self) -> None:
+        """Test single line returns False."""
+        assert _is_multiline_string("single line") is False
+
+    def test_empty_string(self) -> None:
+        """Test empty string returns False."""
+        assert _is_multiline_string("") is False
+
+    def test_unicode_line_separator(self) -> None:
+        """Test detects unicode line separator."""
+        assert _is_multiline_string("line1 line2") is True  # noqa: RUF001
+
+
+class TestHumanDumper:
+    """Tests for the HumanDumper class."""
+
+    def test_ignore_aliases(self) -> None:
+        """Test ignore_aliases always returns True."""
+        dumper = HumanDumper(io.StringIO(""))
+        assert dumper.ignore_aliases(None) is True
+        assert dumper.ignore_aliases([1, 2, 3]) is True
+
+    def test_multiline_block_style(self) -> None:
+        """Test multiline strings use block style."""
+        data = {"text": "line1\nline2\nline3"}
+        result = yaml.dump(data, Dumper=HumanDumper)
+        assert "|" in result
+
+
+class TestWriteDiagnosticsJson:
+    """Tests for the write_diagnostics_json function."""
+
+    def test_creates_file(self, tmp_path: Path) -> None:
+        """Test write_diagnostics_json creates a file."""
+        path = str(tmp_path / "diag.json")
+        write_diagnostics_json(path, 0o600, {"test": "data"})
+        assert Path(path).exists()
+
+    def test_file_content(self, tmp_path: Path) -> None:
+        """Test written file contains correct JSON."""
+        path = str(tmp_path / "diag.json")
+        write_diagnostics_json(path, 0o600, {"key": "value"})
+        content = json.loads(Path(path).read_text())
+        assert content == {"key": "value"}
+
+    def test_file_permissions(self, tmp_path: Path) -> None:
+        """Test written file has correct permissions."""
+        path = str(tmp_path / "diag.json")
+        write_diagnostics_json(path, 0o600, {})
+        file_stat = Path(path).stat()
+        mode = stat.S_IMODE(file_stat.st_mode)
+        assert mode == 0o600
+
+    def test_umask_restored(self, tmp_path: Path) -> None:
+        """Test umask is restored after writing."""
+        original_umask = os.umask(0o022)
+        os.umask(original_umask)
+        path = str(tmp_path / "diag.json")
+        write_diagnostics_json(path, 0o600, {})
+        current_umask = os.umask(0o022)
+        os.umask(current_umask)
+        assert current_umask == original_umask
+
+
+class TestSerializeWriteFile:
+    """Tests for the serialize_write_file function."""
+
+    def test_write_json(self, tmp_path: Path) -> None:
+        """Test writing JSON to a file."""
+        output = tmp_path / "out.json"
+        serialize_write_file(
+            content={"a": 1},
+            content_view=ContentView.NORMAL,
+            file_mode="w",
+            file=output,
+            serialization_format=SerializationFormat.JSON,
+        )
+        content = json.loads(output.read_text())
+        assert content == {"a": 1}
+
+    def test_write_yaml(self, tmp_path: Path) -> None:
+        """Test writing YAML to a file."""
+        output = tmp_path / "out.yml"
+        serialize_write_file(
+            content={"b": 2},
+            content_view=ContentView.NORMAL,
+            file_mode="w",
+            file=output,
+            serialization_format=SerializationFormat.YAML,
+        )
+        text = output.read_text()
+        assert "b: 2" in text
+
+
+class TestSerializeWriteTempFile:
+    """Tests for the serialize_write_temp_file function."""
+
+    def test_write_json_temp(self) -> None:
+        """Test writing JSON to a temp file."""
+        result = serialize_write_temp_file(
+            content={"x": 1},
+            content_view=ContentView.NORMAL,
+            content_format=ContentFormat.JSON,
+        )
+        assert result.exists()
+        assert result.suffix == ".json"
+        content = json.loads(result.read_text())
+        assert content == {"x": 1}
+        result.unlink()
+
+    def test_write_yaml_temp(self) -> None:
+        """Test writing YAML to a temp file."""
+        result = serialize_write_temp_file(
+            content={"y": 2},
+            content_view=ContentView.NORMAL,
+            content_format=ContentFormat.YAML,
+        )
+        assert result.exists()
+        assert result.suffix == ".yml"
+        assert "y: 2" in result.read_text()
+        result.unlink()
+
+    def test_write_text_temp(self) -> None:
+        """Test writing text (non-serialized) to a temp file."""
+        result = serialize_write_temp_file(
+            content="plain text content",
+            content_view=ContentView.NORMAL,
+            content_format=ContentFormat.TXT,
+        )
+        assert result.exists()
+        assert result.suffix == ".txt"
+        assert "plain text content" in result.read_text()
+        result.unlink()


### PR DESCRIPTION
## Summary

- Added 308 new unit tests across 12 test files to improve unit test coverage for utility and framework modules
- Focused on modules that were under-tested but highly testable in isolation (pure functions, data structures, validators)
- Overall unit test coverage improved from 50% to 54%, with several core modules now at 98-100%

## Why only a 4% overall increase?

While individual modules saw dramatic improvements (several going from 28-33% to 100%), the overall number moved only 4 percentage points because the codebase has roughly 10,000 lines of source and about 3,000 of those live in `actions/` and `ui_framework/` — modules that are tightly coupled to the curses-based TUI. Those action handlers and UI components rely on a running terminal, curses windows, and live user interactions, making them poor candidates for unit testing in isolation. They're already covered by the tmux-based integration test suite under `tests/integration/`. The utility and framework modules targeted here were the best candidates for pure unit tests, and they're now well covered.

## What changed

New test files covering:

| Module | Before | After |
|--------|--------|-------|
| `utils/ansi.py` | 33% | 100% |
| `ui_framework/validators.py` | 28% | 100% |
| `utils/functions.py` | 68% | 98% |
| `utils/key_value_store.py` | 55% | 99% |
| `steps.py` | 77% | 100% |
| `utils/json_schema.py` | 61% | 100% |
| `utils/definitions.py` | 91% | 100% |
| `content_defs.py` | 93% | 100% |
| `utils/serialize.py` | 60% | ~80% |
| `utils/print.py` | 30% | 72% |
| `command_runner/command_runner.py` | 58% | 62% |
| `data/image_introspect.py` | 30% | 42% |

All new tests run independently with `--noconftest` and do not require container engines or integration infrastructure.

## Test plan

- [x] All 308 new tests pass locally
- [x] No regressions in existing test suite (pre-existing failures are macOS `/tmp` symlink issues, unrelated)
- [x] Tests use appropriate mocking (monkeypatch, unittest.mock) to avoid external dependencies
- [x] Tests follow existing project conventions (Google-style docstrings, type hints, pytest patterns)