### PR TITLE
chore: exclude .agents/skills/ from markdownlint and prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
     hooks:
       - id: markdownlint
         exclude:
-          "(?x)^\n  (\n    \\.github/ISSUE_TEMPLATE/\\w+|\n    docs/(\n      faq|\n
+          "(?x)^\n  (\n    \\.agents/skills/.+|\n    \\.github/ISSUE_TEMPLATE/\\w+|\n    docs/(\n      faq|\n
           \     index|\n    )|\n    README|\n    src/ansible_navigator/data/(help|welcome)\n
           \ )\\.md\n$\n"
   - repo: https://github.com/codespell-project/codespell

--- a/.prettierignore
+++ b/.prettierignore
@@ -35,3 +35,6 @@ README.md
 # mkdocs
 site/
 docs/.generated
+
+# skill files
+.agents/skills/


### PR DESCRIPTION
## Summary
- Add `.agents/skills/.+` to the markdownlint exclude regex in `.pre-commit-config.yaml`
- Add `.agents/skills/` to `.prettierignore`

This prevents skill markdown files from being reformatted or flagged by linters, since they have their own formatting conventions.

## Test plan
- [x] `tox -e lint` passes with all checks green

Assisted-by: Claude Code