### PR TITLE
fix: handle missing tzdata gracefully for UTC timezone

### DIFF
--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -1311,8 +1311,10 @@ class NavigatorPostProcessor:
             f" {entry.value.source.value.lower()}, "
         )
         if isinstance(entry.value.current, str):
+            if entry.value.current in ("UTC", "local"):
+                return messages, exit_messages
             available_timezones = sorted(zoneinfo.available_timezones())
-            if entry.value.current in available_timezones or entry.value.current == "local":
+            if entry.value.current in available_timezones:
                 return messages, exit_messages
             exit_msg += "could not be found."
         else:

--- a/src/ansible_navigator/logger.py
+++ b/src/ansible_navigator/logger.py
@@ -53,10 +53,21 @@ class Formatter(logging.Formatter):
                 .astimezone()
                 .isoformat()
             )
-        return datetime.datetime.fromtimestamp(
-            record.created,
-            tz=zoneinfo.ZoneInfo(self._time_zone),
-        ).isoformat()
+        if self._time_zone == "UTC":
+            return datetime.datetime.fromtimestamp(
+                record.created,
+                tz=datetime.timezone.utc,
+            ).isoformat()
+        try:
+            return datetime.datetime.fromtimestamp(
+                record.created,
+                tz=zoneinfo.ZoneInfo(self._time_zone),
+            ).isoformat()
+        except zoneinfo.ZoneInfoNotFoundError:
+            return datetime.datetime.fromtimestamp(
+                record.created,
+                tz=datetime.timezone.utc,
+            ).isoformat()
 
 
 def setup_logger(args: ApplicationConfiguration) -> None:

--- a/src/ansible_navigator/utils/functions.py
+++ b/src/ansible_navigator/utils/functions.py
@@ -367,6 +367,8 @@ def now_iso(time_zone: str) -> str:
     """
     if time_zone == "local":
         return datetime.datetime.now(tz=datetime.timezone.utc).astimezone().isoformat()
+    if time_zone == "UTC":
+        return datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
     try:
         return datetime.datetime.now(tz=zoneinfo.ZoneInfo(time_zone)).isoformat()
     except zoneinfo.ZoneInfoNotFoundError:
@@ -565,6 +567,11 @@ def timestamp_to_iso(timestamp: float, time_zone: str) -> str | None:
                 .astimezone()
                 .isoformat()
             )
+        if time_zone == "UTC":
+            return datetime.datetime.fromtimestamp(
+                timestamp,
+                tz=datetime.timezone.utc,
+            ).isoformat()
         return datetime.datetime.fromtimestamp(
             timestamp,
             tz=zoneinfo.ZoneInfo(time_zone),

--- a/tests/unit/configuration_subsystem/post_processors/test_time_zone.py
+++ b/tests/unit/configuration_subsystem/post_processors/test_time_zone.py
@@ -143,6 +143,32 @@ def test_pp_direct(data: Scenario) -> None:
         assert entry.value.current == data.expected
 
 
+def test_utc_accepted_without_tzdata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that UTC is accepted even when zoneinfo has no timezone data.
+
+    Args:
+        monkeypatch: The monkey patch fixture
+    """
+    monkeypatch.setattr(
+        "ansible_navigator.configuration_subsystem.navigator_post_processor"
+        ".zoneinfo.available_timezones",
+        set,
+    )
+
+    settings = deepcopy(NavigatorConfiguration)
+    entry = settings.entry("time_zone")
+    entry.value.current = "UTC"
+    entry.value.source = C.USER_CLI
+
+    _messages, exit_messages = NavigatorPostProcessor().time_zone(
+        entry=entry,
+        config=settings,
+    )
+
+    assert not exit_messages
+    assert entry.value.current == "UTC"
+
+
 env_var_test_data = [s for s in test_data if s.source is C.ENVIRONMENT_VARIABLE]
 
 

--- a/tests/unit/logger/test_format_time.py
+++ b/tests/unit/logger/test_format_time.py
@@ -1,0 +1,122 @@
+"""Tests for Formatter.formatTime with missing timezone data."""
+
+from __future__ import annotations
+
+import logging
+import zoneinfo
+
+import pytest
+
+from ansible_navigator.logger import Formatter
+
+
+@pytest.fixture(name="log_record")
+def log_record_fixture() -> logging.LogRecord:
+    """Create a log record for testing.
+
+    Returns:
+        A log record with a fixed timestamp
+    """
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="test message",
+        args=(),
+        exc_info=None,
+    )
+    record.created = 1700000000.0
+    return record
+
+
+def test_utc_uses_builtin(log_record: logging.LogRecord) -> None:
+    """Test that UTC bypasses zoneinfo and uses datetime.timezone.utc.
+
+    Args:
+        log_record: The log record fixture
+    """
+    formatter = Formatter(time_zone="UTC")
+    result = formatter.formatTime(log_record)
+
+    assert "+00:00" in result
+    assert "2023-11-14" in result
+
+
+def test_utc_works_without_tzdata(
+    monkeypatch: pytest.MonkeyPatch,
+    log_record: logging.LogRecord,
+) -> None:
+    """Test that UTC works even when zoneinfo.ZoneInfo would raise.
+
+    Args:
+        monkeypatch: The monkey patch fixture
+        log_record: The log record fixture
+    """
+    monkeypatch.setattr(
+        "ansible_navigator.logger.zoneinfo.ZoneInfo",
+        _raise_zone_info_not_found,
+    )
+    formatter = Formatter(time_zone="UTC")
+    result = formatter.formatTime(log_record)
+
+    assert "+00:00" in result
+
+
+def test_local_timezone(log_record: logging.LogRecord) -> None:
+    """Test that local timezone works without zoneinfo.
+
+    Args:
+        log_record: The log record fixture
+    """
+    formatter = Formatter(time_zone="local")
+    result = formatter.formatTime(log_record)
+
+    assert "2023-11-14" in result
+
+
+def test_fallback_on_missing_tzdata(
+    monkeypatch: pytest.MonkeyPatch,
+    log_record: logging.LogRecord,
+) -> None:
+    """Test that a non-UTC timezone falls back to UTC when tzdata is missing.
+
+    Args:
+        monkeypatch: The monkey patch fixture
+        log_record: The log record fixture
+    """
+    monkeypatch.setattr(
+        "ansible_navigator.logger.zoneinfo.ZoneInfo",
+        _raise_zone_info_not_found,
+    )
+    formatter = Formatter(time_zone="America/New_York")
+    result = formatter.formatTime(log_record)
+
+    assert "+00:00" in result
+
+
+def test_valid_non_utc_timezone(log_record: logging.LogRecord) -> None:
+    """Test that a valid non-UTC timezone works normally.
+
+    Args:
+        log_record: The log record fixture
+    """
+    if "Japan" not in zoneinfo.available_timezones():
+        pytest.skip("tzdata not available")
+
+    formatter = Formatter(time_zone="Japan")
+    result = formatter.formatTime(log_record)
+
+    assert "+09:00" in result
+
+
+def _raise_zone_info_not_found(key: str) -> None:
+    """Simulate missing tzdata by raising ZoneInfoNotFoundError.
+
+    Args:
+        key: The timezone key
+
+    Raises:
+        zoneinfo.ZoneInfoNotFoundError: Always
+    """
+    raise zoneinfo.ZoneInfoNotFoundError(key)


### PR DESCRIPTION
## Summary
- Use `datetime.timezone.utc` (always available in stdlib) instead of `zoneinfo.ZoneInfo("UTC")` for the default UTC timezone, avoiding a crash when tzdata files are missing
- Add `try/except ZoneInfoNotFoundError` fallback in the logger's `formatTime` for non-UTC timezones
- Accept "UTC" and "local" unconditionally in the `time_zone` post-processor validation, bypassing `zoneinfo.available_timezones()` which returns empty when tzdata is missing
- Apply the same UTC fast path to `now_iso` and `timestamp_to_iso` utility functions

## Context

In UBI-based container images (e.g. `ansible-devspaces-rhel9`), the `tzdata` RPM is registered in the RPM database but its files (`/usr/share/zoneinfo/`) are stripped from the filesystem. When the Python `tzdata` package is also absent, `zoneinfo.ZoneInfo("UTC")` raises `ZoneInfoNotFoundError`, causing ansible-navigator to crash during logger initialization before any useful error message can be emitted.

The crash manifests as a cascading failure:
1. The `time_zone` post-processor rejects "UTC" (the default) because `available_timezones()` returns an empty set
2. Configuration rolls back, but `setup_logger` still uses "UTC" as the default
3. `Formatter.formatTime` calls `zoneinfo.ZoneInfo("UTC")` which raises `ZoneInfoNotFoundError`

## Test plan
- [x] New unit tests for `Formatter.formatTime` covering UTC fast path, missing tzdata fallback, and local timezone
- [x] New unit test for post-processor accepting UTC when `available_timezones()` is empty
- [x] All existing timezone tests continue to pass (24/24)