### PR TITLE
fix: optimize image introspection with section filtering

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -166,7 +166,7 @@ jobs:
           path: .
 
       - name: Upload coverage data
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@8cad3ba95e5920c42f44492e54bc9639cba47959 # v6.0.2
         with:
           name: ${{ matrix.name }}
           fail_ci_if_error: true

--- a/src/ansible_navigator/actions/images.py
+++ b/src/ansible_navigator/actions/images.py
@@ -182,8 +182,12 @@ class Action(ActionBase):
             A message and return code
         """
         image_name = self._args.execution_environment_image
+        sections: list[str] = self._args.entry("images_details").value.current
 
-        output, error, return_code = self._run_runner(image_name=image_name)
+        output, error, return_code = self._run_runner(
+            image_name=image_name,
+            sections=sections,
+        )
         if error or return_code:
             return RunStdoutReturn(message=error, return_code=return_code)
 
@@ -578,11 +582,18 @@ class Action(ActionBase):
             self._logger.error("%s %s", error["path"], error["error"])
         return parsed
 
-    def _run_runner(self, image_name: str) -> tuple[str, str, int]:
+    def _run_runner(
+        self,
+        image_name: str,
+        sections: list[str] | None = None,
+    ) -> tuple[str, str, int]:
         """Run runner to collect image details.
 
         Args:
             image_name: The full image name
+            sections: Optional list of introspection sections to collect.
+                When provided, only the named collectors run inside the
+                container instead of all of them.
 
         Returns:
             Output, errors and the return code
@@ -591,8 +602,12 @@ class Action(ActionBase):
         container_volume_mounts = [f"{cache_path}:{cache_path}"]
         python_exec_path = f"{cache_path}/python_latest.sh"
 
+        cmdline = [f"{cache_path}/image_introspect.py"]
+        if sections:
+            cmdline.extend(["--sections", *sections])
+
         kwargs = {
-            "cmdline": [f"{cache_path}/image_introspect.py"],
+            "cmdline": cmdline,
             "container_engine": self._args.container_engine,
             "container_volume_mounts": container_volume_mounts,
             "execution_environment_image": image_name,

--- a/src/ansible_navigator/data/image_introspect.py
+++ b/src/ansible_navigator/data/image_introspect.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import re
@@ -427,11 +428,26 @@ class SystemPackages(CmdParser):
         command.details = parsed
 
 
-def main(serialize: bool = True) -> dict[str, JSONTypes] | None:
+ALL_COLLECTORS: dict[str, type[CmdParser]] = {
+    "ansible_collections": AnsibleCollections,
+    "ansible_version": AnsibleVersion,
+    "os_release": OsRelease,
+    "redhat_release": RedhatRelease,
+    "python_packages": PythonPackages,
+    "system_packages": SystemPackages,
+}
+
+
+def main(
+    serialize: bool = True,
+    sections: list[str] | None = None,
+) -> dict[str, JSONTypes] | None:
     """Enter the image introspection process.
 
     Args:
         serialize: Whether to serialize the results
+        sections: Optional list of section IDs to collect. When ``None`` or
+            when ``"everything"`` is present, all collectors run.
 
     Returns:
         The collected data or none if serialize is False
@@ -441,14 +457,14 @@ def main(serialize: bool = True) -> dict[str, JSONTypes] | None:
     response["environment_variables"] = {"details": dict(os.environ)}
     try:
         command_runner = CommandRunner()
-        commands: list[CmdParser] = [
-            AnsibleCollections(),
-            AnsibleVersion(),
-            OsRelease(),
-            RedhatRelease(),
-            PythonPackages(),
-            SystemPackages(),
-        ]
+
+        if sections and "everything" not in sections:
+            commands: list[CmdParser] = [
+                ALL_COLLECTORS[s]() for s in sections if s in ALL_COLLECTORS
+            ]
+        else:
+            commands = [cls() for cls in ALL_COLLECTORS.values()]
+
         results = command_runner.run_multi_thread(commands)
         for result in results:
             result_as_dict = vars(result)
@@ -466,5 +482,27 @@ def main(serialize: bool = True) -> dict[str, JSONTypes] | None:
     return response
 
 
-if __name__ == "__main__":
-    main()
+ALWAYS_COLLECTED = ("python_version", "environment_variables")
+
+
+def _parse_args() -> list[str] | None:
+    """Parse command-line arguments for section filtering.
+
+    Returns:
+        The list of requested sections, or None for all sections.
+    """
+    parser = argparse.ArgumentParser(description="Introspect an execution environment image.")
+    parser.add_argument(
+        "--sections",
+        nargs="*",
+        default=None,
+        choices=[*ALL_COLLECTORS, *ALWAYS_COLLECTED, "everything"],
+        help="Sections to collect. Omit for all sections.",
+    )
+    args = parser.parse_args()
+    return args.sections
+
+
+if __name__ == "__main__":  # pragma: no cover
+    requested_sections = _parse_args()
+    main(sections=requested_sections)

--- a/tests/unit/test_image_introspection.py
+++ b/tests/unit/test_image_introspection.py
@@ -2,6 +2,7 @@
 """Unit tests for image introspection."""
 
 import importlib
+import sys
 import types
 
 from importlib.machinery import ModuleSpec
@@ -11,6 +12,7 @@ import pytest
 
 from ansible_navigator.cli import APP_NAME
 from ansible_navigator.cli import cache_scripts
+from ansible_navigator.data import image_introspect
 from ansible_navigator.utils.functions import generate_cache_path
 
 
@@ -116,6 +118,63 @@ def image_introspection() -> types.ModuleType:
     return module
 
 
+def test_all_collectors_keys(imported_ii: Any) -> None:
+    """Verify ALL_COLLECTORS contains the expected section IDs.
+
+    Args:
+        imported_ii: Image introspection
+    """
+    expected = {
+        "ansible_collections",
+        "ansible_version",
+        "os_release",
+        "redhat_release",
+        "python_packages",
+        "system_packages",
+    }
+    assert set(imported_ii.ALL_COLLECTORS) == expected
+
+
+@pytest.mark.parametrize(
+    "sections",
+    (
+        ["ansible_collections"],
+        ["ansible_collections", "ansible_version"],
+        ["system_packages"],
+    ),
+    ids=["single", "two", "heavy"],
+)
+def test_section_filtering(imported_ii: Any, sections: list[str]) -> None:
+    """Verify only requested collectors are instantiated.
+
+    Args:
+        imported_ii: Image introspection
+        sections: The sections to filter on
+    """
+    collectors = imported_ii.ALL_COLLECTORS
+    selected = [collectors[s]() for s in sections if s in collectors]
+    assert len(selected) == len(sections)
+    for section, cls_instance in zip(sections, selected, strict=False):
+        cmds = cls_instance.commands
+        assert cmds
+        assert cmds[0].id_ == section
+
+
+def test_section_everything_runs_all(imported_ii: Any) -> None:
+    """Verify ``everything`` causes all collectors to be selected.
+
+    Args:
+        imported_ii: Image introspection
+    """
+    sections = ["everything"]
+    collectors = imported_ii.ALL_COLLECTORS
+    if sections and "everything" not in sections:
+        selected = [collectors[s]() for s in sections if s in collectors]
+    else:
+        selected = [cls() for cls in collectors.values()]
+    assert len(selected) == len(collectors)
+
+
 def test_system_packages_parse_one(imported_ii: Any) -> None:
     """Test parsing one package.
 
@@ -217,3 +276,160 @@ def test_python_packages_parse_show(imported_ii: Any) -> None:
     assert crypto["requires"] == ["cffi"]
     assert "ansible-core" in crypto["required-by"]
     assert "paramiko" in crypto["required-by"]
+
+
+class TestMainSectionFiltering:
+    """Tests for the main() function's section filtering logic."""
+
+    def test_main_with_specific_sections(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify main() only runs requested collectors when sections are given.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture
+        """
+        ran_commands: list[Any] = []
+
+        def mock_run_multi_thread(
+            self: Any,
+            command_classes: list[Any],
+        ) -> list[Any]:
+            ran_commands.extend(command_classes)
+            return []
+
+        monkeypatch.setattr(
+            image_introspect.CommandRunner,
+            "run_multi_thread",
+            mock_run_multi_thread,
+        )
+        result = image_introspect.main(serialize=False, sections=["ansible_version"])
+        assert result is not None
+        assert len(ran_commands) == 1
+
+    def test_main_with_everything_runs_all(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify main() runs all collectors when sections contains 'everything'.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture
+        """
+        ran_commands: list[Any] = []
+
+        def mock_run_multi_thread(
+            self: Any,
+            command_classes: list[Any],
+        ) -> list[Any]:
+            ran_commands.extend(command_classes)
+            return []
+
+        monkeypatch.setattr(
+            image_introspect.CommandRunner,
+            "run_multi_thread",
+            mock_run_multi_thread,
+        )
+        result = image_introspect.main(serialize=False, sections=["everything"])
+        assert result is not None
+        assert len(ran_commands) == len(image_introspect.ALL_COLLECTORS)
+
+    def test_main_with_none_sections_runs_all(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify main() runs all collectors when sections is None.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture
+        """
+        ran_commands: list[Any] = []
+
+        def mock_run_multi_thread(
+            self: Any,
+            command_classes: list[Any],
+        ) -> list[Any]:
+            ran_commands.extend(command_classes)
+            return []
+
+        monkeypatch.setattr(
+            image_introspect.CommandRunner,
+            "run_multi_thread",
+            mock_run_multi_thread,
+        )
+        result = image_introspect.main(serialize=False, sections=None)
+        assert result is not None
+        assert len(ran_commands) == len(image_introspect.ALL_COLLECTORS)
+
+    def test_main_with_invalid_section_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify main() skips section names not in ALL_COLLECTORS.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture
+        """
+        ran_commands: list[Any] = []
+
+        def mock_run_multi_thread(
+            self: Any,
+            command_classes: list[Any],
+        ) -> list[Any]:
+            ran_commands.extend(command_classes)
+            return []
+
+        monkeypatch.setattr(
+            image_introspect.CommandRunner,
+            "run_multi_thread",
+            mock_run_multi_thread,
+        )
+        result = image_introspect.main(
+            serialize=False,
+            sections=["nonexistent_section"],
+        )
+        assert result is not None
+        assert len(ran_commands) == 0
+
+
+class TestParseArgs:
+    """Tests for the _parse_args() function."""
+
+    def test_parse_args_no_arguments(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify _parse_args returns None when no --sections flag is given.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture
+        """
+        monkeypatch.setattr(sys, "argv", ["image_introspect.py"])
+        result = image_introspect._parse_args()
+        assert result is None
+
+    def test_parse_args_with_sections(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify _parse_args returns the requested section list.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture
+        """
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["image_introspect.py", "--sections", "ansible_version", "os_release"],
+        )
+        result = image_introspect._parse_args()
+        assert result == ["ansible_version", "os_release"]
+
+    def test_parse_args_with_everything(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify _parse_args accepts 'everything' keyword.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture
+        """
+        monkeypatch.setattr(sys, "argv", ["image_introspect.py", "--sections", "everything"])
+        result = image_introspect._parse_args()
+        assert result == ["everything"]
+
+    def test_parse_args_empty_sections(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify _parse_args returns empty list when --sections given without values.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture
+        """
+        monkeypatch.setattr(sys, "argv", ["image_introspect.py", "--sections"])
+        result = image_introspect._parse_args()
+        assert result == []
+
+
+def test_always_collected_constant() -> None:
+    """Verify ALWAYS_COLLECTED contains expected section IDs."""
+    assert "python_version" in image_introspect.ALWAYS_COLLECTED
+    assert "environment_variables" in image_introspect.ALWAYS_COLLECTED


### PR DESCRIPTION
## Summary

The existing `--details` / `-d` flag on `ansible-navigator images` only controlled which sections were **displayed** — all 6 introspection collectors always ran inside the container regardless of the user's selection. This meant requesting a single lightweight section (e.g. `ansible_version`) still paid the full cost of collecting system packages, python packages, etc., resulting in ~5 minute execution times.

This fix threads the user's section selection into the container script so only the requested collectors execute, reducing filtered introspection from ~5 minutes to seconds.

Fixes AAP-43508

## Changes

- Add `ALL_COLLECTORS` dictionary in `image_introspect.py` mapping section IDs to their collector classes
- Add `--sections` CLI argument to `image_introspect.py` (internal interface between navigator and the container script — not user-facing)
- Update `main()` to only instantiate requested collectors when sections are provided; `"everything"` and `None` still run all collectors
- Pass `images_details` selection from `images.py` → `_run_runner()` → container cmdline so collection matches the user's intent
- `python_version` and `environment_variables` remain always-collected (hardcoded, not part of the collector mechanism)
- Update `codecov/codecov-action` to v6.0.2 (pinned to SHA) for GPG key migration

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e py` passes (CI)
- Unit tests added for `ALL_COLLECTORS` keys, section filtering, `main()` with specific/everything/None/invalid sections, and `_parse_args()` argument parsing