### PR TITLE
ci: replace coactions/upload-artifact with actions/upload-artifact@v7

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,7 +13,7 @@ on:
     branches:
       - "main"
   push: # only publishes pushes to the main branch to TestPyPI
-    branches: # any integration branch but not tag
+    branches: # any integration branch but not tag.
       - "main"
   pull_request:
     branches:
@@ -100,7 +100,7 @@ jobs:
 
       - name: Archive logs and coverage data
         if: ${{ !cancelled() }}
-        uses: coactions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: logs-${{ matrix.name }}.zip
           include-hidden-files: true


### PR DESCRIPTION
The `check` job's merge step uses `actions/upload-artifact/merge@v7` and download uses `actions/download-artifact@v8`, but the `tox` job was uploading artifacts via `coactions/upload-artifact@v4` which internally delegates to `actions/upload-artifact@v4`. This version mismatch causes the merge step to fail with "No artifacts found matching pattern 'logs-*.zip'" because v7 merge cannot locate artifacts created by the v4 uploader.

Replace `coactions/upload-artifact@v4` with `actions/upload-artifact@v7` to align all artifact actions on compatible versions.