### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   ack:
     uses: ansible/team-devtools/.github/workflows/ack.yml@main

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,9 @@ on:
       - "releases/**"
       - "stable/**"
 
+permissions:
+  contents: read
+
 jobs:
   ack:
     uses: ansible/team-devtools/.github/workflows/push.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,15 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read # checkout source for the build
+  id-token: write # PyPI trusted publishing (OIDC)
+
 jobs:
   pypi:
     name: Publish to PyPI registry
     environment: release
     runs-on: ubuntu-24.04
-    permissions:
-      id-token: write
 
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,6 +20,10 @@ on:
       - "main"
   schedule:
     - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
 jobs:
   pre:
     name: pre


### PR DESCRIPTION
Resolve CodeQL code-scanning alerts for missing workflow permissions by adding top-level least-privilege permissions to all workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted automated workflow access to read-only repository contents by default.
  * Preserved secure, token-based authentication for package publishing.
* **Chores**
  * Standardized permission settings across pull request, push, testing, and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->