### PR TITLE
fix: extract duplicated string literals to constants (S1192)

### DIFF
--- a/docs/_ext/regenerate_docs.py
+++ b/docs/_ext/regenerate_docs.py
@@ -32,9 +32,10 @@ TEST_SETTINGS_FIXTURE = (
     / "configuration_subsystem"
     / "ansible-navigator.yml"
 )
-DOCS_SETTINGS_SAMPLE = PROJECT_DIR / "docs" / ".generated" / "ansible-navigator.yml"
-DOCS_SETTINGS_DUMP = PROJECT_DIR / "docs" / ".generated" / "settings-dump.md"
-DOCS_SUBCOMMANDS_OVERVIEW = PROJECT_DIR / "docs" / ".generated" / "subcommands-overview.md"
+GENERATED_DIR_NAME = ".generated"
+DOCS_SETTINGS_SAMPLE = PROJECT_DIR / "docs" / GENERATED_DIR_NAME / "ansible-navigator.yml"
+DOCS_SETTINGS_DUMP = PROJECT_DIR / "docs" / GENERATED_DIR_NAME / "settings-dump.md"
+DOCS_SUBCOMMANDS_OVERVIEW = PROJECT_DIR / "docs" / GENERATED_DIR_NAME / "subcommands-overview.md"
 
 APP = "ansible-navigator"
 

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from ansible_navigator.app_public import AppPublic
     from ansible_navigator.configuration_subsystem.definitions import ApplicationConfiguration
 
+COLUMN_IN_PROGRESS = "__in progress"
 
 RESULT_TO_COLOR = [
     ("(?i)^failed$", 9),
@@ -189,7 +190,7 @@ PLAY_COLUMNS = [
     "__failed",
     "__skipped",
     "__ignored",
-    "__in progress",
+    COLUMN_IN_PROGRESS,
     "__task_count",
     "__progress",
 ]
@@ -790,7 +791,14 @@ class Action(ActionBase):
     def _play_stats(self) -> None:
         """Calculate the play's stats based on it's tasks."""
         for idx, play in enumerate(self._plays.value):
-            total = ["__ok", "__skipped", "__failed", "__unreachable", "__ignored", "__in progress"]
+            total = [
+                "__ok",
+                "__skipped",
+                "__failed",
+                "__unreachable",
+                "__ignored",
+                COLUMN_IN_PROGRESS,
+            ]
             self._plays.value[idx].update(
                 {
                     tot: len([t for t in play["tasks"] if t["__result"].lower() == tot[2:]])
@@ -802,7 +810,7 @@ class Action(ActionBase):
             )
             task_count = len(play["tasks"])
             self._plays.value[idx]["__task_count"] = task_count
-            completed = task_count - self._plays.value[idx]["__in progress"]
+            completed = task_count - self._plays.value[idx][COLUMN_IN_PROGRESS]
             if completed:
                 new = floor(completed / task_count * 100)
                 current = self._plays.value[idx].get("__percent_complete", 0)

--- a/src/ansible_navigator/actions/write_file.py
+++ b/src/ansible_navigator/actions/write_file.py
@@ -17,6 +17,9 @@ from ansible_navigator.utils.serialize import serialize_write_file
 from . import _actions as actions
 
 
+JSON_EXTENSION = ".json"
+
+
 @actions.register
 class Action:
     """``:write`` command implementation."""
@@ -80,8 +83,8 @@ class Action:
             write_as = ".txt"
         elif re.match(r"^.*\.y(?:a)?ml$", filename):
             write_as = ".yaml"
-        elif filename.endswith(".json"):
-            write_as = ".json"
+        elif filename.endswith(JSON_EXTENSION):
+            write_as = JSON_EXTENSION
         else:
             write_as = interaction.ui.content_format().value.file_extension
 
@@ -97,7 +100,7 @@ class Action:
                 file_mode=file_mode,
                 serialization_format=SerializationFormat.YAML,
             )
-        elif write_as == ".json":
+        elif write_as == JSON_EXTENSION:
             serialize_write_file(
                 content=obj,
                 content_view=ContentView.NORMAL,

--- a/src/ansible_navigator/tm_tokenize/compiler.py
+++ b/src/ansible_navigator/tm_tokenize/compiler.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
     from .rules import CompiledRule
     from .rules import _Rule
 
+INCLUDE_SELF = "$self"
+
 
 class Compiler:
     def __init__(self, grammar: Grammar, grammars: Grammars) -> None:
@@ -48,16 +50,16 @@ class Compiler:
         repository: FChainMap[str, _Rule],
         s: str,
     ) -> tuple[list[str], tuple[_Rule, ...]]:
-        if s == "$self":
+        if s == INCLUDE_SELF:
             return self._patterns(grammar, grammar.patterns)
         if s == "$base":
             grammar = self._grammars.grammar_for_scope(self._root_scope)
-            return self._include(grammar, grammar.repository, "$self")
+            return self._include(grammar, grammar.repository, INCLUDE_SELF)
         if s.startswith("#"):
             return self._patterns(grammar, (repository[s[1:]],))
         if "#" not in s:
             grammar = self._grammars.grammar_for_scope(s)
-            return self._include(grammar, grammar.repository, "$self")
+            return self._include(grammar, grammar.repository, INCLUDE_SELF)
         scope, _, s = s.partition("#")
         grammar = self._grammars.grammar_for_scope(scope)
         return self._include(grammar, grammar.repository, f"#{s}")

--- a/src/ansible_navigator/tm_tokenize/grammars.py
+++ b/src/ansible_navigator/tm_tokenize/grammars.py
@@ -19,6 +19,8 @@ from .utils import uniquely_constructed
 
 T = TypeVar("T")
 
+SCOPE_UNKNOWN = "source.unknown"
+
 
 @uniquely_constructed
 class Grammar(NamedTuple):
@@ -58,8 +60,8 @@ class Grammars:
             if filename.endswith(".json")
         }
 
-        unknown_grammar = {"scopeName": "source.unknown", "patterns": []}
-        self._raw = {"source.unknown": unknown_grammar}
+        unknown_grammar = {"scopeName": SCOPE_UNKNOWN, "patterns": []}
+        self._raw = {SCOPE_UNKNOWN: unknown_grammar}
         self._file_types: list[tuple[frozenset[str], str]] = []
         self._first_line: list[tuple[_Reg, str]] = []
         self._parsed: dict[str, Grammar] = {}
@@ -104,7 +106,7 @@ class Grammars:
         return ret
 
     def blank_compiler(self) -> Compiler:
-        return self.compiler_for_scope("source.unknown")
+        return self.compiler_for_scope(SCOPE_UNKNOWN)
 
     def compiler_for_file(self, filename: str, first_line: str) -> Compiler:
         # didn't find it in the fast path, need to read all the json
@@ -120,4 +122,4 @@ class Grammars:
             if reg.match(first_line, 0, first_line=True, boundary=True):
                 return self.compiler_for_scope(scope)
 
-        return self.compiler_for_scope("source.unknown")
+        return self.compiler_for_scope(SCOPE_UNKNOWN)

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -50,6 +50,8 @@ if TYPE_CHECKING:
     from .ui_config import UIConfig
 
 
+KEY_REFRESH = "KEY_F(5)"
+
 STANDARD_KEYS = {
     "^b/PgUp": "page up",
     "^f/PgDn": "page down",
@@ -478,7 +480,7 @@ class UserInterface(CursesWindow):
             "+",
             "-",
             "_",
-            "KEY_F(5)",
+            KEY_REFRESH,
             "^[",
             "\x1b",
             "CURSOR_ENTER",
@@ -540,11 +542,11 @@ class UserInterface(CursesWindow):
 
             if await_input:
                 char = self._screen.getch()
-                key = "KEY_F(5)" if char == -1 else curses.keyname(char).decode()
+                key = KEY_REFRESH if char == -1 else curses.keyname(char).decode()
                 if char in [10, 13]:  # pragma: no cover  # Enter key codes: 10=LF, 13=CR
                     key = "CURSOR_ENTER"
             else:
-                key = "KEY_F(5)"
+                key = KEY_REFRESH
 
             return_value = None
             if key == "KEY_RESIZE":

--- a/src/ansible_navigator/utils/serialize.py
+++ b/src/ansible_navigator/utils/serialize.py
@@ -26,6 +26,8 @@ from ansible_navigator.content_defs import SerializationFormat
 
 logger = logging.getLogger(__name__)
 
+UNKNOWN_SERIALIZATION_FORMAT_MSG = "Unknown serialization format"
+
 try:
     from yaml import CSafeDumper as SafeDumper
 except ImportError:
@@ -66,8 +68,7 @@ def serialize(
         return _yaml_dumps(dumpable=dumpable)
     if serialization_format == SerializationFormat.JSON:
         return _json_dumps(dumpable=dumpable)
-    msg = "Unknown serialization format"
-    raise ValueError(msg)
+    raise ValueError(UNKNOWN_SERIALIZATION_FORMAT_MSG)
 
 
 def serialize_write_file(
@@ -101,8 +102,7 @@ def serialize_write_file(
         if serialization_format == SerializationFormat.YAML:
             _yaml_dump(dumpable=dumpable, file_handle=file_handle)
             return
-    msg = "Unknown serialization format"
-    raise ValueError(msg)
+    raise ValueError(UNKNOWN_SERIALIZATION_FORMAT_MSG)
 
 
 def serialize_write_temp_file(
@@ -144,8 +144,7 @@ def serialize_write_temp_file(
             return Path(file_like.name)
         _text_dump(dumpable=str(dumpable), file_handle=file_like)
         return Path(file_like.name)
-    msg = "Unknown serialization format"
-    raise ValueError(msg)
+    raise ValueError(UNKNOWN_SERIALIZATION_FORMAT_MSG)
 
 
 SERIALIZATION_FAILURE_MSG = (

--- a/tests/integration/_cli2runner.py
+++ b/tests/integration/_cli2runner.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
+OVERRIDE_MSG = "override in subclass"
+
+
 class RunnerTestError(Exception):
     """Custom exception for runner to throw."""
 
@@ -23,15 +26,15 @@ class Cli2Runner:
     """A base class which mocks the runner calls."""
 
     INTERACTIVE = {
-        "config": "override in subclass",
-        "inventory": "override in subclass",
-        "run": "override in subclass",
+        "config": OVERRIDE_MSG,
+        "inventory": OVERRIDE_MSG,
+        "run": OVERRIDE_MSG,
     }
 
     STDOUT = {
-        "config": "override in subclass",
-        "inventory": "override in subclass",
-        "run": "override in subclass",
+        "config": OVERRIDE_MSG,
+        "inventory": OVERRIDE_MSG,
+        "run": OVERRIDE_MSG,
     }
 
     cli_entry = "ansible-navigator {0} {1} -m {2}"

--- a/tests/integration/actions/collections/base.py
+++ b/tests/integration/actions/collections/base.py
@@ -18,33 +18,37 @@ from tests.integration._tmux_session import TmuxSession
 from tests.integration._tmux_session import TmuxSessionKwargs
 
 
+BACK_CMD = ":back"
+BACK_TO_PLUGINS = "Back to browse company_name.coll_1 plugins window"
+BACK_TO_COLLECTIONS = "Back to ansible-navigator collections browse window"
+
 EXPECTED_COLLECTIONS = ["ansible.builtin", "company_name.coll_1", "company_name.coll_2"]
 
 base_steps = (
     UiTestStep(user_input=":1", comment="Browse company_name.coll_1 plugins window"),
     UiTestStep(user_input=":0", comment="filter_1 plugin docs window"),
-    UiTestStep(user_input=":back", comment="Back to browse company_name.coll_1 plugins window"),
+    UiTestStep(user_input=BACK_CMD, comment=BACK_TO_PLUGINS),
     UiTestStep(user_input=":1", comment="lookup_1 plugin docs window"),
-    UiTestStep(user_input=":back", comment="Back to browse company_name.coll_1 plugins window"),
+    UiTestStep(user_input=BACK_CMD, comment=BACK_TO_PLUGINS),
     UiTestStep(user_input=":2", comment="mod_1 plugin docs window"),
-    UiTestStep(user_input=":back", comment="Back to browse company_name.coll_1 plugins window"),
+    UiTestStep(user_input=BACK_CMD, comment=BACK_TO_PLUGINS),
     UiTestStep(user_input=":3", comment="role_full details window"),
-    UiTestStep(user_input=":back", comment="Back to browse company_name.coll_1 plugins window"),
+    UiTestStep(user_input=BACK_CMD, comment=BACK_TO_PLUGINS),
     UiTestStep(user_input=":4", comment="role_minimal details window"),
-    UiTestStep(user_input=":back", comment="Back to browse company_name.coll_1 plugins window"),
+    UiTestStep(user_input=BACK_CMD, comment=BACK_TO_PLUGINS),
     UiTestStep(
-        user_input=":back",
-        comment="Back to ansible-navigator collections browse window",
+        user_input=BACK_CMD,
+        comment=BACK_TO_COLLECTIONS,
         present=EXPECTED_COLLECTIONS,
     ),
     UiTestStep(user_input=":2", comment="Browse company_name.coll_2 plugins window"),
     UiTestStep(user_input=":0", comment="lookup_2 plugin docs window"),
-    UiTestStep(user_input=":back", comment="Back to browse company_name.coll_2 plugins window"),
+    UiTestStep(user_input=BACK_CMD, comment="Back to browse company_name.coll_2 plugins window"),
     UiTestStep(user_input=":1", comment="mod_2 plugin docs window"),
-    UiTestStep(user_input=":back", comment="Back to browse company_name.coll_2 plugins window"),
+    UiTestStep(user_input=BACK_CMD, comment="Back to browse company_name.coll_2 plugins window"),
     UiTestStep(
-        user_input=":back",
-        comment="Back to ansible-navigator collections browse window",
+        user_input=BACK_CMD,
+        comment=BACK_TO_COLLECTIONS,
         present=EXPECTED_COLLECTIONS,
     ),
     # Try some things that should not work but not fail (#1061 and #1062)
@@ -63,12 +67,12 @@ base_steps = (
     # and repeat some basic browsing
     UiTestStep(user_input=":1", comment="Browse company_name.coll_1 plugins window"),
     UiTestStep(user_input=":0", comment="filter_1 plugin docs window"),
-    UiTestStep(user_input=":back", comment="Back to browse company_name.coll_1 plugins window"),
+    UiTestStep(user_input=BACK_CMD, comment=BACK_TO_PLUGINS),
     UiTestStep(user_input=":1", comment="lookup_1 plugin docs window"),
-    UiTestStep(user_input=":back", comment="Back to browse company_name.coll_1 plugins window"),
+    UiTestStep(user_input=BACK_CMD, comment=BACK_TO_PLUGINS),
     UiTestStep(
-        user_input=":back",
-        comment="Back to ansible-navigator collections browse window",
+        user_input=BACK_CMD,
+        comment=BACK_TO_COLLECTIONS,
         present=EXPECTED_COLLECTIONS,
     ),
     UiTestStep(

--- a/tests/integration/actions/inventory/base.py
+++ b/tests/integration/actions/inventory/base.py
@@ -20,32 +20,35 @@ ANSIBLE_INVENTORY_FIXTURE_DIR = TEST_FIXTURE_DIR / "ansible_inventory" / "invent
 TEST_CONFIG_FILE = TEST_FIXTURE_DIR / "ansible-navigator.yml"
 
 
+BACK_CMD = ":back"
+PREV_GROUP_LIST = "Previous window (Group list window)"
+
 base_steps = (
     UiTestStep(user_input=":0", comment="Browse hosts/ungrouped window"),
     UiTestStep(user_input=":0", comment="Group list window"),
     UiTestStep(user_input=":0", comment="group01 hosts detail window"),
     UiTestStep(user_input=":0", comment="host0101 detail window"),
-    UiTestStep(user_input=":back", comment="Previous window (group01 hosts detail window)"),
-    UiTestStep(user_input=":back", comment="Previous window (Group list window)"),
+    UiTestStep(user_input=BACK_CMD, comment="Previous window (group01 hosts detail window)"),
+    UiTestStep(user_input=BACK_CMD, comment=PREV_GROUP_LIST),
     UiTestStep(user_input=":1", comment="group02 hosts detail window"),
     UiTestStep(user_input=":0", comment="host0201 detail window"),
-    UiTestStep(user_input=":back", comment="Previous window (group02 hosts detail window)"),
-    UiTestStep(user_input=":back", comment="Previous window (Group list window)"),
+    UiTestStep(user_input=BACK_CMD, comment="Previous window (group02 hosts detail window)"),
+    UiTestStep(user_input=BACK_CMD, comment=PREV_GROUP_LIST),
     UiTestStep(user_input=":2", comment="group03 hosts detail window"),
     UiTestStep(user_input=":0", comment="host0301 detail window"),
-    UiTestStep(user_input=":back", comment="Previous window (group03 hosts detail window)"),
-    UiTestStep(user_input=":back", comment="Previous window (Group list window)"),
-    UiTestStep(user_input=":back", comment="Previous window (Browse hosts/ungrouped window)"),
-    UiTestStep(user_input=":back", comment="Previous window (top window)"),
+    UiTestStep(user_input=BACK_CMD, comment="Previous window (group03 hosts detail window)"),
+    UiTestStep(user_input=BACK_CMD, comment=PREV_GROUP_LIST),
+    UiTestStep(user_input=BACK_CMD, comment="Previous window (Browse hosts/ungrouped window)"),
+    UiTestStep(user_input=BACK_CMD, comment="Previous window (top window)"),
     UiTestStep(user_input=":1", comment="Inventory hostname window"),
     UiTestStep(user_input=":0", comment="host0101 detail window"),
     UiTestStep(
-        user_input=":back",
+        user_input=BACK_CMD,
         comment="Previous window after host0101 (Inventory hostname window)",
     ),
     UiTestStep(user_input=":1", comment="host0201 detail window"),
     UiTestStep(
-        user_input=":back",
+        user_input=BACK_CMD,
         comment="Previous window after host0201 (Inventory hostname window)",
     ),
     UiTestStep(user_input=":2", comment="host0301 detail window"),

--- a/tests/integration/actions/run/base.py
+++ b/tests/integration/actions/run/base.py
@@ -30,19 +30,23 @@ playbook_path = run_fixture_dir / "site.yaml"
 common_fixture_dir = FIXTURES_DIR / "common" / "collections"
 PLAYBOOK_COLLECTION = "company_name.coll_1.playbook_1"
 
+PLAY_1_DETAILS = "play-1 details"
+BACK_CMD = ":back"
+PLAY_2_DETAILS = "play-2 details"
+
 base_steps = (
-    UiTestStep(user_input=":0", comment="play-1 details"),
+    UiTestStep(user_input=":0", comment=PLAY_1_DETAILS),
     UiTestStep(user_input=":0", comment="task-1 details"),
-    UiTestStep(user_input=":back", comment="play-1 details"),
+    UiTestStep(user_input=BACK_CMD, comment=PLAY_1_DETAILS),
     UiTestStep(user_input=":1", comment="play-1 task-2 details"),
-    UiTestStep(user_input=":back", comment="play-1 details"),
-    UiTestStep(user_input=":back", comment="all play details"),
-    UiTestStep(user_input=":1", comment="play-2 details"),
+    UiTestStep(user_input=BACK_CMD, comment=PLAY_1_DETAILS),
+    UiTestStep(user_input=BACK_CMD, comment="all play details"),
+    UiTestStep(user_input=":1", comment=PLAY_2_DETAILS),
     UiTestStep(user_input=":0", comment="play-2 task-1 details"),
-    UiTestStep(user_input=":back", comment="play-2 details"),
+    UiTestStep(user_input=BACK_CMD, comment=PLAY_2_DETAILS),
     UiTestStep(user_input=":1", comment="play-2 task-2 details"),
-    UiTestStep(user_input=":back", comment="play-2 details"),
-    UiTestStep(user_input=":back", comment="all play details"),
+    UiTestStep(user_input=BACK_CMD, comment=PLAY_2_DETAILS),
+    UiTestStep(user_input=BACK_CMD, comment="all play details"),
     UiTestStep(user_input=":st", comment="display stream"),
 )
 

--- a/tests/integration/actions/run_unicode/base.py
+++ b/tests/integration/actions/run_unicode/base.py
@@ -27,15 +27,18 @@ run_fixture_dir = FIXTURES_DIR / "integration" / "actions" / "run_unicode"
 inventory_path = run_fixture_dir / "inventory"
 playbook_path = run_fixture_dir / "site.yaml"
 
+PLAY_1_DETAILS = "play-1 details"
+BACK_CMD = ":back"
+
 base_steps = (
-    UiTestStep(user_input=":0", comment="play-1 details"),
+    UiTestStep(user_input=":0", comment=PLAY_1_DETAILS),
     UiTestStep(user_input=":0", comment="task-1 yaml", present=["航海家"]),
     UiTestStep(user_input=":json", comment="task-1 json", present=["航海家"]),
-    UiTestStep(user_input=":back", comment="play-1 details"),
+    UiTestStep(user_input=BACK_CMD, comment=PLAY_1_DETAILS),
     UiTestStep(user_input=":1", comment="task-2 json", present=["航海家"]),
     UiTestStep(user_input=":yaml", comment="task-2 yaml", present=["航海家"]),
-    UiTestStep(user_input=":back", comment="play-1 details"),
-    UiTestStep(user_input=":back", comment="all play details"),
+    UiTestStep(user_input=BACK_CMD, comment=PLAY_1_DETAILS),
+    UiTestStep(user_input=BACK_CMD, comment="all play details"),
     UiTestStep(user_input=":st", comment="display stream"),
 )
 

--- a/tests/integration/actions/templar/base.py
+++ b/tests/integration/actions/templar/base.py
@@ -28,16 +28,19 @@ run_fixture_dir = FIXTURES_DIR / "integration" / "actions" / "run"
 inventory_path = run_fixture_dir / "inventory"
 playbook_path = run_fixture_dir / "site.yaml"
 
+BACK_CMD = ":back"
+MODULE_DEBUG = "module: debug"
+
 base_steps = (
     UiTestStep(user_input=":0", comment="play-1 details"),
     UiTestStep(user_input=":{{ this[0] }}", comment="render menu as content"),
-    UiTestStep(user_input=":back", comment="show play-1 details"),
+    UiTestStep(user_input=BACK_CMD, comment="show play-1 details"),
     UiTestStep(user_input=":0", comment="task-1 details"),
     UiTestStep(
         user_input=":doc",
         comment="doc for task",
-        present=["module: debug"],
-        search_within_response="module: debug",
+        present=[MODULE_DEBUG],
+        search_within_response=MODULE_DEBUG,
     ),
     UiTestStep(
         user_input=":{{ examples }}",
@@ -45,12 +48,12 @@ base_steps = (
         present=["ansible.builtin.debug:"],
     ),
     UiTestStep(
-        user_input=":back",
+        user_input=BACK_CMD,
         comment="show doc",
-        present=["module: debug"],
-        search_within_response="module: debug",
+        present=[MODULE_DEBUG],
+        search_within_response=MODULE_DEBUG,
     ),
-    UiTestStep(user_input=":back", comment="show task"),
+    UiTestStep(user_input=BACK_CMD, comment="show task"),
     UiTestStep(
         user_input=":open {{ task_path }}",
         comment="goto vi, look for localhost since it is not in the task",

--- a/tests/unit/configuration_subsystem/data.py
+++ b/tests/unit/configuration_subsystem/data.py
@@ -12,6 +12,16 @@ import pytest
 from _pytest.mark.structures import ParameterSet
 
 
+TMP_ANSIBLE_CFG = "/tmp/ansible.cfg"
+TMP_INV1 = "/tmp/inv1.yml"
+TMP_INV2 = "/tmp/inv2.yml"
+TMP_SITE_YML = "/tmp/site.yml"
+TMP_TEST1 = "/tmp/test1"
+NET_HOST = "--net=host"
+TEST_IMAGE = "test_image:latest"
+TMP_APP_LOG = "/tmp/app.log"
+
+
 def d2t(dictionary: dict[Any, Any]) -> tuple[Any, ...]:
     """Turn the data dictionary into a frozen set so they are immutable.
 
@@ -70,18 +80,18 @@ BASE_LONG_CLI = """
 
 BASE_EXPECTED = d2t(
     {
-        "ansible_runner_artifact_dir": "/tmp/test1",
+        "ansible_runner_artifact_dir": TMP_TEST1,
         "ansible_runner_rotate_artifacts_count": 10,
         "ansible_runner_timeout": 300,
         "container_engine": "docker",
-        "container_options": ["--net=host"],
+        "container_options": [NET_HOST],
         "display_color": False,
         "editor_command": "vim_base",
         "editor_console": True,
         "execution_environment": False,
-        "execution_environment_image": "test_image:latest",
+        "execution_environment_image": TEST_IMAGE,
         "log_append": False,
-        "log_file": "/tmp/app.log",
+        "log_file": TMP_APP_LOG,
         "log_level": "warning",
         "osc4": False,
         "pass_environment_variable": ["FOO", "BAR"],
@@ -99,7 +109,7 @@ CLI_DATA_CONFIG: list[tuple[str, dict[Any, Any]]] = [
     ("config dump", {"app": "config", "cmdline": ["dump"]}),
     (
         "config dump -c /tmp/ansible.cfg",
-        {"app": "config", "cmdline": ["dump"], "config": "/tmp/ansible.cfg"},
+        {"app": "config", "cmdline": ["dump"], "config": TMP_ANSIBLE_CFG},
     ),
 ]
 CLI_DATA_DOC: list[tuple[str, dict[Any, Any]]] = [
@@ -112,38 +122,38 @@ CLI_DATA_DOC: list[tuple[str, dict[Any, Any]]] = [
     ),
 ]
 CLI_DATA_INVENTORY: list[tuple[str, dict[Any, Any]]] = [
-    ("inventory -i /tmp/inv1.yml", {"app": "inventory", "inventory": ["/tmp/inv1.yml"]}),
+    ("inventory -i /tmp/inv1.yml", {"app": "inventory", "inventory": [TMP_INV1]}),
     (
         "inventory -i /tmp/inv1.yml -m stdout",
-        {"app": "inventory", "inventory": ["/tmp/inv1.yml"], "mode": "stdout"},
+        {"app": "inventory", "inventory": [TMP_INV1], "mode": "stdout"},
     ),
     ("inventory -i host1,host2", {"app": "inventory", "inventory": ["host1,host2"]}),
     (
         "inventory -i /tmp/inv1.yml -i /tmp/inv2.yml",
-        {"app": "inventory", "inventory": ["/tmp/inv1.yml", "/tmp/inv2.yml"]},
+        {"app": "inventory", "inventory": [TMP_INV1, TMP_INV2]},
     ),
-    ("inventory --inventory /tmp/inv1.yml", {"app": "inventory", "inventory": ["/tmp/inv1.yml"]}),
+    ("inventory --inventory /tmp/inv1.yml", {"app": "inventory", "inventory": [TMP_INV1]}),
     (
         "inventory --inventory /tmp/inv1.yml --inventory /tmp/inv2.yml",
-        {"app": "inventory", "inventory": ["/tmp/inv1.yml", "/tmp/inv2.yml"]},
+        {"app": "inventory", "inventory": [TMP_INV1, TMP_INV2]},
     ),
 ]
 CLI_DATA_INVENTORY_COLUMNS: list[tuple[str, dict[Any, Any]]] = [
     (
         "inventory -i /tmp/inv1.yml --ic hv1",
-        {"app": "inventory", "inventory": ["/tmp/inv1.yml"], "inventory_column": ["hv1"]},
+        {"app": "inventory", "inventory": [TMP_INV1], "inventory_column": ["hv1"]},
     ),
     (
         "inventory -i /tmp/inv1.yml -i /tmp/inv2.yml --ic hv1 --ic hv2",
         {
             "app": "inventory",
-            "inventory": ["/tmp/inv1.yml", "/tmp/inv2.yml"],
+            "inventory": [TMP_INV1, TMP_INV2],
             "inventory_column": ["hv1", "hv2"],
         },
     ),
     (
         "inventory --inventory /tmp/inv1.yml --inventory-column hv1",
-        {"app": "inventory", "inventory": ["/tmp/inv1.yml"], "inventory_column": ["hv1"]},
+        {"app": "inventory", "inventory": [TMP_INV1], "inventory_column": ["hv1"]},
     ),
     (
         (
@@ -152,7 +162,7 @@ CLI_DATA_INVENTORY_COLUMNS: list[tuple[str, dict[Any, Any]]] = [
         ),
         {
             "app": "inventory",
-            "inventory": ["/tmp/inv1.yml", "/tmp/inv2.yml"],
+            "inventory": [TMP_INV1, TMP_INV2],
             "inventory_column": ["hv1", "hv2"],
         },
     ),
@@ -164,38 +174,38 @@ CLI_DATA_REPLAY: list[tuple[str, dict[Any, Any]]] = [
     ),
 ]
 CLI_DATA_RUN: list[tuple[str, dict[Any, Any]]] = [
-    ("run /tmp/site.yml", {"app": "run", "playbook": "/tmp/site.yml"}),
-    ("run /tmp/site.yml -m stdout", {"app": "run", "mode": "stdout", "playbook": "/tmp/site.yml"}),
+    ("run /tmp/site.yml", {"app": "run", "playbook": TMP_SITE_YML}),
+    ("run /tmp/site.yml -m stdout", {"app": "run", "mode": "stdout", "playbook": TMP_SITE_YML}),
     (
         "run /tmp/site.yml --check --diff --forks 50",
         {
             "app": "run",
             "cmdline": ["--check", "--diff", "--forks", "50"],
-            "playbook": "/tmp/site.yml",
+            "playbook": TMP_SITE_YML,
         },
     ),
     (
         "run /tmp/site.yml -i /tmp/inv1.yml",
-        {"app": "run", "playbook": "/tmp/site.yml", "inventory": ["/tmp/inv1.yml"]},
+        {"app": "run", "playbook": TMP_SITE_YML, "inventory": [TMP_INV1]},
     ),
     (
         "run /tmp/site.yml --inventory /tmp/inv1.yml",
-        {"app": "run", "playbook": "/tmp/site.yml", "inventory": ["/tmp/inv1.yml"]},
+        {"app": "run", "playbook": TMP_SITE_YML, "inventory": [TMP_INV1]},
     ),
     (
         "run /tmp/site.yml -i /tmp/inv1.yml -i /tmp/inv2.yml",
         {
             "app": "run",
-            "playbook": "/tmp/site.yml",
-            "inventory": ["/tmp/inv1.yml", "/tmp/inv2.yml"],
+            "playbook": TMP_SITE_YML,
+            "inventory": [TMP_INV1, TMP_INV2],
         },
     ),
     (
         "run /tmp/site.yml --inventory /tmp/inv1.yml --inventory /tmp/inv2.yml",
         {
             "app": "run",
-            "playbook": "/tmp/site.yml",
-            "inventory": ["/tmp/inv1.yml", "/tmp/inv2.yml"],
+            "playbook": TMP_SITE_YML,
+            "inventory": [TMP_INV1, TMP_INV2],
         },
     ),
 ]
@@ -226,16 +236,16 @@ def cli_data() -> Generator[ParameterSet, None, None]:
 CLI_DATA = cli_data()
 
 ENV_VAR_DATA = [
-    pytest.param("ansible_runner_artifact_dir", "/tmp/test1", "/tmp/test1", id="0"),
+    pytest.param("ansible_runner_artifact_dir", TMP_TEST1, TMP_TEST1, id="0"),
     pytest.param("ansible_runner_rotate_artifacts_count", "10", 10, id="1"),
     pytest.param("ansible_runner_timeout", "300", 300, id="2"),
     pytest.param("ansible_runner_write_job_events", "false", False, id="3"),
     pytest.param("app", "config", "config", id="4"),
     pytest.param("cmdline", "--forks 15", ["--forks", "15"], id="5"),
     pytest.param("collection_doc_cache_path", "/tmp/cache.db", "/tmp/cache.db", id="6"),
-    pytest.param("config", "/tmp/ansible.cfg", "/tmp/ansible.cfg", id="7"),
+    pytest.param("config", TMP_ANSIBLE_CFG, TMP_ANSIBLE_CFG, id="7"),
     pytest.param("container_engine", "docker", "docker", id="8"),
-    pytest.param("container_options", "--net=host", ["--net=host"], id="9"),
+    pytest.param("container_options", NET_HOST, [NET_HOST], id="9"),
     pytest.param("display_color", "yellow is the color of a banana", False, id="10"),
     pytest.param("editor_command", "nano_env_var", "nano_env_var", id="11"),
     pytest.param("editor_console", "false", False, id="12"),
@@ -243,7 +253,7 @@ ENV_VAR_DATA = [
     pytest.param("exec_command", "/bin/foo", "/bin/foo", id="14"),
     pytest.param("exec_shell", "false", False, id="15"),
     pytest.param("execution_environment", "false", False, id="16"),
-    pytest.param("execution_environment_image", "test_image:latest", "test_image:latest", id="17"),
+    pytest.param("execution_environment_image", TEST_IMAGE, TEST_IMAGE, id="17"),
     pytest.param(
         "execution_environment_volume_mounts",
         "/tmp:/test1:Z;/tmp:/test2:z",
@@ -277,7 +287,7 @@ ENV_VAR_DATA = [
     ),
     pytest.param("lintables", "/tmp/lintables", "/tmp/lintables", id="29"),
     pytest.param("log_append", "false", False, id="30"),
-    pytest.param("log_file", "/tmp/app.log", "/tmp/app.log", id="31"),
+    pytest.param("log_file", TMP_APP_LOG, TMP_APP_LOG, id="31"),
     pytest.param("log_level", "info", "info", id="32"),
     pytest.param("mode", "interactive", "interactive", id="33"),
     pytest.param("osc4", "false", False, id="34"),


### PR DESCRIPTION
## Summary

Extract duplicated string literals into module-level constants to resolve 28 SonarCloud S1192 issues.

### src/ files
- `docs/_ext/regenerate_docs.py`: `GENERATED_DIR_NAME`
- `src/ansible_navigator/actions/run.py`: `COLUMN_IN_PROGRESS`
- `src/ansible_navigator/actions/write_file.py`: `JSON_EXTENSION`
- `src/ansible_navigator/tm_tokenize/compiler.py`: `INCLUDE_SELF`
- `src/ansible_navigator/tm_tokenize/grammars.py`: `SCOPE_UNKNOWN`
- `src/ansible_navigator/ui_framework/ui.py`: `KEY_REFRESH`
- `src/ansible_navigator/utils/serialize.py`: `UNKNOWN_SERIALIZATION_FORMAT_MSG`

### test/ files
- `tests/integration/_cli2runner.py`: `OVERRIDE_MSG`
- `tests/integration/actions/collections/base.py`: `BACK_CMD`, `BACK_TO_PLUGINS`, `BACK_TO_COLLECTIONS`
- `tests/integration/actions/inventory/base.py`: `BACK_CMD`, `PREV_GROUP_LIST`
- `tests/integration/actions/run/base.py`: `PLAY_1_DETAILS`, `BACK_CMD`, `PLAY_2_DETAILS`
- `tests/integration/actions/run_unicode/base.py`: `PLAY_1_DETAILS`, `BACK_CMD`
- `tests/integration/actions/templar/base.py`: `BACK_CMD`, `MODULE_DEBUG`
- `tests/unit/configuration_subsystem/data.py`: `TMP_ANSIBLE_CFG`, `TMP_INV1`, `TMP_INV2`, `TMP_SITE_YML`, `TMP_TEST1`, `NET_HOST`, `TEST_IMAGE`, `TMP_APP_LOG`

## Test plan
- [x] `ruff format` and `ruff check` pass
- [x] `tox -e lint` passes (cspell, mypy, pylint, prettier all green)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Centralized repeated internal constants for UI refresh key handling, JSON output detection, “in progress” play status labeling, unknown grammar/scope fallback, and serialization error messaging.
  - Improved maintainability of generated documentation output paths.
- **Documentation**
  - Updated docs generation settings to use a single shared generated-directory name.
- **Tests**
  - Consolidated repeated navigation labels, commands, and expected CLI/test data into shared constants for clearer integration/configuration coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->