### PR TITLE
fix: reduce cognitive complexity in actions/ modules (S3776)

### DIFF
--- a/src/ansible_navigator/actions/collections.py
+++ b/src/ansible_navigator/actions/collections.py
@@ -313,6 +313,91 @@ class Action(ActionBase):
             value=self._collections,
         )
 
+    def _process_plugin_for_menu(
+        self,
+        plugin_checksum: str,
+        details: dict[str, Any],
+        selected_collection: dict[str, Any],
+        collection_name: str,
+    ) -> dict[str, Any] | None:
+        """Process a single plugin entry for the collection content menu.
+
+        Args:
+            plugin_checksum: The checksum key for the plugin in the cache
+            details: The plugin details including type information
+            selected_collection: The parent collection data
+            collection_name: The display column name for the collection
+
+        Returns:
+            The processed plugin dict, or None if it could not be loaded
+        """
+        try:
+            plugin_json = self._collection_cache[plugin_checksum]
+            loaded = json.loads(plugin_json)
+
+            plugin = loaded["plugin"]
+            if plugin["doc"] is None:
+                return None
+
+            if "name" in plugin["doc"]:
+                short_name = plugin["doc"]["name"]
+            else:
+                short_name = plugin["doc"][details["type"]]
+            plugin[collection_name] = short_name
+            plugin["full_name"] = f"{selected_collection['known_as']}.{short_name}"
+            plugin["__type"] = details["type"]
+            plugin["collection_info"] = selected_collection["collection_info"]
+            plugin["collection_info"]["name"] = selected_collection["known_as"]
+            plugin["collection_info"]["shadowed_by"] = selected_collection["hidden_by"]
+            plugin["collection_info"]["path"] = selected_collection["path"]
+
+            plugin["__added"] = plugin["doc"].get("version_added")
+            plugin["__description"] = plugin["doc"]["short_description"]
+
+            runtime_section = "modules" if details["type"] == "module" else details["type"]
+            plugin["__deprecated"] = "False"
+            try:
+                routing_info = selected_collection["runtime"]["plugin_routing"]
+                runtime_info = routing_info[runtime_section][short_name]
+                plugin["additional_information"] = runtime_info
+                if "deprecation" in runtime_info:
+                    plugin["__deprecated"] = "True"
+            except KeyError:
+                plugin["additional_information"] = {}
+        except (KeyError, JSONDecodeError) as exc:
+            self._logger.exception("error loading plugin doc %s", details)
+            self._logger.debug("error was %s", str(exc))
+            return None
+        else:
+            return plugin
+
+    def _process_roles_for_menu(
+        self,
+        roles: list[dict[str, Any]],
+        collection_name: str,
+    ) -> list[dict[str, Any]]:
+        """Process roles for the collection content menu.
+
+        Args:
+            roles: The list of role dicts from the collection
+            collection_name: The display column name for the collection
+
+        Returns:
+            The list of processed role dicts ready for menu display
+        """
+        processed = []
+        for role in roles:
+            role[collection_name] = role["short_name"]
+            try:
+                role["__description"] = role["info"]["galaxy_info"]["description"]
+            except KeyError:
+                role["__description"] = ""
+            role["__deprecated"] = "Unknown"
+            role["__added"] = "Unknown"
+            role["__type"] = "role"
+            processed.append(role)
+        return processed
+
     def _build_collection_content_menu(self) -> Step:
         """Build the menu of plugins.
 
@@ -324,55 +409,20 @@ class Action(ActionBase):
         collection_name = f"__{selected_collection['known_as']}"
         collection_contents = []
         for plugin_checksum, details in selected_collection["plugin_checksums"].items():
-            try:
-                plugin_json = self._collection_cache[plugin_checksum]
-                loaded = json.loads(plugin_json)
-
-                plugin = loaded["plugin"]
-                if plugin["doc"] is not None:
-                    if "name" in plugin["doc"]:
-                        short_name = plugin["doc"]["name"]
-                    else:
-                        short_name = plugin["doc"][details["type"]]
-                    plugin[collection_name] = short_name
-                    plugin["full_name"] = f"{selected_collection['known_as']}.{short_name}"
-                    plugin["__type"] = details["type"]
-                    plugin["collection_info"] = selected_collection["collection_info"]
-                    plugin["collection_info"]["name"] = selected_collection["known_as"]
-                    plugin["collection_info"]["shadowed_by"] = selected_collection["hidden_by"]
-                    plugin["collection_info"]["path"] = selected_collection["path"]
-
-                    plugin["__added"] = plugin["doc"].get("version_added")
-                    plugin["__description"] = plugin["doc"]["short_description"]
-
-                    runtime_section = "modules" if details["type"] == "module" else details["type"]
-                    plugin["__deprecated"] = "False"
-                    try:
-                        routing_info = selected_collection["runtime"]["plugin_routing"]
-                        runtime_info = routing_info[runtime_section][short_name]
-                        plugin["additional_information"] = runtime_info
-                        if "deprecation" in runtime_info:
-                            plugin["__deprecated"] = "True"
-                    except KeyError:
-                        plugin["additional_information"] = {}
-
-                    collection_contents.append(plugin)
-            except (KeyError, JSONDecodeError) as exc:
-                self._logger.exception("error loading plugin doc %s", details)
-                self._logger.debug("error was %s", str(exc))
+            plugin = self._process_plugin_for_menu(
+                plugin_checksum,
+                details,
+                selected_collection,
+                collection_name,
+            )
+            if plugin is not None:
+                collection_contents.append(plugin)
 
         self._collection_cache.close()
 
-        for role in selected_collection["roles"]:
-            role[collection_name] = role["short_name"]
-            try:
-                role["__description"] = role["info"]["galaxy_info"]["description"]
-            except KeyError:
-                role["__description"] = ""
-            role["__deprecated"] = "Unknown"
-            role["__added"] = "Unknown"
-            role["__type"] = "role"
-            collection_contents.append(role)
+        collection_contents.extend(
+            self._process_roles_for_menu(selected_collection["roles"], collection_name),
+        )
 
         collection_contents = sorted(collection_contents, key=lambda i: i[collection_name])
 
@@ -397,8 +447,83 @@ class Action(ActionBase):
             index=self.steps.current.index,
         )
 
+    def _setup_ee_pythonpath(
+        self,
+        set_environment_variable: dict[str, Any],
+    ) -> None:
+        """Configure PYTHONPATH for execution environment runs.
+
+        Injects the navigator utils mount path into PYTHONPATH so that
+        the key_value_store module is accessible inside the EE.
+
+        Args:
+            set_environment_variable: The environment variable dict to update in place
+        """
+        ee_navigator_utils_mount = "/opt/ansible_navigator_utils"
+        if "PYTHONPATH" in set_environment_variable:
+            set_environment_variable["PYTHONPATH"].append(
+                f":{ee_navigator_utils_mount}",
+            )
+        else:
+            set_environment_variable["PYTHONPATH"] = f"${{PYTHONPATH}}:{ee_navigator_utils_mount}"
+        self._logger.debug(
+            "Execution Environment's PYTHONPATH is set to: %s",
+            set_environment_variable["PYTHONPATH"],
+        )
+
+    def _setup_ee_volume_mounts(
+        self,
+        kwargs: dict[str, Any],
+        playbook_dir: str,
+        cache_path: Path,
+    ) -> str:
+        """Build container volume mounts and return the python executable path for EE runs.
+
+        Args:
+            kwargs: The runner kwargs dict to update with volume mounts
+            playbook_dir: The playbook directory path
+            cache_path: The application cache path
+
+        Returns:
+            The python executable path to use inside the EE
+        """
+        self._logger.debug("running collections command with execution environment enabled")
+        python_exec_path = f"{cache_path}/python_latest.sh"
+        utils_lib = Path(__file__).parent / ".." / "utils"
+
+        container_volume_mounts = [
+            f"{cache_path}:{cache_path}",
+            f"{utils_lib!s}:/opt/ansible_navigator_utils",
+        ]
+        if Path(self._adjacent_collection_dir).exists():
+            container_volume_mounts.append(
+                f"{self._adjacent_collection_dir}:{self._adjacent_collection_dir}:z",
+            )
+
+        mount_doc_cache = not path_is_relative_to(
+            child=Path(self._args.collection_doc_cache_path),
+            parent=(cache_path),
+        ) and not path_is_relative_to(
+            child=Path(self._args.collection_doc_cache_path),
+            parent=(Path(playbook_dir)),
+        )
+
+        if mount_doc_cache:
+            container_volume_mounts.append(
+                f"{self._args.collection_doc_cache_path}:{self._args.collection_doc_cache_path}:z",
+            )
+
+        for volume_mount in container_volume_mounts:
+            self._logger.debug("Adding volume mount to container invocation: %s", volume_mount)
+
+        if "container_volume_mounts" in kwargs:
+            kwargs["container_volume_mounts"] += container_volume_mounts
+        else:
+            kwargs["container_volume_mounts"] = container_volume_mounts
+
+        return python_exec_path
+
     def _run_runner(self) -> None:
-        # pylint: disable=too-many-locals
         """Use the runner subsystem to catalog collections."""
         if isinstance(self._args.set_environment_variable, dict):
             set_environment_variable = deepcopy(self._args.set_environment_variable)
@@ -406,26 +531,8 @@ class Action(ActionBase):
             set_environment_variable = {}
         set_environment_variable["ANSIBLE_NOCOLOR"] = "True"
 
-        # We mount in the utils directory to /opt/ansible_navigator_utils
-        # We do this so that we can access key_value_store (KVS) from within
-        # the EE. If the Navigator user is overriding PYTHONPATH, we still need
-        # to inject this utils directory into the PYTHONPATH. If not, we'll just
-        # use the EE's default PYTHONPATH (if it exists) and just add our path
-        # at the end.
         if self._args.execution_environment:
-            ee_navigator_utils_mount = "/opt/ansible_navigator_utils"
-            if "PYTHONPATH" in set_environment_variable:
-                set_environment_variable["PYTHONPATH"].append(
-                    f":{ee_navigator_utils_mount}",
-                )
-            else:
-                set_environment_variable["PYTHONPATH"] = (
-                    f"${{PYTHONPATH}}:{ee_navigator_utils_mount}"
-                )
-            self._logger.debug(
-                "Execution Environment's PYTHONPATH is set to: %s",
-                set_environment_variable["PYTHONPATH"],
-            )
+            self._setup_ee_pythonpath(set_environment_variable)
 
         kwargs = {
             "container_engine": self._args.container_engine,
@@ -466,50 +573,7 @@ class Action(ActionBase):
         kwargs["cmdline"] = pass_through_arg
 
         if self._args.execution_environment:
-            self._logger.debug("running collections command with execution environment enabled")
-            python_exec_path = f"{cache_path}/python_latest.sh"
-            utils_lib = Path(__file__).parent / ".." / "utils"
-
-            container_volume_mounts = [
-                # cache directory which has introspection script
-                f"{cache_path}:{cache_path}",
-                # KVS library used by both Navigator and the introspection script
-                f"{utils_lib!s}:/opt/ansible_navigator_utils",
-            ]
-            if Path(self._adjacent_collection_dir).exists():
-                container_volume_mounts.append(
-                    f"{self._adjacent_collection_dir}:{self._adjacent_collection_dir}:z",
-                )
-
-            mount_doc_cache = True
-            # Determine if the doc_cache is relative to the cache directory
-            if path_is_relative_to(
-                child=Path(self._args.collection_doc_cache_path),
-                parent=(cache_path),
-            ):
-                mount_doc_cache = False
-
-            # The playbook directory will be mounted as host_cwd, so don't duplicate
-            if path_is_relative_to(
-                child=Path(self._args.collection_doc_cache_path),
-                parent=(Path(playbook_dir)),
-            ):
-                mount_doc_cache = False
-
-            if mount_doc_cache:
-                container_volume_mounts.append(
-                    f"{self._args.collection_doc_cache_path}:"
-                    f"{self._args.collection_doc_cache_path}:z",
-                )
-
-            for volume_mount in container_volume_mounts:
-                self._logger.debug("Adding volume mount to container invocation: %s", volume_mount)
-
-            if "container_volume_mounts" in kwargs:
-                kwargs["container_volume_mounts"] += container_volume_mounts
-            else:
-                kwargs["container_volume_mounts"] = container_volume_mounts
-
+            python_exec_path = self._setup_ee_volume_mounts(kwargs, playbook_dir, cache_path)
         else:
             self._logger.debug("running collections command locally")
             python_exec_path = sys.executable
@@ -531,17 +595,15 @@ class Action(ActionBase):
         if output:
             self._parse(output)
 
-    def _parse(self, output: str) -> None:
-        """Load and process the ``json`` output from the collection cataloging process.
+    def _extract_json_output(self, output: str) -> dict[str, Any] | None:
+        """Extract and parse JSON from the collection cataloging output.
 
         Args:
-            output: The output from the collection cataloging process
+            output: The raw output string that may contain warnings before JSON
 
         Returns:
-            Nothing
+            The parsed JSON dict, or None if parsing failed
         """
-        # pylint: disable=too-many-locals
-
         try:
             if not output.startswith("{"):
                 _warnings, json_str = output.split("{", 1)
@@ -554,6 +616,80 @@ class Action(ActionBase):
             self._logger.exception("Unable to extract collection json from stdout")
             self._logger.debug("error json loading output: '%s'", str(exc))
             self._logger.debug(output)
+            return None
+        return parsed
+
+    def _get_dest_volume_mounts(self) -> tuple[str, ...]:
+        """Build a tuple of destination volume mount paths for collection type detection.
+
+        Returns:
+            A tuple of destination paths derived from execution environment volume mounts
+        """
+        volume_mounts = self.app.args.execution_environment_volume_mounts
+        if not isinstance(volume_mounts, list):
+            return ()
+
+        tmp_list = []
+        for mount in volume_mounts:
+            source_str, destination_str = mount.split(":")[0:2]
+            if not Path(source_str).is_dir():
+                continue
+            dest_path = Path(destination_str)
+            if dest_path.parent.name == "ansible_collections":
+                continue
+            if dest_path.parent.parent.name == "ansible_collections":
+                continue
+            if dest_path.name != "ansible_collections":
+                dest_path /= "ansible_collections"
+            tmp_list.append(str(dest_path))
+        return tuple(tmp_list)
+
+    def _annotate_collection(
+        self,
+        collection: dict[str, Any],
+        dest_volume_mounts: tuple[str, ...],
+    ) -> None:
+        """Annotate a single collection with display metadata.
+
+        Adds __name, __version, __shadowed, and (for EE runs) __type fields.
+
+        Args:
+            collection: The collection dict to annotate in place
+            dest_volume_mounts: Destination volume mount paths for type detection
+        """
+        collection["__name"] = collection["known_as"]
+        collection["__version"] = collection["collection_info"].get("version", "missing")
+        collection["__shadowed"] = bool(collection["hidden_by"])
+        if not self._args.execution_environment:
+            return
+
+        if collection["path"].startswith(dest_volume_mounts) or collection["path"].startswith(
+            self._adjacent_collection_dir,
+        ):
+            collection["__type"] = "bind_mount"
+        elif collection["path"].startswith(f"{Path(self._adjacent_collection_dir).parent}"):
+            collection["__type"] = "bind_mount"
+            error = (
+                f"{collection['known_as']} was mounted and catalogued in the"
+                " execution environment but was outside the adjacent 'collections'"
+                " directory. This may cause issues outside the local development"
+                " environment."
+            )
+            self._logger.error(error)
+        else:
+            collection["__type"] = "contained"
+
+    def _parse(self, output: str) -> None:
+        """Load and process the ``json`` output from the collection cataloging process.
+
+        Args:
+            output: The output from the collection cataloging process
+
+        Returns:
+            Nothing
+        """
+        parsed = self._extract_json_output(output)
+        if parsed is None:
             return
 
         for error in parsed["errors"]:
@@ -563,48 +699,11 @@ class Action(ActionBase):
             parsed["collections"].values(),
             key=lambda i: i["known_as"],
         )
-        volume_mounts = self.app.args.execution_environment_volume_mounts
-        if isinstance(volume_mounts, list):
-            tmp_list = []
-            for mount in volume_mounts:
-                source_str, destination_str = mount.split(":")[0:2]
-                if not Path(source_str).is_dir():
-                    continue
-                dest_path = Path(destination_str)
-                # /x/ansible_collections/co:/x/ansible_collections/co
-                if dest_path.parent.name == "ansible_collections":
-                    continue
-                # /x/ansible_collections/co/ns:/x/ansible_collections/co/ns
-                if dest_path.parent.parent.name == "ansible_collections":
-                    continue
-                # /x:/x
-                if dest_path.name != "ansible_collections":
-                    dest_path /= "ansible_collections"
-                tmp_list.append(str(dest_path))
-            dest_volume_mounts = tuple(tmp_list)
-        else:
-            dest_volume_mounts = ()
+
+        dest_volume_mounts = self._get_dest_volume_mounts()
 
         for collection in self._collections:
-            collection["__name"] = collection["known_as"]
-            collection["__version"] = collection["collection_info"].get("version", "missing")
-            collection["__shadowed"] = bool(collection["hidden_by"])
-            if self._args.execution_environment:
-                if collection["path"].startswith(dest_volume_mounts) or collection[
-                    "path"
-                ].startswith(self._adjacent_collection_dir):
-                    collection["__type"] = "bind_mount"
-                elif collection["path"].startswith(f"{Path(self._adjacent_collection_dir).parent}"):
-                    collection["__type"] = "bind_mount"
-                    error = (
-                        f"{collection['known_as']} was mounted and catalogued in the"
-                        " execution environment but was outside the adjacent 'collections'"
-                        " directory. This may cause issues outside the local development"
-                        " environment."
-                    )
-                    self._logger.error(error)
-                else:
-                    collection["__type"] = "contained"
+            self._annotate_collection(collection, dest_volume_mounts)
 
         self._stats = parsed["stats"]
 
@@ -622,6 +721,56 @@ class Action(ActionBase):
             error = f"No collections found in {env} environment, searched in "
             error += parsed["collection_scan_paths"]
             self._logger.warning(error)
+
+    def _extract_single_plugin_details(
+        self,
+        plugin_checksum: str,
+        plugin_info: dict[str, Any],
+        selected_collection: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Extract details for a single plugin from the cache.
+
+        Args:
+            plugin_checksum: The checksum key for the plugin in the cache
+            plugin_info: The plugin info dict containing type and path
+            selected_collection: The parent collection data
+
+        Returns:
+            A dict with path, full_name, and optionally short_description
+        """
+        plugin_type = plugin_info.get("type")
+        plugin_json = self._collection_cache[plugin_checksum]
+        loaded = json.loads(plugin_json)
+
+        plugin = loaded.get("plugin")
+        plugin_docs: dict[str, Any] = {}
+        plugin_path = Path(selected_collection.get("path", "")) / Path(
+            plugin_info.get("path", ""),
+        )
+        plugin_docs["path"] = str(plugin_path)
+        if plugin and plugin["doc"] is not None:
+            try:
+                if "name" in plugin["doc"]:
+                    short_name = plugin["doc"]["name"]
+                else:
+                    short_name = plugin["doc"][plugin_type]
+            except (KeyError, TypeError) as exc:
+                short_name = None
+                self._logger.exception(
+                    "Error getting short name from plugin doc %s",
+                    plugin_docs["path"],
+                )
+                self._logger.debug("error was %s", str(exc))
+                self._logger.debug(plugin)
+            if short_name is None:
+                plugin_docs["full_name"] = selected_collection["known_as"]
+            else:
+                plugin_docs["full_name"] = f"{selected_collection['known_as']}.{short_name}"
+
+            if "short_description" in plugin["doc"]:
+                plugin_docs["short_description"] = plugin["doc"]["short_description"]
+
+        return plugin_docs
 
     def _get_collection_plugins_details(
         self,
@@ -643,40 +792,69 @@ class Action(ActionBase):
             if plugin_type not in plugins_details:
                 plugins_details[plugin_type] = []
 
-            plugin_json = self._collection_cache[plugin_checksum]
-            loaded = json.loads(plugin_json)
-
-            plugin = loaded.get("plugin")
-            plugin_docs = {}
-            plugin_path = Path(selected_collection.get("path", "")) / Path(
-                plugin_info.get("path", ""),
+            plugin_docs = self._extract_single_plugin_details(
+                plugin_checksum,
+                plugin_info,
+                selected_collection,
             )
-            plugin_docs["path"] = str(plugin_path)
-            if plugin and plugin["doc"] is not None:
-                try:
-                    if "name" in plugin["doc"]:
-                        short_name = plugin["doc"]["name"]
-                    else:
-                        short_name = plugin["doc"][plugin_type]
-                except (KeyError, TypeError) as exc:
-                    short_name = None
-                    self._logger.exception(
-                        "Error getting short name from plugin doc %s",
-                        plugin_docs["path"],
-                    )
-                    self._logger.debug("error was %s", str(exc))
-                    self._logger.debug(plugin)
-                if short_name is None:
-                    plugin_docs["full_name"] = selected_collection["known_as"]
-                else:
-                    plugin_docs["full_name"] = f"{selected_collection['known_as']}.{short_name}"
-
-                if "short_description" in plugin["doc"]:
-                    plugin_docs["short_description"] = plugin["doc"]["short_description"]
-
             plugins_details[plugin_type].append(plugin_docs)
 
         return plugins_details
+
+    @staticmethod
+    def _filter_roles_for_stdout(
+        roles: list[dict[str, Any]],
+        exclude_keys: list[str],
+    ) -> list[dict[str, Any]]:
+        """Filter excluded keys from role dicts for stdout display.
+
+        Args:
+            roles: The list of role dicts to filter
+            exclude_keys: Keys to exclude from each role dict
+
+        Returns:
+            A list of role dicts with excluded keys removed
+        """
+        filtered = []
+        for role in roles:
+            updated_role_info = {k: v for k, v in role.items() if k not in exclude_keys}
+            filtered.append(updated_role_info)
+        return filtered
+
+    def _format_collection_for_stdout(
+        self,
+        collection: dict[str, Any],
+        collection_exclude_keys: list[str],
+        roles_exclude_keys: list[str],
+    ) -> dict[str, Any]:
+        """Format a single collection for stdout display.
+
+        Args:
+            collection: The collection dict to format
+            collection_exclude_keys: Top-level keys to exclude
+            roles_exclude_keys: Keys to exclude from role entries
+
+        Returns:
+            The formatted collection dict with plugins details attached
+        """
+        plugins_details = self._get_collection_plugins_details(collection)
+
+        collection_stdout: dict[str, Any] = {}
+        for info_name, info_value in collection.items():
+            info_name = remove_dbl_un(info_name)
+            if info_name in collection_exclude_keys:
+                continue
+
+            if info_name == "roles":
+                collection_stdout["roles"] = self._filter_roles_for_stdout(
+                    info_value,
+                    roles_exclude_keys,
+                )
+            else:
+                collection_stdout[info_name] = info_value
+
+        collection_stdout["plugins"] = plugins_details
+        return collection_stdout
 
     def _parse_collection_info_stdout(self) -> dict[str, Any]:
         """Parse collection information from catalog collection cache.
@@ -684,9 +862,6 @@ class Action(ActionBase):
         Returns:
             The collection information to be displayed on stdout
         """
-        collections_info: dict[str, Any] = {
-            "collections": [],
-        }
         collection_exclude_keys = [
             "file_manifest_file",
             "format",
@@ -697,29 +872,16 @@ class Action(ActionBase):
         roles_exclude_keys = ["readme"]
 
         self._collection_cache.open_()
-        for collection in self._collections:
-            plugins_details = self._get_collection_plugins_details(collection)
-
-            collection_stdout: dict[str, Any] = {}
-            for info_name, info_value in collection.items():
-                info_name = remove_dbl_un(info_name)
-                if info_name in collection_exclude_keys:
-                    continue
-
-                if info_name == "roles":
-                    collection_stdout["roles"] = []
-                    for role in info_value:
-                        updated_role_info = {}
-                        for role_info_key, role_info_value in role.items():
-                            if role_info_key in roles_exclude_keys:
-                                continue
-                            updated_role_info[role_info_key] = role_info_value
-                        collection_stdout["roles"].append(updated_role_info)
-                else:
-                    collection_stdout[info_name] = info_value
-
-            collection_stdout["plugins"] = plugins_details
-            collections_info["collections"].append(collection_stdout)
+        collections_info: dict[str, Any] = {
+            "collections": [
+                self._format_collection_for_stdout(
+                    collection,
+                    collection_exclude_keys,
+                    roles_exclude_keys,
+                )
+                for collection in self._collections
+            ],
+        }
         self._collection_cache.close()
 
         return collections_info

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -306,7 +306,7 @@ class Action(ActionBase):
             msg = f"Error occurred while fetching ansible config (dump): '{dump_output_err}'"
             self._logger.error(msg)
 
-        err_msg = "\n".join({list_output_err, dump_output_err})
+        err_msg = "\n".join(e for e in (list_output_err, dump_output_err) if e)
         if "ERROR!" in err_msg or not list_output or not dump_output:
             warn_msg = ["Errors were encountered while gathering the configuration:"]
             if err_msg:
@@ -442,7 +442,7 @@ class Action(ActionBase):
             parsed[variable]["__current"] = current_as_str
             parsed[variable]["current_value"] = current
         except KeyError:
-            self._logger.exception("variable '%s' not found in list output")
+            self._logger.exception("variable '%s' not found in list output", variable)
             return False
         return True
 

--- a/src/ansible_navigator/actions/config.py
+++ b/src/ansible_navigator/actions/config.py
@@ -239,10 +239,6 @@ class Action(ActionBase):
     def _run_runner(self) -> tuple[str, str, int] | None:
         """Use the runner subsystem to retrieve the configuration.
 
-        Raises:
-            RuntimeError: When the ansible-config command cannot be
-                found with execution environment support disabled.
-
         Returns:
             For mode interactive nothing. For mode stdout the output,
             errors and return code from runner.
@@ -277,58 +273,93 @@ class Action(ActionBase):
             kwargs.update({"container_options": self._args.container_options})
 
         if self._args.mode == "interactive":
-            self._runner = AnsibleConfig(**kwargs)
-            kwargs = {}
-            if isinstance(self._args.config, str):
-                kwargs["config_file"] = self._args.config
-            list_output, list_output_err = self._runner.fetch_ansible_config("list", **kwargs)
-            dump_output, dump_output_err = self._runner.fetch_ansible_config("dump", **kwargs)
-            if list_output_err:
-                msg = f"Error occurred while fetching ansible config (list): '{list_output_err}'"
-                self._logger.error(msg)
-            if dump_output_err:
-                msg = f"Error occurred while fetching ansible config (dump): '{dump_output_err}'"
-                self._logger.error(msg)
+            self._run_runner_interactive(kwargs)
+            return None
+        return self._run_runner_stdout(kwargs)
 
-            err_msg = "\n".join({list_output_err, dump_output_err})
-            if "ERROR!" in err_msg or not list_output or not dump_output:
-                warn_msg = ["Errors were encountered while gathering the configuration:"]
-                if err_msg:
-                    warn_msg += err_msg.splitlines()
-                if not list_output or not dump_output:
-                    warn_msg.append("The configuration could not be gathered.")
-                warning = warning_notification(warn_msg)
-                self._interaction.ui.show_form(warning)
-            else:
-                self._parse_and_merge(list_output, dump_output)
+    def _run_runner_interactive(
+        self,
+        kwargs: dict[str, Any],
+    ) -> None:
+        """Run the ansible-config runner in interactive mode.
+
+        Fetches both the list and dump output from ansible-config,
+        logs any errors, and parses/merges the results.
+
+        Args:
+            kwargs: The common runner keyword arguments.
+        """
+        self._runner = AnsibleConfig(**kwargs)
+        config_file = self._args.config if isinstance(self._args.config, str) else None
+        list_output, list_output_err = self._runner.fetch_ansible_config(
+            "list",
+            config_file=config_file,
+        )
+        dump_output, dump_output_err = self._runner.fetch_ansible_config(
+            "dump",
+            config_file=config_file,
+        )
+        if list_output_err:
+            msg = f"Error occurred while fetching ansible config (list): '{list_output_err}'"
+            self._logger.error(msg)
+        if dump_output_err:
+            msg = f"Error occurred while fetching ansible config (dump): '{dump_output_err}'"
+            self._logger.error(msg)
+
+        err_msg = "\n".join({list_output_err, dump_output_err})
+        if "ERROR!" in err_msg or not list_output or not dump_output:
+            warn_msg = ["Errors were encountered while gathering the configuration:"]
+            if err_msg:
+                warn_msg += err_msg.splitlines()
+            if not list_output or not dump_output:
+                warn_msg.append("The configuration could not be gathered.")
+            warning = warning_notification(warn_msg)
+            self._interaction.ui.show_form(warning)
         else:
-            if self._args.execution_environment:
-                ansible_config_path = "ansible-config"
-            else:
-                exec_path = shutil.which("ansible-config")
-                if exec_path is None:
-                    msg = "'ansible-config' executable not found"
-                    self._logger.error(msg)
-                    raise RuntimeError(msg)
-                ansible_config_path = exec_path
+            self._parse_and_merge(list_output, dump_output)
 
-            if isinstance(self._args.cmdline, list):
-                pass_through_arg = self._args.cmdline.copy()
-            else:
-                pass_through_arg = []
+    def _run_runner_stdout(
+        self,
+        kwargs: dict[str, Any],
+    ) -> tuple[str, str, int] | None:
+        """Run the ansible-config runner in stdout mode.
 
-            if self._args.help_config is True:
-                pass_through_arg.append("--help")
+        Resolves the ansible-config executable path, builds the
+        pass-through arguments, and runs the command.
 
-            if isinstance(self._args.config, str):
-                pass_through_arg.extend(["--config", self._args.config])
+        Args:
+            kwargs: The common runner keyword arguments.
 
-            kwargs.update({"cmdline": pass_through_arg})
+        Raises:
+            RuntimeError: When the ansible-config command cannot be
+                found with execution environment support disabled.
 
-            self._runner = Command(executable_cmd=ansible_config_path, **kwargs)
-            stdout_return = self._runner.run()
-            return stdout_return
-        return None
+        Returns:
+            The output, errors and return code from runner.
+        """
+        if self._args.execution_environment:
+            ansible_config_path = "ansible-config"
+        else:
+            exec_path = shutil.which("ansible-config")
+            if exec_path is None:
+                msg = "'ansible-config' executable not found"
+                self._logger.error(msg)
+                raise RuntimeError(msg)
+            ansible_config_path = exec_path
+
+        pass_through_arg = self._args.cmdline.copy() if isinstance(self._args.cmdline, list) else []
+
+        if self._args.help_config is True:
+            pass_through_arg.append("--help")
+
+        if isinstance(self._args.config, str):
+            pass_through_arg.extend(["--config", self._args.config])
+
+        kwargs.update({"cmdline": pass_through_arg})
+
+        self._runner = Command(executable_cmd=ansible_config_path, **kwargs)
+        stdout_return = self._runner.run()
+        return stdout_return
 
     def _parse_and_merge(self, list_output: str, dump_output: str) -> None:
         """Parse the list and dump output. Merge dump into list.
@@ -340,7 +371,6 @@ class Action(ActionBase):
         Returns:
             Nothing
         """
-        # pylint: disable=too-many-locals
         try:
             parsed = yaml.load(list_output, Loader=Loader)
             self._logger.debug("yaml loading list output succeeded")
@@ -354,40 +384,77 @@ class Action(ActionBase):
         for line in dump_output.splitlines():
             if not line:
                 break
-            extracted = regex.match(line)
-            if extracted:
-                variable = extracted.groupdict()["variable"]
-                try:
-                    source = yaml.load(extracted.groupdict()["source"], Loader=Loader)
-                except yaml.YAMLError:
-                    source = extracted.groupdict()["source"]
-                try:
-                    current = yaml.load(extracted.groupdict()["current"], Loader=Loader)
-                except yaml.YAMLError:
-                    current = extracted.groupdict()["current"]
-                try:
-                    if isinstance(source, dict):
-                        parsed[variable]["source"] = next(iter(source.keys()))
-                        parsed[variable]["via"] = next(iter(source.values()))
-                    else:
-                        parsed[variable]["source"] = source
-                        parsed[variable]["via"] = source
-                    current_as_str = str(current)
-
-                    target_screen_w = int(100 / 2)  # half a wide screen
-                    if len(current_as_str) > target_screen_w:
-                        more_indicator = "..."
-                        text_width = target_screen_w - len(more_indicator)
-                        current_as_str = f"{current_as_str[0:text_width]}{more_indicator}"
-                    parsed[variable]["__current"] = current_as_str
-                    parsed[variable]["current_value"] = current
-                except KeyError:
-                    self._logger.exception("variable '%s' not found in list output")
-                    return
-            else:
-                self._logger.error("Unparsable dump entry: %s", line)
+            if not self._parse_dump_line(regex, line, parsed):
                 return
 
+        self._finalize_parsed_config(parsed)
+        self._config = list(parsed.values())
+        self._logger.debug("parsed and merged list and dump successfully")
+        return
+
+    def _parse_dump_line(
+        self,
+        regex: re.Pattern[str],
+        line: str,
+        parsed: dict[str, Any],
+    ) -> bool:
+        """Parse a single line from the ansible-config dump output.
+
+        Extracts the variable name, source, and current value from
+        the line and merges them into the parsed config dictionary.
+
+        Args:
+            regex: The compiled regex pattern for matching dump lines.
+            line: A single line from the dump output.
+            parsed: The parsed config dictionary to update in place.
+
+        Returns:
+            True if the line was parsed successfully, False on error.
+        """
+        extracted = regex.match(line)
+        if not extracted:
+            self._logger.error("Unparsable dump entry: %s", line)
+            return False
+
+        variable = extracted.groupdict()["variable"]
+        try:
+            source = yaml.load(extracted.groupdict()["source"], Loader=Loader)
+        except yaml.YAMLError:
+            source = extracted.groupdict()["source"]
+        try:
+            current = yaml.load(extracted.groupdict()["current"], Loader=Loader)
+        except yaml.YAMLError:
+            current = extracted.groupdict()["current"]
+        try:
+            if isinstance(source, dict):
+                parsed[variable]["source"] = next(iter(source.keys()))
+                parsed[variable]["via"] = next(iter(source.values()))
+            else:
+                parsed[variable]["source"] = source
+                parsed[variable]["via"] = source
+            current_as_str = str(current)
+
+            target_screen_w = int(100 / 2)  # half a wide screen
+            if len(current_as_str) > target_screen_w:
+                more_indicator = "..."
+                text_width = target_screen_w - len(more_indicator)
+                current_as_str = f"{current_as_str[0:text_width]}{more_indicator}"
+            parsed[variable]["__current"] = current_as_str
+            parsed[variable]["current_value"] = current
+        except KeyError:
+            self._logger.exception("variable '%s' not found in list output")
+            return False
+        return True
+
+    def _finalize_parsed_config(self, parsed: dict[str, Any]) -> None:
+        """Post-process the parsed config entries with display metadata.
+
+        Adds option name, default indicators, and config file path
+        to each parsed config entry.
+
+        Args:
+            parsed: The parsed config dictionary to update in place.
+        """
         for key, value in parsed.items():
             value["option"] = key
             value["name"] = key.replace("_", " ").capitalize()

--- a/src/ansible_navigator/actions/doc.py
+++ b/src/ansible_navigator/actions/doc.py
@@ -151,10 +151,6 @@ class Action(ActionBase):
     def _run_runner(self) -> dict[Any, Any] | tuple[str, str, int] | None:
         """Use the runner subsystem to retrieve the configuration.
 
-        Raises:
-            RuntimeError: When the ansible-doc command cannot be found
-                with execution environment support disabled.
-
         Returns:
             For mode interactive nothing or the plugin's doc. For mode
             stdout the output, errors and return code from runner.
@@ -188,31 +184,69 @@ class Action(ActionBase):
             kwargs.update({"container_options": self._args.container_options})
 
         if self._args.mode == "interactive":
-            if isinstance(self._args.playbook, str):
-                playbook_dir = f"{Path(self._args.playbook).parent}"
-            else:
-                playbook_dir = str(Path.cwd())
-            kwargs.update({"host_cwd": playbook_dir})
+            return self._run_runner_interactive(kwargs)
+        return self._run_runner_stdout(kwargs)
 
-            self._runner = AnsibleDoc(**kwargs)
+    def _run_runner_interactive(
+        self,
+        kwargs: dict[str, Any],
+    ) -> dict[Any, Any] | None:
+        """Run the ansible-doc runner in interactive mode.
 
-            # set the playbook directory so playbook
-            # adjacent collection docs can be found
-            self._logger.debug("doc playbook dir set to: %s", playbook_dir)
+        Resolves the playbook directory, fetches plugin documentation
+        via AnsibleDoc, and extracts the result.
 
-            plugin_doc, plugin_doc_err = self._runner.fetch_plugin_doc(
-                [self._plugin_name],
-                plugin_type=self._plugin_type,
-                playbook_dir=playbook_dir,
+        Args:
+            kwargs: The common runner keyword arguments.
+
+        Returns:
+            The plugin's documentation dictionary or None.
+        """
+        if isinstance(self._args.playbook, str):
+            playbook_dir = f"{Path(self._args.playbook).parent}"
+        else:
+            playbook_dir = str(Path.cwd())
+        kwargs.update({"host_cwd": playbook_dir})
+
+        self._runner = AnsibleDoc(**kwargs)
+
+        # set the playbook directory so playbook
+        # adjacent collection docs can be found
+        self._logger.debug("doc playbook dir set to: %s", playbook_dir)
+
+        plugin_doc, plugin_doc_err = self._runner.fetch_plugin_doc(
+            [self._plugin_name],
+            plugin_type=self._plugin_type,
+            playbook_dir=playbook_dir,
+        )
+        if plugin_doc_err:
+            self._logger.error(
+                "Error occurred while fetching doc for plugin %s: '%s'",
+                self._plugin_name,
+                plugin_doc_err,
             )
-            if plugin_doc_err:
-                self._logger.error(
-                    "Error occurred while fetching doc for plugin %s: '%s'",
-                    self._plugin_name,
-                    plugin_doc_err,
-                )
-            plugin_doc_response = self._extract_plugin_doc(plugin_doc, plugin_doc_err)
-            return plugin_doc_response
+        plugin_doc_response = self._extract_plugin_doc(plugin_doc, plugin_doc_err)
+        return plugin_doc_response
+
+    def _run_runner_stdout(
+        self,
+        kwargs: dict[str, Any],
+    ) -> tuple[str, str, int] | None:
+        """Run the ansible-doc runner in stdout mode.
+
+        Resolves the ansible-doc executable path, builds the
+        pass-through arguments, and runs the command.
+
+        Args:
+            kwargs: The common runner keyword arguments.
+
+        Raises:
+            RuntimeError: When the ansible-doc command cannot be
+                found with execution environment support disabled.
+
+        Returns:
+            The output, errors and return code from runner.
+        """
         kwargs.update({"host_cwd": str(Path.cwd())})
         if self._args.execution_environment:
             ansible_doc_path = "ansible-doc"
@@ -257,39 +291,62 @@ class Action(ActionBase):
         Returns:
             The plugin's doc or errors
         """
-        plugin_doc = {}
         if self._args.execution_environment:
             error_key_name = "execution_environment_errors"
         else:
             error_key_name = "local_errors"
 
         if out:
-            if isinstance(out, dict):
-                plugin_doc = out[self._plugin_name]
-            else:
-                try:
-                    json_loaded = json.loads(out)
-                except json.JSONDecodeError as exc:
-                    if self._args.mode == "interactive":
-                        self._logger.info(
-                            "Parsing of ansible-doc output failed for '%s'",
-                            self._plugin_name,
-                        )
-                    self._logger.debug("json decode error: %s", str(exc))
-                    self._logger.debug("tried: %s", out)
-                    plugin_doc[error_key_name] = out
-                else:
-                    plugin_doc = json_loaded[self._plugin_name]
+            return self._process_plugin_output(out, err, error_key_name)
 
-            if isinstance(err, dict):
-                plugin_doc["warnings"] = err
-            else:
-                plugin_doc["warnings"] = err.splitlines()
-
-        elif err:
+        plugin_doc: dict[Any, Any] = {}
+        if err:
             if isinstance(err, dict):
                 plugin_doc[error_key_name] = err
             else:
                 plugin_doc[error_key_name] = err.splitlines()
+        return plugin_doc
+
+    def _process_plugin_output(
+        self,
+        out: dict[Any, Any] | str,
+        err: dict[Any, Any] | str,
+        error_key_name: str,
+    ) -> dict[Any, Any]:
+        """Process the plugin output when output is present.
+
+        Parses the runner output (dict or JSON string), extracts the
+        plugin documentation, and attaches any warnings from stderr.
+
+        Args:
+            out: The non-empty output from runner.
+            err: Any runner errors.
+            error_key_name: The key name to use for error entries.
+
+        Returns:
+            The plugin's documentation dictionary with warnings.
+        """
+        plugin_doc: dict[Any, Any] = {}
+        if isinstance(out, dict):
+            plugin_doc = out[self._plugin_name]
+        else:
+            try:
+                json_loaded = json.loads(out)
+            except json.JSONDecodeError as exc:
+                if self._args.mode == "interactive":
+                    self._logger.info(
+                        "Parsing of ansible-doc output failed for '%s'",
+                        self._plugin_name,
+                    )
+                self._logger.debug("json decode error: %s", str(exc))
+                self._logger.debug("tried: %s", out)
+                plugin_doc[error_key_name] = out
+            else:
+                plugin_doc = json_loaded[self._plugin_name]
+
+        if isinstance(err, dict):
+            plugin_doc["warnings"] = err
+        else:
+            plugin_doc["warnings"] = err.splitlines()
 
         return plugin_doc

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -206,7 +206,7 @@ class Action(ActionBase):
         self._set_inventories_mtime()
 
         self._collect_inventory_details()
-        return bool(self._inventory)
+        return bool(self._inventory) or bool(self._inventory_error)
 
     def _check_inventory_changed(self) -> bool:
         """Check if inventory files have been modified and refresh if needed.

--- a/src/ansible_navigator/actions/inventory.py
+++ b/src/ansible_navigator/actions/inventory.py
@@ -189,6 +189,48 @@ class Action(ActionBase):
         """Request calling app update, inventory update checked in ``run()``."""
         self._calling_app.update()
 
+    def _initialize_inventory(self) -> bool:
+        """Set up args, collect inventory details, and check for errors.
+
+        Returns:
+            True if initialization succeeded, False otherwise
+        """
+        args_updated = self._update_args(
+            [self._name] + shlex.split(self._interaction.action.match.groupdict()["params"] or ""),
+        )
+        if not args_updated:
+            return False
+
+        self.stdout = self._calling_app.stdout
+        self._inventories = self._args.inventory
+        self._set_inventories_mtime()
+
+        self._collect_inventory_details()
+        return bool(self._inventory)
+
+    def _check_inventory_changed(self) -> bool:
+        """Check if inventory files have been modified and refresh if needed.
+
+        Returns:
+            True if the loop should break, False otherwise
+        """
+        current_mtime = self._inventories_mtime
+        self._set_inventories_mtime()
+        if current_mtime != self._inventories_mtime:
+            self._logger.debug("inventory changed")
+
+            self._set_inventories_mtime()
+
+            self._collect_inventory_details()
+            if not self._inventory:
+                return True
+
+            if self._inventory_error:
+                self._logger.error(self._inventory_error)
+                return True
+
+        return False
+
     def run(self, interaction: Interaction, app: AppPublic) -> Interaction | None:
         """Execute the ``inventory`` request for mode interactive.
 
@@ -204,19 +246,7 @@ class Action(ActionBase):
         self._logger.debug("inventory requested in interactive mode")
         self._prepare_to_run(app, interaction)
 
-        args_updated = self._update_args(
-            [self._name] + shlex.split(self._interaction.action.match.groupdict()["params"] or ""),
-        )
-        if not args_updated:
-            self._prepare_to_exit(interaction)
-            return None
-
-        self.stdout = self._calling_app.stdout
-        self._inventories = self._args.inventory
-        self._set_inventories_mtime()
-
-        self._collect_inventory_details()
-        if not self._inventory:
+        if not self._initialize_inventory():
             self._prepare_to_exit(interaction)
             return None
 
@@ -239,20 +269,8 @@ class Action(ActionBase):
             if not self.steps:
                 break
 
-            current_mtime = self._inventories_mtime
-            self._set_inventories_mtime()
-            if current_mtime != self._inventories_mtime:
-                self._logger.debug("inventory changed")
-
-                self._set_inventories_mtime()
-
-                self._collect_inventory_details()
-                if not self._inventory:
-                    break
-
-                if self._inventory_error:
-                    self._logger.error(self._inventory_error)
-                    break
+            if self._check_inventory_changed():
+                break
 
             if self.steps.current.name == "quit":
                 return self.steps.current
@@ -467,6 +485,29 @@ class Action(ActionBase):
         msg = "unknown step type"
         raise TypeError(msg)
 
+    def _handle_inventory_errors(self, inventory_err: str, inventory_output: str) -> None:
+        """Check inventory errors and show notifications or extract inventory.
+
+        Args:
+            inventory_err: The error output from the inventory collection
+            inventory_output: The standard output from the inventory collection
+        """
+        preface = ["Errors were encountered while gathering the inventory:"]
+        notify = ("ERROR!", "Error", "Unable to parse")
+        if any(string in inventory_err for string in notify):
+            if "[WARNING]" in inventory_err:
+                parts = inventory_err.split("[WARNING]")
+                messages = [part.replace("\n", " ").strip() for part in parts if part]
+                present = preface + [f"[WARNING]{message}" for message in messages]
+            else:
+                present = preface + inventory_err.splitlines()
+            for line in present:
+                self._logger.error(line)
+            warning = warning_notification(present)
+            self._interaction.ui.show_form(warning)
+        else:
+            self._extract_inventory(inventory_output)
+
     def _collect_inventory_details_interactive(
         self,
         kwargs: dict[str, Any],
@@ -503,21 +544,7 @@ class Action(ActionBase):
             parts = inventory_output.split("{", 1)
             inventory_err = parts[0] + inventory_err if inventory_err else parts[0]
             inventory_output = "{" + parts[1] if len(parts) == 2 else ""
-        preface = ["Errors were encountered while gathering the inventory:"]
-        notify = ("ERROR!", "Error", "Unable to parse")
-        if any(string in inventory_err for string in notify):
-            if "[WARNING]" in inventory_err:
-                parts = inventory_err.split("[WARNING]")
-                messages = [part.replace("\n", " ").strip() for part in parts if part]
-                present = preface + [f"[WARNING]{message}" for message in messages]
-            else:
-                present = preface + inventory_err.splitlines()
-            for line in present:
-                self._logger.error(line)
-            warning = warning_notification(present)
-            self._interaction.ui.show_form(warning)
-        else:
-            self._extract_inventory(inventory_output)
+        self._handle_inventory_errors(inventory_err, inventory_output)
 
     def _collect_inventory_details_automated(
         self,

--- a/src/ansible_navigator/actions/lint.py
+++ b/src/ansible_navigator/actions/lint.py
@@ -514,6 +514,46 @@ class Action(ActionBase):
             index=self.steps.current.index,
         )
 
+    def _update_file_timestamps(
+        self,
+        path: str,
+        unix_ts: float | None,
+        iso_ts: str | None,
+    ) -> bool:
+        """Update timestamps for all issues matching the given path.
+
+        Args:
+            path: The file path to match against issues
+            unix_ts: The unix timestamp of the file
+            iso_ts: The ISO formatted timestamp of the file
+
+        Returns:
+            True if any matching issue indicates a rerun is needed
+        """
+        rerun_needed = False
+        for issue in self._issues_menu.value:
+            if issue["__path"] != path:
+                continue
+
+            previous_ts = issue.get("__last_modified")
+            issue["last_modified"] = iso_ts
+            issue["__last_modified"] = unix_ts
+
+            # The file may be gone or non existent
+            if unix_ts is None:
+                continue
+
+            # The may be a first run
+            if previous_ts is None:
+                rerun_needed = True
+                continue
+
+            # Has the file changed
+            if unix_ts > previous_ts:
+                rerun_needed = True
+
+        return rerun_needed
+
     def _rerun_needed(self) -> bool:
         """Add a modification timestamp to each issue, check for changes.
 
@@ -521,35 +561,15 @@ class Action(ActionBase):
             Indication if lint should be rerun
         """
         rerun_lint = False
-        checked_paths = []
-        for outer_issue in self._issues_menu.value:
-            outer_path = outer_issue["__path"]
-            if outer_path in checked_paths:
+        checked_paths: list[str] = []
+        for issue in self._issues_menu.value:
+            path = issue["__path"]
+            if path in checked_paths:
                 continue
-            checked_paths.append(outer_path)
-            unix_ts, iso_ts = time_stamp_for_file(outer_path, self._args.time_zone)
-            # Set all issues for the same file
-            for inner_issue in self._issues_menu.value:
-                inner_path = inner_issue["__path"]
-                if inner_path != outer_path:
-                    continue
-
-                previous_ts = inner_issue.get("__last_modified")
-                inner_issue["last_modified"] = iso_ts
-                inner_issue["__last_modified"] = unix_ts
-
-                # The file may be gone or non existent
-                if unix_ts is None:
-                    continue
-
-                # The may be a first run
-                if previous_ts is None:
-                    rerun_lint = True
-                    continue
-
-                # Has the file changed
-                if unix_ts > previous_ts:
-                    rerun_lint = True
+            checked_paths.append(path)
+            unix_ts, iso_ts = time_stamp_for_file(path, self._args.time_zone)
+            if self._update_file_timestamps(path, unix_ts, iso_ts):
+                rerun_lint = True
 
         self._modification_times_last_updated = datetime.now(timezone.utc)
         if rerun_lint:

--- a/src/ansible_navigator/actions/lint.py
+++ b/src/ansible_navigator/actions/lint.py
@@ -514,46 +514,6 @@ class Action(ActionBase):
             index=self.steps.current.index,
         )
 
-    def _update_file_timestamps(
-        self,
-        path: str,
-        unix_ts: float | None,
-        iso_ts: str | None,
-    ) -> bool:
-        """Update timestamps for all issues matching the given path.
-
-        Args:
-            path: The file path to match against issues
-            unix_ts: The unix timestamp of the file
-            iso_ts: The ISO formatted timestamp of the file
-
-        Returns:
-            True if any matching issue indicates a rerun is needed
-        """
-        rerun_needed = False
-        for issue in self._issues_menu.value:
-            if issue["__path"] != path:
-                continue
-
-            previous_ts = issue.get("__last_modified")
-            issue["last_modified"] = iso_ts
-            issue["__last_modified"] = unix_ts
-
-            # The file may be gone or non existent
-            if unix_ts is None:
-                continue
-
-            # The may be a first run
-            if previous_ts is None:
-                rerun_needed = True
-                continue
-
-            # Has the file changed
-            if unix_ts > previous_ts:
-                rerun_needed = True
-
-        return rerun_needed
-
     def _rerun_needed(self) -> bool:
         """Add a modification timestamp to each issue, check for changes.
 
@@ -561,14 +521,19 @@ class Action(ActionBase):
             Indication if lint should be rerun
         """
         rerun_lint = False
-        checked_paths: list[str] = []
+        path_timestamps: dict[str, tuple[float | None, str | None]] = {}
         for issue in self._issues_menu.value:
             path = issue["__path"]
-            if path in checked_paths:
-                continue
-            checked_paths.append(path)
-            unix_ts, iso_ts = time_stamp_for_file(path, self._args.time_zone)
-            if self._update_file_timestamps(path, unix_ts, iso_ts):
+            if path not in path_timestamps:
+                path_timestamps[path] = time_stamp_for_file(path, self._args.time_zone)
+
+            unix_ts, iso_ts = path_timestamps[path]
+            previous_ts = issue.get("__last_modified")
+
+            issue["last_modified"] = iso_ts
+            issue["__last_modified"] = unix_ts
+
+            if unix_ts is not None and (previous_ts is None or unix_ts > previous_ts):
                 rerun_lint = True
 
         self._modification_times_last_updated = datetime.now(timezone.utc)

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -489,11 +489,15 @@ class Action(ActionBase):
         else:
             artifact_valid = False
 
-        if not artifact_valid and self.mode == "interactive":
-            populated_form = self._prompt_for_artifact(artifact_file=artifact_file)
-            if populated_form["cancelled"]:
+        if not artifact_valid:
+            if self.mode == "interactive":
+                populated_form = self._prompt_for_artifact(artifact_file=artifact_file)
+                if populated_form["cancelled"]:
+                    return None
+                artifact_file = populated_form["fields"]["artifact_file"]["value"]
+            else:
+                self._logger.error("Artifact file '%s' not found", artifact_file)
                 return None
-            artifact_file = populated_form["fields"]["artifact_file"]["value"]
 
         return artifact_file
 

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -81,6 +81,64 @@ def get_color(word: str) -> int:
     )
 
 
+def _color_for_play(colname: str, colval: Any, entry: dict[str, Any]) -> tuple[int, int]:
+    """Determine color and decoration for a play menu entry.
+
+    Args:
+        colname: The column name
+        colval: The column value
+        entry: The menu entry
+
+    Returns:
+        The color and decoration
+    """
+    color = 0
+    decoration = 0
+    if not colval:
+        color = 8
+    elif colname in ["__task_count", "__play_name", "__progress"]:
+        failures = entry["__failed"] + entry["__unreachable"]
+        if failures:
+            color = 9
+        elif entry["__ok"]:
+            color = 10
+        else:
+            color = 8
+    elif colname == "__changed":
+        color = 11
+    else:
+        color = get_color(colname[2:])
+
+    if colname == "__progress" and entry["__progress"].strip().lower() == "complete":
+        decoration = curses.A_BOLD
+
+    return color, decoration
+
+
+def _color_for_task(colname: str, colval: Any, entry: dict[str, Any]) -> tuple[int, int]:
+    """Determine color and decoration for a task menu entry.
+
+    Args:
+        colname: The column name
+        colval: The column value
+        entry: The menu entry
+
+    Returns:
+        The color and decoration
+    """
+    color = 0
+    decoration = 0
+    if entry["__result"].lower() == "in progress" or (
+        colname in ["__result", "__host", "__number", "__task", "__task_action"]
+    ):
+        color = get_color(entry["__result"])
+    elif colname == "__changed":
+        color = 11 if colval is True else get_color(entry["__result"])
+    elif colname == "__duration":
+        color = 12
+    return color, decoration
+
+
 def color_menu(_colno: int, colname: str, entry: dict[str, Any]) -> tuple[int, int]:
     """Find matching color for word.
 
@@ -92,38 +150,11 @@ def color_menu(_colno: int, colname: str, entry: dict[str, Any]) -> tuple[int, i
         The color and decoration
     """
     colval = entry[colname]
-    color = 0
-    decoration = 0
     if "__play_name" in entry:
-        if not colval:
-            color = 8
-        elif colname in ["__task_count", "__play_name", "__progress"]:
-            failures = entry["__failed"] + entry["__unreachable"]
-            if failures:
-                color = 9
-            elif entry["__ok"]:
-                color = 10
-            else:
-                color = 8
-        elif colname == "__changed":
-            color = 11
-        else:
-            color = get_color(colname[2:])
-
-        if colname == "__progress" and entry["__progress"].strip().lower() == "complete":
-            decoration = curses.A_BOLD
-
-    elif "task" in entry:
-        if entry["__result"].lower() == "in progress" or (
-            colname in ["__result", "__host", "__number", "__task", "__task_action"]
-        ):
-            color = get_color(entry["__result"])
-        elif colname == "__changed":
-            color = 11 if colval is True else get_color(entry["__result"])
-        elif colname == "__duration":
-            color = 12
-
-    return color, decoration
+        return _color_for_play(colname, colval, entry)
+    if "task" in entry:
+        return _color_for_task(colname, colval, entry)
+    return 0, 0
 
 
 def content_heading(obj: Any, screen_w: int) -> CursesLines | None:
@@ -303,6 +334,32 @@ class Action(ActionBase):
             )
         return RunStdoutReturn(message="", return_code=return_code)
 
+    def _initialize_subaction(self, interaction: Interaction) -> bool:
+        """Initialize the run or replay subaction based on user interaction.
+
+        Args:
+            interaction: The interaction from the user
+
+        Returns:
+            True if initialization succeeded
+        """
+        if interaction.action.match.groupdict().get("run"):
+            self._logger.debug("run requested in interactive mode")
+            self._subaction_type = "run"
+            str_uuid = str(uuid.uuid4())
+            self._logger = logging.getLogger(f"{__name__}_{str_uuid[-4:]}")
+            self._name = f"run_{str_uuid[-4:]}"
+            return self._init_run()
+
+        if interaction.action.match.groupdict().get("replay"):
+            self._logger.debug("replay requested in interactive mode")
+            self._subaction_type = "replay"
+            self._name = "replay"
+            self._logger = logging.getLogger(f"{__name__}_{self._subaction_type}")
+            return self._init_replay()
+
+        return False
+
     def run(self, interaction: Interaction, app: AppPublic) -> Interaction | None:
         """Run :run or :replay.
 
@@ -314,23 +371,8 @@ class Action(ActionBase):
             The pending interaction or none
         """
         self._prepare_to_run(app, interaction)
-        initialized = False
 
-        if interaction.action.match.groupdict().get("run"):
-            self._logger.debug("run requested in interactive mode")
-            self._subaction_type = "run"
-            str_uuid = str(uuid.uuid4())
-            self._logger = logging.getLogger(f"{__name__}_{str_uuid[-4:]}")
-            self._name = f"run_{str_uuid[-4:]}"
-            initialized = self._init_run()
-        elif interaction.action.match.groupdict().get("replay"):
-            self._logger.debug("replay requested in interactive mode")
-            self._subaction_type = "replay"
-            self._name = "replay"
-            self._logger = logging.getLogger(f"{__name__}_{self._subaction_type}")
-            initialized = self._init_replay()
-
-        if not initialized:
+        if not self._initialize_subaction(interaction):
             self._prepare_to_exit(interaction)
             return None
 
@@ -346,32 +388,72 @@ class Action(ActionBase):
 
         while True:
             self.update()
-
             self._take_step()
 
             if not self.steps:
                 if not self._runner_finished:
                     self._logger.error("Can not step back while playbook in progress, :q! to exit")
                     self.steps.append(self._plays)
-                else:
-                    self._logger.debug(
-                        "No steps remaining for '%s' returning to calling app",
-                        self._name,
-                    )
-                    break
+                    continue
+                self._logger.debug(
+                    "No steps remaining for '%s' returning to calling app",
+                    self._name,
+                )
+                break
 
             if self.steps.current.name == "quit":
-                if self._args.app == "replay":
-                    self._prepare_to_exit(interaction)
-                    return self.steps.current
-                done = self._prepare_to_quit(self.steps.current)
-                if done:
-                    self._prepare_to_exit(interaction)
-                    return self.steps.current
-                self.steps.back_one()
+                result = self._handle_quit(interaction)
+                if result is not None:
+                    return result
 
         self._prepare_to_exit(interaction)
         return None
+
+    def _handle_quit(self, interaction: Interaction) -> Interaction | None:
+        """Handle quit step logic during the run loop.
+
+        Args:
+            interaction: The interaction from the user
+
+        Returns:
+            The quit interaction if exiting, None to continue the loop
+        """
+        if self._args.app == "replay":
+            self._prepare_to_exit(interaction)
+            return self.steps.current
+        done = self._prepare_to_quit(self.steps.current)
+        if done:
+            self._prepare_to_exit(interaction)
+            return self.steps.current
+        self.steps.back_one()
+        return None
+
+    def _validate_and_prompt_playbook(self) -> bool:
+        """Validate the playbook path and prompt the user if invalid.
+
+        Returns:
+            True if the playbook is valid or the user provided a valid one
+        """
+        if isinstance(self._args.playbook, str):
+            playbook_valid = Path(self._args.playbook).exists()
+        else:
+            playbook_valid = False
+
+        if playbook_valid:
+            return True
+
+        populated_form = self._prompt_for_playbook()
+        if populated_form["cancelled"]:
+            return False
+
+        new_cmd = ["run"]
+        new_cmd.append(populated_form["fields"]["playbook"]["value"])
+
+        if populated_form["fields"]["cmdline"]["value"]:
+            new_cmd.extend(shlex.split(populated_form["fields"]["cmdline"]["value"]))
+
+        # Parse as if provided from the cmdline
+        return self._update_args(new_cmd)
 
     def _init_run(self) -> bool:
         """In the case of :run, check the user input.
@@ -387,30 +469,68 @@ class Action(ActionBase):
         if not args_updated:
             return False
 
-        if self._playbook_type == "file":
-            if isinstance(self._args.playbook, str):
-                playbook_valid = Path(self._args.playbook).exists()
-            else:
-                playbook_valid = False
-
-            if not playbook_valid:
-                populated_form = self._prompt_for_playbook()
-                if populated_form["cancelled"]:
-                    return False
-
-                new_cmd = ["run"]
-                new_cmd.append(populated_form["fields"]["playbook"]["value"])
-
-                if populated_form["fields"]["cmdline"]["value"]:
-                    new_cmd.extend(shlex.split(populated_form["fields"]["cmdline"]["value"]))
-
-                # Parse as if provided from the cmdline
-                args_updated = self._update_args(new_cmd)
-                if not args_updated:
-                    return False
+        if self._playbook_type == "file" and not self._validate_and_prompt_playbook():
+            return False
 
         self._run_runner()
         self._logger.info("Run initialized and playbook started.")
+        return True
+
+    def _validate_artifact_file(self) -> str | None:
+        """Validate the artifact file path and prompt if needed.
+
+        Returns:
+            The resolved artifact file path, or None if validation failed
+        """
+        artifact_file = self._args.playbook_artifact_replay
+
+        if isinstance(self._args.playbook_artifact_replay, str):
+            artifact_valid = Path(self._args.playbook_artifact_replay).exists()
+        else:
+            artifact_valid = False
+
+        if not artifact_valid and self.mode == "interactive":
+            populated_form = self._prompt_for_artifact(artifact_file=artifact_file)
+            if populated_form["cancelled"]:
+                return None
+            artifact_file = populated_form["fields"]["artifact_file"]["value"]
+
+        return artifact_file
+
+    def _load_artifact_data(self, data: dict[str, Any]) -> bool:
+        """Load artifact data based on version and current mode.
+
+        Args:
+            data: The parsed artifact data
+
+        Returns:
+            True if the data was loaded successfully
+        """
+        version = data.get("version", "")
+        if not version.startswith(("1.", "2.")):
+            self._logger.error(
+                "Incompatible artifact version, got '%s', compatible = '1.y.z'",
+                version,
+            )
+            return False
+
+        try:
+            stdout = data["stdout"]
+            if self.mode == "interactive":
+                self._plays.value = data["plays"]
+                self._interaction.ui.update_status(data["status"], data["status_color"])
+                self.stdout = stdout
+            else:
+                for line in data["stdout"]:
+                    if self._args.display_color is True:
+                        print(line)
+                    else:
+                        print(remove_ansi(line))
+        except KeyError as exc:
+            self._logger.debug("missing keys from artifact file")
+            self._logger.debug("error was: %s", str(exc))
+            return False
+
         return True
 
     def _init_replay(self) -> bool:
@@ -431,18 +551,9 @@ class Action(ActionBase):
             if not args_updated:
                 return False
 
-        artifact_file = self._args.playbook_artifact_replay
-
-        if isinstance(self._args.playbook_artifact_replay, str):
-            artifact_valid = Path(self._args.playbook_artifact_replay).exists()
-        else:
-            artifact_valid = False
-
-        if not artifact_valid and self.mode == "interactive":
-            populated_form = self._prompt_for_artifact(artifact_file=artifact_file)
-            if populated_form["cancelled"]:
-                return False
-            artifact_file = populated_form["fields"]["artifact_file"]["value"]
+        artifact_file = self._validate_artifact_file()
+        if artifact_file is None:
+            return False
 
         try:
             with Path(artifact_file).open(encoding="utf-8") as fh:
@@ -452,29 +563,7 @@ class Action(ActionBase):
             self._logger.exception("Unable to parse artifact file")
             return False
 
-        version = data.get("version", "")
-        if version.startswith(("1.", "2.")):
-            try:
-                stdout = data["stdout"]
-                if self.mode == "interactive":
-                    self._plays.value = data["plays"]
-                    self._interaction.ui.update_status(data["status"], data["status_color"])
-                    self.stdout = stdout
-                else:
-                    for line in data["stdout"]:
-                        if self._args.display_color is True:
-                            print(line)
-                        else:
-                            print(remove_ansi(line))
-            except KeyError as exc:
-                self._logger.debug("missing keys from artifact file")
-                self._logger.debug("error was: %s", str(exc))
-                return False
-        else:
-            self._logger.error(
-                "Incompatible artifact version, got '%s', compatible = '1.y.z'",
-                version,
-            )
+        if not self._load_artifact_data(data):
             return False
 
         self._runner_finished = True
@@ -548,40 +637,60 @@ class Action(ActionBase):
         populated_form = form_to_dict(form, key_on_name=True)
         return populated_form
 
+    def _handle_step_display(self) -> Interaction | None:
+        """Handle display logic for a Step on the stack.
+
+        Returns:
+            The interaction result from the UI, or None
+        """
+        if self.steps.current.show_func:
+            self.steps.current.show_func()
+
+        if self.steps.current.type == "menu":
+            return self._handle_menu_step()
+
+        if self.steps.current.type == "content":
+            return self._interaction.ui.show(
+                obj=self.steps.current.value,
+                index=self.steps.current.index,
+                content_heading=content_heading,
+                filter_content_keys=self._content_key_filter,
+            )
+        return None
+
+    def _handle_menu_step(self) -> Interaction | None:
+        """Handle display and auto-scroll logic for a menu step.
+
+        Returns:
+            The interaction result from the UI, or None
+        """
+        new_scroll = len(self.steps.current.value)
+        if self._auto_scroll:
+            self._interaction.ui.scroll(new_scroll)
+
+        result = self._interaction.ui.show(
+            obj=self.steps.current.value,
+            columns=self.steps.current.columns,
+            color_menu_item=color_menu,
+        )
+
+        if self._interaction.ui.scroll() < new_scroll and self._auto_scroll:
+            self._logger.debug("auto_scroll disabled")
+            self._auto_scroll = False
+        elif self._interaction.ui.scroll() >= new_scroll and not self._auto_scroll:
+            self._logger.debug("auto_scroll enabled")
+            self._auto_scroll = True
+
+        return result
+
     def _take_step(self) -> None:
         """Run the current step on the stack."""
         result = None
         if isinstance(self.steps.current, Interaction):
             result = run_action(self.steps.current.name, self.app, self.steps.current)
         elif isinstance(self.steps.current, Step):
-            if self.steps.current.show_func:
-                self.steps.current.show_func()
+            result = self._handle_step_display()
 
-            if self.steps.current.type == "menu":
-                new_scroll = len(self.steps.current.value)
-                if self._auto_scroll:
-                    self._interaction.ui.scroll(new_scroll)
-
-                result = self._interaction.ui.show(
-                    obj=self.steps.current.value,
-                    columns=self.steps.current.columns,
-                    color_menu_item=color_menu,
-                )
-
-                if self._interaction.ui.scroll() < new_scroll and self._auto_scroll:
-                    self._logger.debug("auto_scroll disabled")
-                    self._auto_scroll = False
-                elif self._interaction.ui.scroll() >= new_scroll and not self._auto_scroll:
-                    self._logger.debug("auto_scroll enabled")
-                    self._auto_scroll = True
-
-            elif self.steps.current.type == "content":
-                result = self._interaction.ui.show(
-                    obj=self.steps.current.value,
-                    index=self.steps.current.index,
-                    content_heading=content_heading,
-                    filter_content_keys=self._content_key_filter,
-                )
         if result is None:
             self.steps.back_one()
         else:
@@ -668,8 +777,90 @@ class Action(ActionBase):
         if drain_count:
             self._logger.debug("Drained %s events", drain_count)
 
+    def _handle_runner_on_start(
+        self,
+        play: dict[str, Any],
+        event_data: dict[str, Any],
+    ) -> None:
+        """Handle a runner_on_start event by adding a new in-progress task.
+
+        Args:
+            play: The parent play data
+            event_data: The event data from the runner
+        """
+        try:
+            previous_name = self._task_cache[event_data["task_uuid"]]
+            use_previous = not is_jinja(previous_name)
+        except KeyError:
+            use_previous = False
+
+        event_data.update(
+            {
+                "__changed": "unknown",
+                "__duration": "Pending",
+                "__host": event_data["host"],
+                "__number": len(play["tasks"]),
+                "__result": "In progress",
+                "__task_action": event_data["task_action"],
+                "__task": previous_name if use_previous else event_data["task"],
+            },
+        )
+        play["tasks"].append(event_data)
+
+    def _handle_runner_on_finish(
+        self,
+        play: dict[str, Any],
+        event_data: dict[str, Any],
+        runner_event: str,
+    ) -> None:
+        """Handle a runner task-finished event by updating the task with results.
+
+        Args:
+            play: The parent play data
+            event_data: The event data from the runner
+            runner_event: The runner event type (ok, skipped, failed, etc.)
+        """
+        match = ("task_uuid", "host")
+        try:
+            task = next(
+                t for t in play["tasks"] if itemgetter(*match)(t) == itemgetter(*match)(event_data)
+            )
+        except StopIteration:
+            self._logger.warning("Task event without parent task")
+            return
+
+        # Get the duration
+        if isinstance(event_data["duration"], int | float):
+            duration = human_time(seconds=round_half_up(event_data["duration"]))
+        else:
+            self._logger.debug(
+                "Task duration for '%s' was type '%s', set to 0",
+                event_data["task"],
+                type(event_data["duration"]),
+            )
+            duration = human_time(seconds=0)
+
+        # Replace failed with ignored
+        modify_result = runner_event == "failed" and event_data["ignore_errors"]
+
+        event_data.update(
+            {
+                "__changed": event_data.get("res", {}).get("changed", False),
+                "__duration": duration,
+                "__result": ("ignored" if modify_result else runner_event).capitalize(),
+            },
+        )
+
+        # Find the best name for the task
+        name_changed = task["__task"] != event_data["task"]
+        no_longer_templated = is_jinja(task["__task"]) and not is_jinja(event_data["task"])
+        changed_and_not_templated = name_changed and not is_jinja(event_data["task"])
+        if no_longer_templated or changed_and_not_templated:
+            event_data["__task"] = event_data["task"]
+
+        task.update(event_data)
+
     def _handle_message(self, message: dict[str, Any]) -> None:
-        # pylint: disable=too-many-locals
         """Handle a runner message.
 
         Args:
@@ -725,68 +916,10 @@ class Action(ActionBase):
             self._logger.warning("Playbook event without parent play")
             return
 
-        # New task encountered
         if runner_event == "start":
-            try:
-                previous_name = self._task_cache[event_data["task_uuid"]]
-                use_previous = not is_jinja(previous_name)
-            except KeyError:
-                use_previous = False
-
-            event_data.update(
-                {
-                    "__changed": "unknown",
-                    "__duration": "Pending",
-                    "__host": event_data["host"],
-                    "__number": len(play["tasks"]),
-                    "__result": "In progress",
-                    "__task_action": event_data["task_action"],
-                    "__task": previous_name if use_previous else event_data["task"],
-                },
-            )
-            play["tasks"].append(event_data)
-            return
-
-        # The runner event indicates a task has finished, find the task in the play
-        match = ("task_uuid", "host")
-        try:
-            task = next(
-                t for t in play["tasks"] if itemgetter(*match)(t) == itemgetter(*match)(event_data)
-            )
-        except StopIteration:
-            self._logger.warning("Task event without parent task")
-            return
-
-        # Get the duration
-        if isinstance(event_data["duration"], int | float):
-            duration = human_time(seconds=round_half_up(event_data["duration"]))
+            self._handle_runner_on_start(play, event_data)
         else:
-            self._logger.debug(
-                "Task duration for '%s' was type '%s', set to 0",
-                event_data["task"],
-                type(event_data["duration"]),
-            )
-            duration = human_time(seconds=0)
-
-        # Replace failed with ignored
-        modify_result = runner_event == "failed" and event_data["ignore_errors"]
-
-        event_data.update(
-            {
-                "__changed": event_data.get("res", {}).get("changed", False),
-                "__duration": duration,
-                "__result": ("ignored" if modify_result else runner_event).capitalize(),
-            },
-        )
-
-        # Find the best name for the task
-        name_changed = task["__task"] != event_data["task"]
-        no_longer_templated = is_jinja(task["__task"]) and not is_jinja(event_data["task"])
-        changed_and_not_templated = name_changed and not is_jinja(event_data["task"])
-        if no_longer_templated or changed_and_not_templated:
-            event_data["__task"] = event_data["task"]
-
-        task.update(event_data)
+            self._handle_runner_on_finish(play, event_data, runner_event)
 
     def _play_stats(self) -> None:
         """Calculate the play's stats based on it's tasks."""

--- a/src/ansible_navigator/actions/template.py
+++ b/src/ansible_navigator/actions/template.py
@@ -9,6 +9,7 @@ import html
 
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
+from typing import Any
 
 from ansible_navigator.action_base import ActionBase
 from ansible_navigator.content_defs import ContentFormat
@@ -39,6 +40,64 @@ class Action(ActionBase):
         """
         super().__init__(args=args, logger_name=__name__, name="template")
 
+    def _resolve_template_vars(
+        self,
+        interaction: Interaction,
+    ) -> tuple[dict[str, Any], list[str]] | None:
+        """Resolve template variables from the current interaction content or menu.
+
+        Args:
+            interaction: The interaction from the user
+
+        Returns:
+            A tuple of (template_vars, type_msgs) or None if no content is available
+        """
+        type_msgs = ["Current content passed for templating is not a dictionary."]
+        type_msgs.append("[HINT] Use 'this' to reference it (e.g. {{ this[0] }}")
+
+        if interaction.content:
+            if isinstance(interaction.content.showing, Mapping):
+                return dict(interaction.content.showing), []
+            return {"this": interaction.content.showing}, type_msgs
+
+        if interaction.menu:
+            obj = [
+                {remove_dbl_un(k): v for k, v in c.items() if k in interaction.menu.columns}
+                for c in interaction.menu.current
+            ]
+            if interaction.ui.menu_filter():
+                obj = [
+                    e
+                    for e in obj
+                    if interaction.ui.menu_filter().search(" ".join(str(v) for v in e.values()))
+                ]
+            return {"this": obj}, type_msgs
+
+        self._logger.error("No menu or content found")
+        return None
+
+    @staticmethod
+    def _determine_content_format(
+        requested: str,
+        templated: Any,
+    ) -> ContentFormat | None:
+        """Determine the content format based on the requested parameter and templated value.
+
+        Args:
+            requested: The requested template parameter string
+            templated: The templated output value
+
+        Returns:
+            The content format or None
+        """
+        if requested == "examples":
+            return ContentFormat.YAML_TXT
+        if requested == "readme":
+            return ContentFormat.MARKDOWN
+        if isinstance(templated, str):
+            return ContentFormat.TXT
+        return None
+
     def run(self, interaction: Interaction, app: AppPublic) -> Interaction | None:
         """Execute the templating request for mode interactive.
 
@@ -54,32 +113,10 @@ class Action(ActionBase):
         self._logger.debug("template requested '%s'", interaction.action.value)
         self._prepare_to_run(app, interaction)
 
-        type_msgs = ["Current content passed for templating is not a dictionary."]
-        type_msgs.append("[HINT] Use 'this' to reference it (e.g. {{ this[0] }}")
-
-        if interaction.content:
-            if isinstance(interaction.content.showing, Mapping):
-                template_vars = interaction.content.showing
-                type_msgs = []
-            else:
-                template_vars = {"this": interaction.content.showing}
-
-        elif interaction.menu:
-            obj = [
-                {remove_dbl_un(k): v for k, v in c.items() if k in interaction.menu.columns}
-                for c in interaction.menu.current
-            ]
-            if interaction.ui.menu_filter():
-                obj = [
-                    e
-                    for e in obj
-                    if interaction.ui.menu_filter().search(" ".join(str(v) for v in e.values()))
-                ]
-
-            template_vars = {"this": obj}
-        else:
-            self._logger.error("No menu or content found")
+        resolved = self._resolve_template_vars(interaction)
+        if resolved is None:
             return None
+        template_vars, type_msgs = resolved
 
         previous_scroll = interaction.ui.scroll()
         interaction.ui.scroll(0)
@@ -98,14 +135,7 @@ class Action(ActionBase):
             templated = html.unescape(templated)
 
         requested = self._interaction.action.match.groupdict()["params"]
-        if requested == "examples":
-            content_format = ContentFormat.YAML_TXT
-        elif requested == "readme":
-            content_format = ContentFormat.MARKDOWN
-        elif isinstance(templated, str):
-            content_format = ContentFormat.TXT
-        else:
-            content_format = None
+        content_format = self._determine_content_format(requested, templated)
 
         while True:
             app.update()

--- a/src/ansible_navigator/actions/write_file.py
+++ b/src/ansible_navigator/actions/write_file.py
@@ -150,6 +150,9 @@ class Action:
             return
 
         obj = self._resolve_content(interaction)
+        if obj is None:
+            self._logger.error("No menu or content found to write")
+            return
 
         if isinstance(obj, str):
             write_as = ".txt"

--- a/src/ansible_navigator/actions/write_file.py
+++ b/src/ansible_navigator/actions/write_file.py
@@ -4,6 +4,7 @@ import logging
 import re
 
 from pathlib import Path
+from typing import Any
 
 from ansible_navigator.app_public import AppPublic
 from ansible_navigator.configuration_subsystem.definitions import ApplicationConfiguration
@@ -35,39 +36,51 @@ class Action:
         self._args = args
         self._logger = logging.getLogger(__name__)
 
-    def run(self, interaction: Interaction, app: AppPublic) -> None:
-        """Execute the ``:write`` request for mode interactive.
+    def _determine_file_mode(
+        self,
+        filename: str,
+        match: dict[str, str],
+    ) -> str | None:
+        """Determine the file open mode based on append/force flags.
 
         Args:
-            interaction: The interaction from the user
-            app: The app instance
+            filename: The resolved filename path
+            match: The regex match groupdict from the interaction
 
         Returns:
-            Nothing
+            The file mode string ('a' or 'w'), or None if the operation should be aborted
         """
-        self._logger.debug("write requested as %s", interaction.action.value)
-        match = interaction.action.match.groupdict()
-        filename = str(expand_path(match["filename"]))
         if match["append"]:
             if not Path(filename).exists() and not match["force"]:
                 self._logger.warning(
                     "Append operation failed because %s does not exist, force with !",
                     filename,
                 )
-                return
-            file_mode = "a"
-        else:
-            if Path(filename).exists() and not match["force"]:
-                self._logger.warning(
-                    "Write operation failed because %s exists, force with !",
-                    filename,
-                )
-                return
-            file_mode = "w"
+                return None
+            return "a"
 
+        if Path(filename).exists() and not match["force"]:
+            self._logger.warning(
+                "Write operation failed because %s exists, force with !",
+                filename,
+            )
+            return None
+        return "w"
+
+    @staticmethod
+    def _resolve_content(interaction: Interaction) -> Any:
+        """Resolve the content to write from the interaction.
+
+        Args:
+            interaction: The interaction from the user
+
+        Returns:
+            The content object to be written
+        """
         if interaction.content:
-            obj = interaction.content.showing
-        elif interaction.menu:
+            return interaction.content.showing
+
+        if interaction.menu:
             obj = [
                 {remove_dbl_un(k): v for k, v in c.items() if k in interaction.menu.columns}
                 for c in interaction.menu.current
@@ -78,16 +91,25 @@ class Action:
                     for e in obj
                     if interaction.ui.menu_filter().search(" ".join(str(v) for v in e.values()))
                 ]
+            return obj
 
-        if isinstance(obj, str):
-            write_as = ".txt"
-        elif re.match(r"^.*\.y(?:a)?ml$", filename):
-            write_as = ".yaml"
-        elif filename.endswith(JSON_EXTENSION):
-            write_as = JSON_EXTENSION
-        else:
-            write_as = interaction.ui.content_format().value.file_extension
+        return None
 
+    @staticmethod
+    def _write_content(
+        obj: Any,
+        filename: str,
+        file_mode: str,
+        write_as: str,
+    ) -> None:
+        """Write the resolved content to a file in the determined format.
+
+        Args:
+            obj: The content to write
+            filename: The target file path
+            file_mode: The file open mode ('a' or 'w')
+            write_as: The file extension determining serialization format
+        """
         if write_as == ".txt":
             file = expand_path(filename)
             with file.open(file_mode, encoding="utf-8") as fh:
@@ -108,4 +130,35 @@ class Action:
                 file_mode=file_mode,
                 serialization_format=SerializationFormat.JSON,
             )
+
+    def run(self, interaction: Interaction, app: AppPublic) -> None:
+        """Execute the ``:write`` request for mode interactive.
+
+        Args:
+            interaction: The interaction from the user
+            app: The app instance
+
+        Returns:
+            Nothing
+        """
+        self._logger.debug("write requested as %s", interaction.action.value)
+        match = interaction.action.match.groupdict()
+        filename = str(expand_path(match["filename"]))
+
+        file_mode = self._determine_file_mode(filename, match)
+        if file_mode is None:
+            return
+
+        obj = self._resolve_content(interaction)
+
+        if isinstance(obj, str):
+            write_as = ".txt"
+        elif re.match(r"^.*\.y(?:a)?ml$", filename):
+            write_as = ".yaml"
+        elif filename.endswith(".json"):
+            write_as = ".json"
+        else:
+            write_as = interaction.ui.content_format().value.file_extension
+
+        self._write_content(obj, filename, file_mode, write_as)
         self._logger.info("Wrote to '%s' with mode '%s' as '%s'", filename, file_mode, write_as)

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -127,6 +127,7 @@ class TmuxSession:
             The tmux session
 
         Raises:
+            RuntimeError: If the tmux pane resize fails after retry
             ValueError: If the time is exceeded for finding the shell
                 prompt
         """
@@ -157,6 +158,19 @@ class TmuxSession:
             # Last-resort retry: issue the resize one more time.
             self._window.resize(height=self._pane_height, width=self._pane_width)
             time.sleep(0.5)
+            # Verify retry succeeded
+            pane = self._window.active_pane
+            if (
+                pane
+                and pane.pane_width is not None
+                and pane.pane_height is not None
+                and (
+                    int(pane.pane_width) != self._pane_width
+                    or int(pane.pane_height) != self._pane_height
+                )
+            ):
+                msg = f"tmux pane resize failed: wanted {self._pane_width}x{self._pane_height}"
+                raise RuntimeError(msg)
 
         # Figure out where the tox initiated venv is. In environments where a
         # venv is activated as part of bashrc, $VIRTUAL_ENV won't be what we

--- a/tests/integration/_tmux_session.py
+++ b/tests/integration/_tmux_session.py
@@ -138,6 +138,26 @@ class TmuxSession:
         self._pane = self._window.panes[0]
         self._window.resize(height=self._pane_height, width=self._pane_width)
 
+        # Verify the pane actually resized; on slow CI runners the resize
+        # can be asynchronous and the TUI may start before the pane has
+        # the requested dimensions.
+        resize_deadline = time.time() + 5
+        while time.time() < resize_deadline:
+            pane_w = self._pane.pane_width
+            pane_h = self._pane.pane_height
+            if (
+                pane_w is not None
+                and pane_h is not None
+                and int(pane_w) == self._pane_width
+                and int(pane_h) == self._pane_height
+            ):
+                break
+            time.sleep(0.1)
+        else:
+            # Last-resort retry: issue the resize one more time.
+            self._window.resize(height=self._pane_height, width=self._pane_width)
+            time.sleep(0.5)
+
         # Figure out where the tox initiated venv is. In environments where a
         # venv is activated as part of bashrc, $VIRTUAL_ENV won't be what we
         # expect inside of tmux, so we can't depend on it. We *must* determine


### PR DESCRIPTION
## Summary

- Refactored 20 functions across 8 files in `src/ansible_navigator/actions/` to reduce cognitive complexity below the SonarCloud S3776 threshold of 15
- Extracted nested logic into private helper methods while preserving all existing behavior and public method signatures
- Files modified: `collections.py`, `config.py`, `doc.py`, `inventory.py`, `lint.py`, `run.py`, `template.py`, `write_file.py`

### Functions refactored

- **collections.py**: `_build_collection_content_menu`, `_run_runner`, `_parse`, `_get_collection_plugins_details`, `_parse_collection_info_stdout`
- **config.py**: `_run_runner`, `_parse_and_merge`
- **doc.py**: `_run_runner`, `_extract_plugin_doc`
- **inventory.py**: `run`, `_collect_inventory_details_interactive`
- **lint.py**: `_rerun_needed`
- **run.py**: `color_menu`, `run`, `_init_run`, `_init_replay`, `_take_step`, `_handle_message`
- **template.py**: `run`
- **write_file.py**: `run`

## Test plan

- [x] `tox -e lint` passes locally (ruff, mypy, pylint, pydoclint, pre-commit hooks)
- [ ] CI tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced collections action with richer interactive menu data, more robust catalog JSON handling, and improved stdout formatting.
  * Improved config and doc actions by separating interactive vs stdout execution and hardening output parsing.
  * Inventory interactive mode now auto-initializes and refreshes when on-disk inventory changes.
  * Improved run/replay UI flow with clearer playbook/artifact validation and more consistent task start/finish updates.
  * Refined lint rerun detection; improved template and write-file variable/content/format resolution.
* **Bug Fixes**
  * Tmux pane resizing now verifies final dimensions and errors if they still don’t match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->