### PR TITLE
fix: reduce cognitive complexity in ui_framework/ modules (S3776)

### DIFF
--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -401,17 +401,21 @@ def columns_and_colors(
     return results
 
 
-def _parse_ansi_match(cap: dict[str, str | None]) -> tuple[int, int]:
+def _parse_ansi_match(
+    cap: dict[str, str | None],
+    color: int = 0,
+    style: int = 0,
+) -> tuple[int, int]:
     """Parse an ANSI color match groupdict into a color and style.
 
     Args:
         cap: The groupdict from a color_regex match
+        color: The current color state to preserve across calls
+        style: The current style state to preserve across calls
 
     Returns:
         A (color, style) tuple
     """
-    color = 0
-    style = 0
     one = cap["one"]
     two = cap["two"]
     if cap["fg_action"] == "39;" or (one == "0" and two is None):
@@ -469,7 +473,7 @@ def ansi_to_curses(line: str) -> CursesLine:
         if part:
             match = color_regex.match(part)
             if match:
-                color, style = _parse_ansi_match(match.groupdict())
+                color, style = _parse_ansi_match(match.groupdict(), color, style)
             else:
                 curses_line = CursesLinePart(
                     column=colno,

--- a/src/ansible_navigator/ui_framework/colorize.py
+++ b/src/ansible_navigator/ui_framework/colorize.py
@@ -244,6 +244,47 @@ def hex_to_rgb_curses(value: str) -> RgbTuple:
     return (scale_for_curses(red), scale_for_curses(green), scale_for_curses(blue))
 
 
+def _rgb_to_ansi_256(red: int, green: int, blue: int) -> int:
+    """Convert an RGB color to a 256-color ansi value.
+
+    Args:
+        red: The red component
+        green: The green component
+        blue: The blue component
+
+    Returns:
+        A 256-color ansi value
+    """
+    if red == green and green == blue:
+        if red < 8:
+            return 16
+        if red > 248:
+            return 231
+        return round(((red - 8) / 247) * 24) + 232
+    return 16 + (36 * round(red / 255 * 5)) + (6 * round(green / 255 * 5)) + round(blue / 255 * 5)
+
+
+def _rgb_to_ansi_16(red: int, green: int, blue: int) -> int:
+    """Convert an RGB color to a 16-color ansi value.
+
+    Args:
+        red: The red component
+        green: The green component
+        blue: The blue component
+
+    Returns:
+        A 16-color ansi value
+    """
+    value = colorsys.rgb_to_hsv(red, green, blue)[2]
+    value = round(value / 50)
+    if value == 0:
+        return 30
+    ansi = (round(blue / 255) << 2) | (round(green / 255) << 1) | round(red / 255)
+    if value == 2:
+        ansi += 8
+    return ansi
+
+
 def rgb_to_ansi(red: int, green: int, blue: int, colors: int) -> int:
     """Convert an RGB color to an ansi color.
 
@@ -258,31 +299,72 @@ def rgb_to_ansi(red: int, green: int, blue: int, colors: int) -> int:
     """
     # https://github.com/Qix-/color-convert/blob/master/conversions.js
     if colors == 256:
-        if red == green and green == blue:
-            if red < 8:
-                return 16
-            if red > 248:
-                return 231
-            ansi = round(((red - 8) / 247) * 24) + 232
-        else:
-            ansi = (
-                16
-                + (36 * round(red / 255 * 5))
-                + (6 * round(green / 255 * 5))
-                + round(blue / 255 * 5)
-            )
+        ansi = _rgb_to_ansi_256(red, green, blue)
     elif colors == 16:
-        value = colorsys.rgb_to_hsv(red, green, blue)[2]
-        value = round(value / 50)
-        if value == 0:
-            ansi = 30
-        else:
-            ansi = (round(blue / 255) << 2) | (round(green / 255) << 1) | round(red / 255)
-            if value == 2:
-                ansi += 8
+        ansi = _rgb_to_ansi_16(red, green, blue)
     else:  # colors == 8, sorry
         ansi = (round(blue / 255) << 2) | (round(green / 255) << 1) | round(red / 255)
     return ansi
+
+
+def _apply_regions_to_parts(
+    line_parts: list[SimpleLinePart],
+    regions: Regions,
+    schema: ColorSchema,
+) -> None:
+    """Apply color and style from regions to line parts.
+
+    Args:
+        line_parts: The individual character parts of a line
+        regions: The tokenized regions for the line
+        schema: An instance of the ColorSchema
+    """
+    for region in regions:
+        color, style = schema.get_color_and_style(region.scope)
+        if color:
+            for idx in range(region.start, region.end):
+                line_parts[idx].color = color
+        if style:
+            for idx in range(region.start, region.end):
+                line_parts[idx].style = style
+
+
+def _compress_line_parts(
+    line_parts: list[SimpleLinePart],
+    line_text: str,
+) -> list[SimpleLinePart]:
+    """Compress adjacent line parts with the same color and style.
+
+    Args:
+        line_parts: The individual character parts of a line
+        line_text: The original line text
+
+    Returns:
+        Compressed line parts
+    """
+    if not line_parts:
+        return [SimpleLinePart(chars=line_text, color=None, column=0, style=None)]
+    grouped = [line_parts.pop(0)]
+    while line_parts:
+        entry = line_parts.pop(0)
+        if entry.color == grouped[-1].color and entry.style == grouped[-1].style:
+            grouped[-1].chars += entry.chars
+        else:
+            grouped.append(entry)
+    return grouped
+
+
+def _update_line_part_columns(results: list[list[SimpleLinePart]]) -> None:
+    """Update column offsets in each line part based on preceding text lengths.
+
+    Args:
+        results: Lines of text parts to update
+    """
+    for result in results:
+        column = 0
+        for line_part in result:
+            line_part.column = column
+            column += len(line_part.chars)
 
 
 def columns_and_colors(
@@ -308,36 +390,44 @@ def columns_and_colors(
         ]
 
         # Replace the color with the RgbTuple
-        for region in line[0]:
-            color, style = schema.get_color_and_style(region.scope)
-            if color:
-                for idx in range(region.start, region.end):
-                    line_parts[idx].color = color
-            if style:
-                for idx in range(region.start, region.end):
-                    line_parts[idx].style = style
+        _apply_regions_to_parts(line_parts, line[0], schema)
 
         # Compress the line, grouping characters of like color and decoration
-        if line_parts:
-            grouped = [line_parts.pop(0)]
-            while line_parts:
-                entry = line_parts.pop(0)
-                if entry.color == grouped[-1].color and entry.style == grouped[-1].style:
-                    grouped[-1].chars += entry.chars
-                else:
-                    grouped.append(entry)
-            results.append(grouped)
-        else:
-            results.append([SimpleLinePart(chars=line[1], color=None, column=0, style=None)])
+        results.append(_compress_line_parts(line_parts, line[1]))
 
     # Update the column in each line part, based on the total of the preceding text lengths
-    for result in results:
-        column = 0
-        for line_part in result:
-            line_part.column = column
-            column += len(line_part.chars)
+    _update_line_part_columns(results)
 
     return results
+
+
+def _parse_ansi_match(cap: dict[str, str | None]) -> tuple[int, int]:
+    """Parse an ANSI color match groupdict into a color and style.
+
+    Args:
+        cap: The groupdict from a color_regex match
+
+    Returns:
+        A (color, style) tuple
+    """
+    color = 0
+    style = 0
+    one = cap["one"]
+    two = cap["two"]
+    if cap["fg_action"] == "39;" or (one == "0" and two is None):
+        pass  # default color
+    elif cap["fg_action"] == "38;5;":
+        color = int(one)  # type: ignore[arg-type]
+        if two:
+            style = CURSES_STYLES.get(int(two)) or 0
+    elif not cap["fg_action"]:
+        ansi_16 = list(chain(range(30, 38), range(90, 98)))
+        if two is None:
+            color = ansi_16.index(int(one)) if int(one) in ansi_16 else int(one)  # type: ignore[arg-type]
+        else:
+            color = ansi_16.index(int(two)) if int(two) in ansi_16 else int(two)
+            style = CURSES_STYLES.get(int(one)) or 0  # type: ignore[arg-type]
+    return color, style
 
 
 def ansi_to_curses(line: str) -> CursesLine:
@@ -349,7 +439,6 @@ def ansi_to_curses(line: str) -> CursesLine:
     Returns:
         A line ready for presentation in the TUI
     """
-    # pylint: disable=too-many-locals
     if line == "":
         line_part = CursesLinePart(
             column=0,
@@ -380,22 +469,7 @@ def ansi_to_curses(line: str) -> CursesLine:
         if part:
             match = color_regex.match(part)
             if match:
-                cap = match.groupdict()
-                one = cap["one"]
-                two = cap["two"]
-                if cap["fg_action"] == "39;" or (one == "0" and two is None):
-                    pass  # default color
-                elif cap["fg_action"] == "38;5;":
-                    color = int(one)
-                    if two:
-                        style = CURSES_STYLES.get(int(two)) or 0
-                elif not cap["fg_action"]:
-                    ansi_16 = list(chain(range(30, 38), range(90, 98)))
-                    if two is None:
-                        color = ansi_16.index(int(one)) if int(one) in ansi_16 else int(one)
-                    else:
-                        color = ansi_16.index(int(two)) if int(two) in ansi_16 else int(two)
-                        style = CURSES_STYLES.get(int(one)) or 0
+                color, style = _parse_ansi_match(match.groupdict())
             else:
                 curses_line = CursesLinePart(
                     column=colno,
@@ -408,6 +482,64 @@ def ansi_to_curses(line: str) -> CursesLine:
                 color = 0
                 style = 0
     return CursesLine(tuple(printable))
+
+
+def _process_markdown_part(
+    lines: list[list[SimpleLinePart]],
+    line_idx: int,
+    part_idx: int,
+    part: SimpleLinePart,
+    in_a_code_block: bool,
+    full_dash_line: list[SimpleLinePart],
+) -> bool:
+    """Process a single markdown part and apply transformations.
+
+    Args:
+        lines: Lines of text and their parts (mutated in place)
+        line_idx: The index of the current line
+        part_idx: The index of the current part within the line
+        part: The current part to process
+        in_a_code_block: Whether we are currently inside a code block
+        full_dash_line: The dash line to use for separators
+
+    Returns:
+        The updated in_a_code_block state
+    """
+    if part.chars.startswith("```"):
+        # Remove ```x from a line
+        lines[line_idx][part_idx].chars = "\n"
+        return not in_a_code_block
+
+    if in_a_code_block:
+        # Don't modify inside a code block
+        return in_a_code_block
+
+    if part.chars.startswith("#"):
+        # Remove # headings
+        lines[line_idx][part_idx].chars = re.sub(r"^(#{1,6}\s)(.*$)", r"\2", part.chars)
+        if part.chars.startswith("# "):
+            # Insert a full line after a heading 1
+            lines.insert(line_idx + 1, full_dash_line)
+        return in_a_code_block
+
+    if part.chars == "---\n":
+        # Replace all dash line with no-break dashes if \n before and after
+        try:
+            if lines[line_idx - 1][0].chars == "\n" and lines[line_idx + 1][0].chars == "\n":
+                lines[line_idx] = full_dash_line
+                return in_a_code_block
+        except IndexError:
+            pass
+
+    if "`" in part.chars:
+        # Remove `` from code blocks
+        lines[line_idx][part_idx].chars = re.sub(r"`(.*)`", r"\1", part.chars)
+
+    if "*" in part.chars:
+        # Remove `` from code blocks
+        lines[line_idx][part_idx].chars = re.sub(r"\*(.*)\*", r"\1", part.chars)
+
+    return in_a_code_block
 
 
 def strip_markdown(lines: list[list[SimpleLinePart]]) -> list[list[SimpleLinePart]]:
@@ -433,42 +565,13 @@ def strip_markdown(lines: list[list[SimpleLinePart]]) -> list[list[SimpleLinePar
     in_a_code_block = False
     for line_idx, line in reversed(list(enumerate(copy.deepcopy(lines)))):
         for part_idx, part in enumerate(line):
-            if part.chars.startswith("```"):
-                # Remove ```x from a line
-                lines[line_idx][part_idx].chars = "\n"
-                in_a_code_block = not in_a_code_block
-                continue
-
-            if in_a_code_block:
-                # Don't modify inside a code block
-                continue
-
-            if part.chars.startswith("#"):
-                # Remove # headings
-                lines[line_idx][part_idx].chars = re.sub(r"^(#{1,6}\s)(.*$)", r"\2", part.chars)
-                if part.chars.startswith("# "):
-                    # Insert a full line after a heading 1
-                    lines.insert(line_idx + 1, full_dash_line)
-                continue
-
-            if part.chars == "---\n":
-                # Replace all dash line with no-break dashes if \n before and after
-                try:
-                    if (
-                        lines[line_idx - 1][0].chars == "\n"
-                        and lines[line_idx + 1][0].chars == "\n"
-                    ):
-                        lines[line_idx] = full_dash_line
-                        continue
-                except IndexError:
-                    pass
-
-            if "`" in part.chars:
-                # Remove `` from code blocks
-                lines[line_idx][part_idx].chars = re.sub(r"`(.*)`", r"\1", part.chars)
-
-            if "*" in part.chars:
-                # Remove `` from code blocks
-                lines[line_idx][part_idx].chars = re.sub(r"\*(.*)\*", r"\1", part.chars)
+            in_a_code_block = _process_markdown_part(
+                lines,
+                line_idx,
+                part_idx,
+                part,
+                in_a_code_block,
+                full_dash_line,
+            )
 
     return lines

--- a/src/ansible_navigator/ui_framework/curses_window.py
+++ b/src/ansible_navigator/ui_framework/curses_window.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from _curses import window
 
     from .curses_defs import CursesLine
+    from .curses_defs import CursesLinePart
     from .ui_config import UIConfig
 
     Window = window
@@ -114,6 +115,55 @@ class CursesWindow:
         except curses.error:
             self._logger.exception("Errors setting up terminal, check TERM value")
 
+    def _render_line_part(
+        self,
+        window: Window,
+        lineno: int,
+        line_part: CursesLinePart,
+        prefix_len: int,
+    ) -> None:
+        """Render a single line part to a curses window.
+
+        Args:
+            window: A curses window
+            lineno: the line number
+            line_part: The individual line part to render
+            prefix_len: The length of the line prefix
+        """
+        column = line_part.column + prefix_len
+        if column > self._screen_width:
+            return
+
+        text = line_part.string[0 : self._screen_width - column + 1]
+        try:
+            color = self._color_pair_or_none(line_part.color)
+            if color is None:
+                window.addstr(lineno, column, text)
+            else:
+                window.addstr(lineno, column, text, color | line_part.decoration)
+        except curses.error:
+            # curses error at last column & row but I don't care
+            # because it still draws it
+            # https://stackoverflow.com/questions/10877469/
+            # ncurses-setting-last-character-on-screen-without-scrolling-enabled
+            if lineno == window.getyx()[0] and column + len(text) == window.getyx()[1] + 1:
+                pass
+            else:
+                self._logger.debug("curses error")
+                self._logger.debug(
+                    "screen_height: %s, lineno: %s",
+                    self._screen_height,
+                    lineno,
+                )
+                self._logger.debug(
+                    "screen_w: %s, column: %s text: %s, lentext: %s, end_col: %s",
+                    self._screen_width,
+                    column,
+                    text,
+                    len(text),
+                    column + len(text),
+                )
+
     def _add_line(
         self,
         window: Window,
@@ -138,41 +188,7 @@ class CursesWindow:
         if line:
             window.move(lineno, 0)
             for line_part in line:
-                column = line_part.column + len(prefix or "")
-                if column <= self._screen_width:
-                    text = line_part.string[0 : self._screen_width - column + 1]
-                    try:
-                        color = self._color_pair_or_none(line_part.color)
-                        if color is None:
-                            window.addstr(lineno, column, text)
-                        else:
-                            window.addstr(lineno, column, text, color | line_part.decoration)
-                    except curses.error:
-                        # curses error at last column & row but I don't care
-                        # because it still draws it
-                        # https://stackoverflow.com/questions/10877469/
-                        # ncurses-setting-last-character-on-screen-without-scrolling-enabled
-                        if (
-                            lineno == window.getyx()[0]
-                            and column + len(text) == window.getyx()[1] + 1
-                        ):
-                            pass  # cursor is at expected position, no error
-
-                        else:
-                            self._logger.debug("curses error")
-                            self._logger.debug(
-                                "screen_height: %s, lineno: %s",
-                                self._screen_height,
-                                lineno,
-                            )
-                            self._logger.debug(
-                                "screen_w: %s, column: %s text: %s, lentext: %s, end_col: %s",
-                                self._screen_width,
-                                column,
-                                text,
-                                len(text),
-                                column + len(text),
-                            )
+                self._render_line_part(window, lineno, line_part, len(prefix or ""))
 
     def _set_colors(self) -> None:
         """Set the colors for curses."""

--- a/src/ansible_navigator/ui_framework/form.py
+++ b/src/ansible_navigator/ui_framework/form.py
@@ -139,13 +139,17 @@ class FormPresenter(CursesWindow):
         """
         return self._screen_width - self._field_win_start
 
-    def _dimensions(self) -> None:
-        """Calculate the dimensions of the form."""
-        self._prompt_end = max(len(form_field.full_prompt) for form_field in self._form.fields)
-        self._input_start = self._prompt_end + len(self._separator)
+    def _calculate_field_widths(self, fields: list[Any]) -> list[int]:
+        """Calculate the widths needed for each form field.
 
+        Args:
+            fields: The list of form fields
+
+        Returns:
+            A list of widths for each field
+        """
         widths = []
-        for form_field in self._form.fields:
+        for form_field in fields:
             if hasattr(form_field, "value") and form_field.value is not unknown:
                 widths.append(len(str(form_field.value)) + self._input_start)
             if hasattr(form_field, "options"):
@@ -155,14 +159,19 @@ class FormPresenter(CursesWindow):
             if hasattr(form_field, "messages"):
                 widths.append(max(len(msg) for msg in form_field.messages))
             widths.append(len(form_field.validator(hint=True)) + self._input_start)
+        return widths
 
-        if self._form.type_ is FormType.FORM:
-            self._form_width = max(widths) + BUTTON_SPACE
-        elif self._form.type_ in (FormType.NOTIFICATION, FormType.WORKING):
-            self._form_width = max(widths)
+    def _calculate_form_height(self, fields: list[Any]) -> int:
+        """Calculate the height of the form from fields.
 
+        Args:
+            fields: The list of form fields
+
+        Returns:
+            The total height of the form
+        """
         height = 2  # title + horizontal line
-        for form_field in self._form.fields:
+        for form_field in fields:
             if isinstance(form_field, FieldCursesInformation | FieldInformation):
                 height += len(form_field.information)
             if isinstance(form_field, (FieldWorking)):
@@ -172,10 +181,82 @@ class FormPresenter(CursesWindow):
             elif isinstance(form_field, FieldChecks | FieldRadio):
                 height += len(form_field.options)
         height += 2  # horizontal line + buttons
-        self._form_height = height
+        return height
+
+    def _dimensions(self) -> None:
+        """Calculate the dimensions of the form."""
+        self._prompt_end = max(len(form_field.full_prompt) for form_field in self._form.fields)
+        self._input_start = self._prompt_end + len(self._separator)
+
+        widths = self._calculate_field_widths(self._form.fields)
+
+        if self._form.type_ is FormType.FORM:
+            self._form_width = max(widths) + BUTTON_SPACE
+        elif self._form.type_ in (FormType.NOTIFICATION, FormType.WORKING):
+            self._form_width = max(widths)
+
+        self._form_height = self._calculate_form_height(self._form.fields)
 
         self._pad_top = max(int((self._screen_height - self._form_height) * TOP_PAD_RATIO), 0)
         self._pad_left = max(int((self._screen_width - self._form_width) * LEFT_PAD_RATIO), 0)
+
+    def _generate_body_field_lines(
+        self,
+        form_field: Any,
+    ) -> list[tuple[int, CursesLine]]:
+        """Generate the lines for a single body field.
+
+        Args:
+            form_field: The form field to generate lines for
+
+        Returns:
+            A list of (line_number, CursesLine) tuples for this field
+        """
+        lines: list[tuple[int, CursesLine]] = []
+
+        if isinstance(form_field, (FieldCursesInformation)):
+            for line in form_field.information:
+                lines.append((self._line_number, line))
+                self._line_number += 1
+
+        elif isinstance(form_field, FieldInformation):
+            information_lines = self._generate_information(form_field)
+            for line in information_lines:  # pylint: disable=not-an-iterable
+                lines.append((self._line_number, line))
+                self._line_number += 1
+
+        elif isinstance(form_field, FieldWorking):
+            message_lines = self._generate_messages(form_field)
+            for line in message_lines:  # pylint: disable=not-an-iterable
+                lines.append((self._line_number, line))
+                self._line_number += 1
+
+        elif isinstance(form_field, FieldText):
+            prompt = self._generate_prompt(form_field)
+            line = CursesLine(tuple(prompt + [self._generate_field_text(form_field)]))
+            lines.append((self._line_number, line))
+            self._line_number += 1
+
+        elif isinstance(form_field, FieldChecks | FieldRadio):
+            prompt = self._generate_prompt(form_field)
+            option_lines = self._generate_field_options(form_field)
+            # although option_lines[0] is a CursesLine, only it's first line part is needed
+            # because the prompt needs to be prepended to it
+            first_option_line_part = option_lines[0][0]
+            line = CursesLine(tuple(prompt + [first_option_line_part]))
+            lines.append((self._line_number, line))
+            self._line_number += 1
+
+            for option_line in option_lines[1:]:
+                lines.append((self._line_number, CursesLine(option_line)))
+                self._line_number += 1
+
+        error = self._generate_error(form_field)
+        if error:
+            lines.append((self._line_number, error))
+            self._line_number += 1
+
+        return lines
 
     def _generate_form(self) -> tuple[tuple[int, CursesLine], ...]:
         """Generate the form.
@@ -193,47 +274,7 @@ class FormPresenter(CursesWindow):
             field for field in self._form.fields if field.name not in ["submit", "cancel"]
         ]
         for form_field in body_fields:
-            if isinstance(form_field, (FieldCursesInformation)):
-                for line in form_field.information:
-                    lines.append((self._line_number, line))
-                    self._line_number += 1
-
-            elif isinstance(form_field, FieldInformation):
-                information_lines = self._generate_information(form_field)
-                for line in information_lines:  # pylint: disable=not-an-iterable
-                    lines.append((self._line_number, line))
-                    self._line_number += 1
-
-            elif isinstance(form_field, FieldWorking):
-                message_lines = self._generate_messages(form_field)
-                for line in message_lines:  # pylint: disable=not-an-iterable
-                    lines.append((self._line_number, line))
-                    self._line_number += 1
-
-            elif isinstance(form_field, FieldText):
-                prompt = self._generate_prompt(form_field)
-                line = CursesLine(tuple(prompt + [self._generate_field_text(form_field)]))
-                lines.append((self._line_number, line))
-                self._line_number += 1
-
-            elif isinstance(form_field, FieldChecks | FieldRadio):
-                prompt = self._generate_prompt(form_field)
-                option_lines = self._generate_field_options(form_field)
-                # although option_lines[0] is a CursesLine, only it's first line part is needed
-                # because the prompt needs to be prepended to it
-                first_option_line_part = option_lines[0][0]
-                line = CursesLine(tuple(prompt + [first_option_line_part]))
-                lines.append((self._line_number, line))
-                self._line_number += 1
-
-                for option_line in option_lines[1:]:
-                    lines.append((self._line_number, CursesLine(option_line)))
-                    self._line_number += 1
-
-            error = self._generate_error(form_field)
-            if error:
-                lines.append((self._line_number, error))
-                self._line_number += 1
+            lines.extend(self._generate_body_field_lines(form_field))
 
         lines.append((self._line_number, self._generate_horizontal_line()))
         self._line_number += 1
@@ -400,6 +441,46 @@ class FormPresenter(CursesWindow):
         line_part = CursesLinePart(0, title, self._form.title_color, 0)
         return CursesLine((line_part,))
 
+    def _handle_form_input(
+        self,
+        idx: int,
+        form_field: Any,
+        win_response: tuple[Any, int],
+    ) -> tuple[bool, int]:
+        """Handle user input for a single form interaction cycle.
+
+        Args:
+            idx: The current field index
+            form_field: The current form field
+            win_response: The response and character from the window handler
+
+        Returns:
+            A tuple of (should_break, new_idx)
+        """
+        response, char = win_response
+
+        if char == curses.KEY_RESIZE:
+            self._screen.clear()
+            self._screen.refresh()
+
+        elif char == 112065:
+            # non-blocking form
+            return True, idx
+
+        elif isinstance(form_field, FieldButton):
+            if form_field.pressed:
+                return True, idx
+            idx += 1
+        elif char == curses_ascii.TAB:
+            form_field.conditional_validation(response)
+            idx += 1
+        else:
+            form_field.validate(response)
+            if form_field.valid is True:
+                idx += 1
+
+        return False, idx
+
     def present(self) -> Form:
         """Present the form to the user.
 
@@ -434,27 +515,9 @@ class FormPresenter(CursesWindow):
             form_field.window_handler.win = form_field.win
             win_response = form_field.window_handler.handle(idx, self._form.fields)
 
-            response, char = win_response
-
-            if char == curses.KEY_RESIZE:
-                self._screen.clear()
-                self._screen.refresh()
-
-            elif char == 112065:
-                # non-blocking form
+            should_break, idx = self._handle_form_input(idx, form_field, win_response)
+            if should_break:
                 break
-
-            elif isinstance(form_field, FieldButton):
-                if form_field.pressed:
-                    break
-                idx += 1
-            elif char == curses_ascii.TAB:
-                form_field.conditional_validation(response)
-                idx += 1
-            else:
-                form_field.validate(response)
-                if form_field.valid is True:
-                    idx += 1
 
         return self._form
 

--- a/src/ansible_navigator/ui_framework/form_handler_options.py
+++ b/src/ansible_navigator/ui_framework/form_handler_options.py
@@ -6,6 +6,7 @@ import curses
 
 from curses import ascii as curses_ascii
 from typing import TYPE_CHECKING
+from typing import Any
 
 from .curses_defs import CursesLine
 from .curses_defs import CursesLinePart
@@ -57,6 +58,50 @@ class FormHandlerOptions(CursesWindow):
                 line=CursesLine((clp_option_code, clp_text)),
             )
 
+    def _handle_key_input(
+        self,
+        char: int,
+        form_field: Any,
+        active: int,
+    ) -> tuple[bool, int]:
+        """Process a single key input for checkbox/radio fields.
+
+        Args:
+            char: The character input from the user
+            form_field: Field from a form
+            active: Track active checkbox/option
+
+        Returns:
+            Tuple of (should_break, new_active)
+        """
+        if char in (curses_ascii.SO, curses.KEY_DOWN):
+            return False, active + 1
+
+        if char in (curses_ascii.DLE, curses.KEY_UP):
+            return False, active - 1
+
+        if char == curses.KEY_RESIZE:
+            return True, active
+
+        if char == curses_ascii.TAB:
+            if active == len(form_field.options) - 1:
+                return True, active
+            return False, active + 1
+
+        if char == curses_ascii.SP:
+            if not form_field.options[active].disabled:
+                form_field.options[active].checked = not form_field.options[active].checked
+                if form_field.__class__.__name__ == "FieldRadio":
+                    for ffo_idx, option in enumerate(form_field.options):
+                        if ffo_idx != active:
+                            option.checked = False
+            return False, active
+
+        if char in [curses_ascii.NL, curses_ascii.CR]:
+            return True, active
+
+        return False, active
+
     def handle(self, idx: int, form_fields: list[FieldText]) -> tuple[FieldText, int]:
         """Handle the check box field.
 
@@ -81,29 +126,8 @@ class FormHandlerOptions(CursesWindow):
 
             char = self.win.getch()
 
-            if char in (curses_ascii.SO, curses.KEY_DOWN):
-                active += 1
-
-            elif char in (curses_ascii.DLE, curses.KEY_UP):
-                active -= 1
-
-            elif char == curses.KEY_RESIZE:
-                break
-
-            elif char == curses_ascii.TAB:
-                if active == len(form_field.options) - 1:
-                    break
-                active += 1
-
-            elif char == curses_ascii.SP:
-                if not form_field.options[active].disabled:
-                    form_field.options[active].checked = not form_field.options[active].checked
-                    if form_field.__class__.__name__ == "FieldRadio":
-                        for ffo_idx, option in enumerate(form_field.options):
-                            if ffo_idx != active:
-                                option.checked = False
-
-            elif char in [curses_ascii.NL, curses_ascii.CR]:
+            should_break, active = self._handle_key_input(char, form_field, active)
+            if should_break:
                 break
 
         return form_field, char

--- a/src/ansible_navigator/ui_framework/form_handler_text.py
+++ b/src/ansible_navigator/ui_framework/form_handler_text.py
@@ -54,6 +54,36 @@ class FormHandlerText(CursesWindow, Textbox):
         """
         self.input_line_pointer = (self.input_line_pointer + amount) % len(self.input_line_cache)
 
+    def _handle_arrow_down(self) -> int:
+        """Handle arrow down / Ctrl-N key input for line cache navigation.
+
+        Returns:
+            1 to indicate the window should be repainted
+        """
+        if self.input_line_cache:
+            if not self._arrowing:
+                self.input_line_pointer = 0
+                self._arrowing = True
+            else:
+                self._adjust_line_pointer(1)
+                self._paint_from_line_cache()
+        return 1
+
+    def _handle_arrow_up(self) -> int:
+        """Handle arrow up / Ctrl-P key input for line cache navigation.
+
+        Returns:
+            1 to indicate the window should be repainted
+        """
+        if self.input_line_cache:
+            if not self._arrowing:
+                self.input_line_pointer = len(self.input_line_cache) - 1
+                self._arrowing = True
+            else:
+                self._adjust_line_pointer(-1)
+                self._paint_from_line_cache()
+        return 1
+
     def _do_command(self, char: int) -> int:
         """Handle the input from the user.
 
@@ -76,23 +106,9 @@ class FormHandlerText(CursesWindow, Textbox):
         elif char == curses.KEY_RESIZE:
             ret = 0
         elif char in (curses_ascii.SO, curses.KEY_DOWN):
-            if self.input_line_cache:
-                if not self._arrowing:
-                    self.input_line_pointer = 0
-                    self._arrowing = True
-                else:
-                    self._adjust_line_pointer(1)
-                    self._paint_from_line_cache()
-            ret = 1
+            ret = self._handle_arrow_down()
         elif char in (curses_ascii.DLE, curses.KEY_UP):
-            if self.input_line_cache:
-                if not self._arrowing:
-                    self.input_line_pointer = len(self.input_line_cache) - 1
-                    self._arrowing = True
-                else:
-                    self._adjust_line_pointer(-1)
-                    self._paint_from_line_cache()
-            ret = 1
+            ret = self._handle_arrow_up()
         elif char == curses_ascii.TAB:
             ret = 0
         else:

--- a/src/ansible_navigator/ui_framework/form_utils.py
+++ b/src/ansible_navigator/ui_framework/form_utils.py
@@ -29,6 +29,75 @@ from .ui_constants import Color
 from .validators import FieldValidators
 
 
+def _build_text_field(field: dict[str, Any]) -> FieldText:
+    """Build a FieldText from a field dictionary.
+
+    Args:
+        field: Field dictionary from form data
+
+    Returns:
+        Constructed FieldText instance
+    """
+    field_params: dict[str, Any] = {"name": field["name"]}
+    field_params["prompt"] = field["prompt"]
+    field_params["validator"] = getattr(FieldValidators, field["validator"]["name"])
+
+    choices = field["validator"].get("choices")
+    if choices:
+        field_params["validator"] = partial(field_params["validator"], choices=choices)
+
+    default = field.get("default")
+    if default:
+        field_params["default"] = default
+
+    frm_field_text = FieldText(**field_params)
+
+    pre_populate = field.get("pre_populate")
+    if pre_populate:
+        frm_field_text.pre_populate(pre_populate)
+
+    return frm_field_text
+
+
+def _build_checks_field(field: dict[str, Any]) -> FieldChecks:
+    """Build a FieldChecks from a field dictionary.
+
+    Args:
+        field: Field dictionary from form data
+
+    Returns:
+        Constructed FieldChecks instance
+    """
+    field_params: dict[str, Any] = {"name": field["name"]}
+    field_params["prompt"] = field["prompt"]
+    field_params["options"] = [FieldOption(**option) for option in field["options"]]
+
+    max_selected = field.get("max_selected")
+    if max_selected:
+        field_params["max_selected"] = max_selected
+
+    min_selected = field.get("min_selected")
+    if min_selected:
+        field_params["min_selected"] = min_selected
+
+    return FieldChecks(**field_params)
+
+
+def _build_radio_field(field: dict[str, Any]) -> FieldRadio:
+    """Build a FieldRadio from a field dictionary.
+
+    Args:
+        field: Field dictionary from form data
+
+    Returns:
+        Constructed FieldRadio instance
+    """
+    field_params: dict[str, Any] = {"name": field["name"]}
+    field_params["prompt"] = field["prompt"]
+    field_params["options"] = [FieldOption(**option) for option in field["options"]]
+    return FieldRadio(**field_params)
+
+
 def dict_to_form(form_data: dict[str, Any]) -> Form:
     """Convert a python dict to a form.
 
@@ -50,44 +119,14 @@ def dict_to_form(form_data: dict[str, Any]) -> Form:
     form.title_color = form_data.get("title_color", 0)
 
     for field in form_data["fields"]:
-        field_params = {"name": field["name"]}
         if field["type"] == "text_input":
-            field_params["prompt"] = field["prompt"]
-            field_params["validator"] = getattr(FieldValidators, field["validator"]["name"])
+            form.fields.append(_build_text_field(field))
 
-            choices = field["validator"].get("choices")
-            if choices:
-                field_params["validator"] = partial(field_params["validator"], choices=choices)
+        elif field["type"] == "checkbox":
+            form.fields.append(_build_checks_field(field))
 
-            default = field.get("default")
-            if default:
-                field_params["default"] = default
-
-            frm_field_text = FieldText(**field_params)
-
-            pre_populate = field.get("pre_populate")
-            if pre_populate:
-                frm_field_text.pre_populate(pre_populate)
-
-            form.fields.append(frm_field_text)
-
-        elif field["type"] in ["checkbox", "radio"]:
-            field_params["prompt"] = field["prompt"]
-            field_params["options"] = [FieldOption(**option) for option in field["options"]]
-            if field["type"] == "checkbox":
-                max_selected = field.get("max_selected")
-                if max_selected:
-                    field_params["max_selected"] = max_selected
-
-                min_selected = field.get("min_selected")
-                if min_selected:
-                    field_params["min_selected"] = min_selected
-                frm_field_checks = FieldChecks(**field_params)
-                form.fields.append(frm_field_checks)
-
-            elif field["type"] == "radio":
-                frm_field_radio = FieldRadio(**field_params)
-                form.fields.append(frm_field_radio)
+        elif field["type"] == "radio":
+            form.fields.append(_build_radio_field(field))
 
         elif field["type"] == "information":
             frm_field_info = FieldInformation(name=field["name"], information=field["information"])
@@ -126,16 +165,28 @@ def form_to_dict(form: Form, key_on_name: bool = False) -> dict[str, Any]:
             ]
 
     if key_on_name:
-        fields = {}
-        for field in res["fields"]:
-            fields[field["name"]] = field
-            if "options" in field:
-                options = {}
-                for option in field["options"]:
-                    options[option["name"]] = option
-                fields[field["name"]]["options"] = options
-        res["fields"] = fields
+        res["fields"] = _rekey_fields_by_name(res)
     return res
+
+
+def _rekey_fields_by_name(res: dict[str, Any]) -> dict[str, Any]:
+    """Rekey the fields list into a dict keyed by field name.
+
+    Args:
+        res: The form result dictionary containing a "fields" list
+
+    Returns:
+        Dictionary of fields keyed by name
+    """
+    fields: dict[str, Any] = {}
+    for field in res["fields"]:
+        fields[field["name"]] = field
+        if "options" in field:
+            options = {}
+            for option in field["options"]:
+                options[option["name"]] = option
+            fields[field["name"]]["options"] = options
+    return fields
 
 
 def break_long_lines(messages: list[str]) -> list[str]:

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -913,7 +913,7 @@ class UserInterface(CursesWindow):
             if should_continue:
                 if new_index != index:
                     index = new_index
-                    self.scroll(0)
+                self.scroll(0)
                 if new_entry == "_":
                     self._hide_keys = not self._hide_keys
                     heading, lines = self._filter_and_serialize(objs[index])

--- a/src/ansible_navigator/ui_framework/ui.py
+++ b/src/ansible_navigator/ui_framework/ui.py
@@ -202,16 +202,16 @@ class UserInterface(CursesWindow):
         self._status_color = 0
         self._screen: Window = curses.initscr()
         self._screen.timeout(refresh)
-        self._screen.keypad(True)  # pragma: no cover  # Enable keypad mode
+        self._screen.keypad(True)  # Enable keypad mode
         self._one_line_input = FormHandlerText(screen=self._screen, ui_config=self._ui_config)
         # This tracks which visible row to highlight
-        self._highlight_line_offset: int | None = None  # pragma: no cover
+        self._highlight_line_offset: int | None = None
         # Cursor position in menus; None means cursor is not yet active.
         # It activates (becomes an int) only after the user presses UP or DOWN.
-        self._menu_cursor_pos: int | None = None  # pragma: no cover
+        self._menu_cursor_pos: int | None = None
         # Tracks the identity of the current menu's data object so the cursor
         # is reset only when entering a new menu, not on refresh cycles.
-        self._menu_current_id: int | None = None  # pragma: no cover
+        self._menu_current_id: int | None = None
 
     def clear(self) -> None:
         """Clear the screen."""
@@ -439,6 +439,61 @@ class UserInterface(CursesWindow):
         self._curs_set(0)
         return user_input
 
+    def _handle_display_key(
+        self,
+        key: str,
+        keypad: set[str],
+        other_valid_keys: list[str],
+        viewport_height: int,
+        heading_len: int,
+        footer_len: int,
+        count: int,
+        lines_len: int,
+        indent_heading: int,
+    ) -> str | None:
+        """Handle a key press during display, adjusting scroll as needed.
+
+        Args:
+            key: The key that was pressed
+            keypad: The set of numeric keypad characters
+            other_valid_keys: Other keys that should be returned as-is
+            viewport_height: The height of the viewport
+            heading_len: The height of the heading
+            footer_len: The height of the footer
+            count: The total number of lines
+            lines_len: The number of currently visible lines
+            indent_heading: The indentation of heading
+
+        Returns:
+            The key string to return, or None if the key was not handled
+        """
+        if key == "KEY_RESIZE":
+            new_scroll = min(
+                self._scroll - viewport_height + self._screen_height - heading_len - footer_len,
+                lines_len,
+            )
+            self.scroll(new_scroll)
+            return key
+        if key in keypad or key in other_valid_keys:
+            return key
+        if key == "KEY_DOWN":
+            if not indent_heading:
+                self.scroll(max(min(self.scroll() + 1, count), viewport_height))
+            return key
+        if key == "KEY_UP":
+            if not indent_heading:
+                self.scroll(max(self.scroll() - 1, viewport_height))
+            return key
+        if key in ["^F", "KEY_NPAGE"]:
+            self.scroll(max(min(self.scroll() + viewport_height, count), viewport_height))
+            return key
+        if key in ["^B", "KEY_PPAGE"]:
+            self.scroll(max(self.scroll() - viewport_height, viewport_height))
+            return key
+        if key == ":":
+            return ":"
+        return None
+
     def _display(
         self,
         lines: CursesLines,
@@ -449,7 +504,6 @@ class UserInterface(CursesWindow):
         await_input: bool,
         count: int,
     ) -> str:
-        # pylint: disable=too-many-locals
         """Show something on the screen.
 
         Args:
@@ -484,7 +538,7 @@ class UserInterface(CursesWindow):
             "^[",
             "\x1b",
             "CURSOR_ENTER",
-        ]  # pragma: no cover
+        ]
 
         while True:
             self._screen.erase()
@@ -500,7 +554,7 @@ class UserInterface(CursesWindow):
                 line_index_str = str(line_index).rjust(index_width)
                 prefix = f"{line_index_str}\u2502"
                 # Apply highlight decoration when this is the selected row
-                if (  # pragma: no cover
+                if (
                     indent_heading
                     and self._highlight_line_offset is not None
                     and idx == self._highlight_line_offset
@@ -517,7 +571,7 @@ class UserInterface(CursesWindow):
                     )
                     line_to_draw = CursesLine(highlighted_parts)
                 else:
-                    line_to_draw = line  # pragma: no cover
+                    line_to_draw = line
                 self._add_line(
                     window=self._screen,
                     lineno=idx + len(heading),
@@ -543,36 +597,23 @@ class UserInterface(CursesWindow):
             if await_input:
                 char = self._screen.getch()
                 key = KEY_REFRESH if char == -1 else curses.keyname(char).decode()
-                if char in [10, 13]:  # pragma: no cover  # Enter key codes: 10=LF, 13=CR
+                if char in [10, 13]:  # Enter key codes: 10=LF, 13=CR
                     key = "CURSOR_ENTER"
             else:
                 key = KEY_REFRESH
 
-            return_value = None
-            if key == "KEY_RESIZE":
-                new_scroll = min(
-                    self._scroll - viewport_height + self._screen_height - heading_len - footer_len,
-                    len(lines),
-                )
-                self.scroll(new_scroll)
-                return_value = key
-            elif key in keypad or key in other_valid_keys:
-                return_value = key
-            elif key == "KEY_DOWN":
-                if not indent_heading:  # pragma: no cover
-                    self.scroll(max(min(self.scroll() + 1, count), viewport_height))
-                return_value = key
-            elif key == "KEY_UP":
-                if not indent_heading:  # pragma: no cover
-                    self.scroll(max(self.scroll() - 1, viewport_height))
-                return_value = key
-            elif key in ["^F", "KEY_NPAGE"]:
-                self.scroll(max(min(self.scroll() + viewport_height, count), viewport_height))
-                return_value = key
-            elif key in ["^B", "KEY_PPAGE"]:
-                self.scroll(max(self.scroll() - viewport_height, viewport_height))
-                return_value = key
-            elif key == ":":
+            return_value = self._handle_display_key(
+                key=key,
+                keypad=keypad,
+                other_valid_keys=other_valid_keys,
+                viewport_height=viewport_height,
+                heading_len=heading_len,
+                footer_len=footer_len,
+                count=count,
+                lines_len=len(lines),
+                indent_heading=indent_heading,
+            )
+            if return_value == ":":
                 colon_entry = self._get_input_line()
                 if colon_entry is None:
                     continue
@@ -764,13 +805,65 @@ class UserInterface(CursesWindow):
         res = obj.present(screen=self._screen, ui_config=self._ui_config)
         return res
 
+    def _handle_obj_navigation(
+        self,
+        entry: str,
+        objs: ContentTypeSequence,
+        index: int,
+    ) -> tuple[bool, int, str | None]:
+        """Handle navigation keys when showing an object from a list.
+
+        Args:
+            entry: The key or command string entered by the user
+            objs: The list of objects being navigated
+            index: The current index into objs
+
+        Returns:
+            A tuple of (should_continue, new_index, new_entry) where
+            should_continue indicates the caller should loop again,
+            new_index is the possibly updated index, and new_entry
+            is a signal string ("_" for toggle keys, "KEY_RESIZE"
+            for resize, or None otherwise).
+        """
+        if entry in ["KEY_DOWN", "KEY_UP", "KEY_NPAGE", "KEY_PPAGE", "^F", "^B"]:
+            return True, index, None
+
+        if entry == "CURSOR_ENTER":
+            return True, index, None
+
+        if entry == "KEY_RESIZE":
+            return True, index, "KEY_RESIZE"
+
+        if entry == "_":
+            return True, index, "_"
+
+        if entry == "-":
+            less = list(reversed([i for i in self._menu_indices if i - index < 0]))
+            more = list(reversed([i for i in self._menu_indices if i - index > 0]))
+            ordered_indices = less + more
+            if ordered_indices:
+                return True, ordered_indices[0], None
+            return True, index, None
+
+        if entry == "+":
+            more = [i for i in self._menu_indices if i - index > 0]
+            less = [i for i in self._menu_indices if i - index < 0]
+            ordered_indices = more + less
+            if ordered_indices:
+                return True, ordered_indices[0], None
+            return True, index, None
+
+        if entry.isnumeric():
+            return True, int(entry) % len(objs), None
+
+        return False, index, None
+
     def _show_obj_from_list(
         self,
         objs: ContentTypeSequence,
         index: int,
         await_input: bool,
     ) -> Interaction:
-        # pylint: disable=too-many-locals
         """Show an object on the display.
 
         Args:
@@ -812,46 +905,20 @@ class UserInterface(CursesWindow):
                 await_input=await_input,
                 count=len(lines),
             )
-            if entry in ["KEY_DOWN", "KEY_UP", "KEY_NPAGE", "KEY_PPAGE", "^F", "^B"]:
-                continue
-
-            if entry == "CURSOR_ENTER":  # pragma: no cover
-                continue
-
-            if entry == "KEY_RESIZE":
-                # only the heading knows about the screen width and height
-                heading = self._content_heading(objs[index], self._screen_width)
-                continue
-
-            if entry == "_":
-                self._hide_keys = not self._hide_keys
-                heading, lines = self._filter_and_serialize(objs[index])
-                continue
-
-            # get the less or more, wrap, in case we jumped out of the menu indices
-            if entry == "-":
-                less = list(reversed([i for i in self._menu_indices if i - index < 0]))
-                more = list(reversed([i for i in self._menu_indices if i - index > 0]))
-
-                ordered_indices = less + more
-                if ordered_indices:
-                    index = ordered_indices[0]
+            should_continue, new_index, new_entry = self._handle_obj_navigation(
+                entry,
+                objs,
+                index,
+            )
+            if should_continue:
+                if new_index != index:
+                    index = new_index
                     self.scroll(0)
-                continue
-
-            if entry == "+":
-                more = [i for i in self._menu_indices if i - index > 0]
-                less = [i for i in self._menu_indices if i - index < 0]
-
-                ordered_indices = more + less
-                if ordered_indices:
-                    index = ordered_indices[0]
-                    self.scroll(0)
-                continue
-
-            if entry.isnumeric():
-                index = int(entry) % len(objs)
-                self.scroll(0)
+                if new_entry == "_":
+                    self._hide_keys = not self._hide_keys
+                    heading, lines = self._filter_and_serialize(objs[index])
+                elif new_entry == "KEY_RESIZE":
+                    heading = self._content_heading(objs[index], self._screen_width)
                 continue
 
             current = objs[index % len(objs)]
@@ -917,6 +984,49 @@ class UserInterface(CursesWindow):
         menu_heading, menu_items = menu_builder.build(current, columns, indices)
         return menu_heading, menu_items
 
+    def _handle_menu_cursor_keys(
+        self,
+        entry: str,
+        menu_heading: CursesLines,
+        showing_indices: tuple[int, ...],
+    ) -> None:
+        """Handle KEY_DOWN/KEY_UP cursor movement in a menu.
+
+        Updates ``_menu_cursor_pos`` and adjusts scroll so the highlighted
+        row stays visible.
+
+        Args:
+            entry: The key that was pressed ("KEY_DOWN" or "KEY_UP")
+            menu_heading: The current menu heading lines (used for
+                viewport height calculation)
+            showing_indices: The indices currently visible on screen
+        """
+        # Activate cursor at position 0 on first arrow-key press (no movement)
+        if self._menu_cursor_pos is None:
+            self._menu_cursor_pos = 0
+            return
+        # Move the cursor position (only if cursor was already active)
+        if entry == "KEY_DOWN" and self._menu_cursor_pos < len(self._menu_indices) - 1:
+            self._menu_cursor_pos += 1
+            # If moved past the last visible item, scroll down one
+            if (
+                self._highlight_line_offset is None
+                or self._highlight_line_offset >= len(showing_indices) - 1
+            ):
+                viewport_height = self._screen_height - len(menu_heading) - 1
+                self.scroll(
+                    max(
+                        min(self.scroll() + 1, len(self._menu_indices)),
+                        viewport_height,
+                    ),
+                )
+        elif entry == "KEY_UP" and self._menu_cursor_pos > 0:
+            self._menu_cursor_pos -= 1
+            # If moved before the first visible item, scroll up one
+            if self._highlight_line_offset is None or self._highlight_line_offset <= 0:
+                viewport_height = self._screen_height - len(menu_heading) - 1
+                self.scroll(max(self.scroll() - 1, viewport_height))
+
     def _show_menu(
         self,
         current: Sequence[Any],
@@ -934,7 +1044,7 @@ class UserInterface(CursesWindow):
             Interaction with the user
         """
         # Reset cursor only when entering a new menu, not on refresh cycles
-        if id(current) != self._menu_current_id:  # pragma: no cover
+        if id(current) != self._menu_current_id:
             self._menu_cursor_pos = None
             self._menu_current_id = id(current)
         while True:
@@ -963,8 +1073,8 @@ class UserInterface(CursesWindow):
             )
 
             # Determine which row to highlight (only when cursor is active)
-            self._highlight_line_offset = None  # pragma: no cover
-            if self._menu_indices and self._menu_cursor_pos is not None:  # pragma: no cover
+            self._highlight_line_offset = None
+            if self._menu_indices and self._menu_cursor_pos is not None:
                 self._menu_cursor_pos = max(
                     0,
                     min(self._menu_cursor_pos, len(self._menu_indices) - 1),
@@ -987,43 +1097,14 @@ class UserInterface(CursesWindow):
 
             # Handle arrow navigation for menus when enabled
             if entry in ["KEY_RESIZE", "KEY_DOWN", "KEY_UP", "KEY_NPAGE", "KEY_PPAGE", "^F", "^B"]:
-                if entry in ["KEY_DOWN", "KEY_UP"] and self._menu_indices:  # pragma: no cover
-                    # Activate cursor at position 0 on first arrow-key press (no movement)
-                    if self._menu_cursor_pos is None:
-                        self._menu_cursor_pos = 0
-                    # Move the cursor position (only if cursor was already active)
-                    elif (
-                        entry == "KEY_DOWN" and self._menu_cursor_pos < len(self._menu_indices) - 1
-                    ):
-                        self._menu_cursor_pos += 1
-                        # If moved past the last visible item, scroll down one
-                        if (
-                            self._highlight_line_offset is None
-                            or self._highlight_line_offset >= len(showing_indices) - 1
-                        ):
-                            # Mimic _display scroll down
-                            viewport_height = self._screen_height - len(menu_heading) - 1
-                            self.scroll(
-                                max(
-                                    min(self.scroll() + 1, len(self._menu_indices)),
-                                    viewport_height,
-                                ),
-                            )
-                    elif entry == "KEY_UP" and self._menu_cursor_pos > 0:
-                        self._menu_cursor_pos -= 1
-                        # If moved before the first visible item, scroll up one
-                        if self._highlight_line_offset is None or self._highlight_line_offset <= 0:
-                            viewport_height = self._screen_height - len(menu_heading) - 1
-                            self.scroll(max(self.scroll() - 1, viewport_height))
-                    # Re-render with updated highlight
-                    continue
-                # Otherwise, preserve prior behavior
+                if entry in ["KEY_DOWN", "KEY_UP"] and self._menu_indices:
+                    self._handle_menu_cursor_keys(entry, menu_heading, showing_indices)
                 continue
 
             # Enter key selects the highlighted item, but only when cursor is active.
             # If cursor is inactive (None), ignore the Enter entirely so it does not
             # fall through to _template_match_action and trigger a spurious warning dialog.
-            if entry in ["CURSOR_ENTER", "^J", "^M", "KEY_ENTER", "KEY_RETURN"]:  # pragma: no cover
+            if entry in ["CURSOR_ENTER", "^J", "^M", "KEY_ENTER", "KEY_RETURN"]:
                 if self._menu_cursor_pos is not None and self._menu_indices:
                     entry = str(self._menu_indices[self._menu_cursor_pos])
                 else:

--- a/tests/unit/ui_framework/test_colorize_helpers.py
+++ b/tests/unit/ui_framework/test_colorize_helpers.py
@@ -1,0 +1,78 @@
+"""Tests for pure helper functions in colorize module."""
+
+from __future__ import annotations
+
+import pytest
+
+from ansible_navigator.ui_framework.colorize import _rgb_to_ansi_16
+from ansible_navigator.ui_framework.colorize import _rgb_to_ansi_256
+
+
+class TestRgbToAnsi256:
+    """Tests for _rgb_to_ansi_256."""
+
+    def test_black(self) -> None:
+        """Pure black (0,0,0) maps to color 16."""
+        assert _rgb_to_ansi_256(0, 0, 0) == 16
+
+    def test_white(self) -> None:
+        """Pure white (255,255,255) maps to color 231."""
+        assert _rgb_to_ansi_256(255, 255, 255) == 231
+
+    def test_mid_grey_grayscale(self) -> None:
+        """A mid-grey value falls in the grayscale ramp (232-255)."""
+        result = _rgb_to_ansi_256(128, 128, 128)
+        assert 232 <= result <= 255
+
+    def test_pure_red(self) -> None:
+        """Pure red (255,0,0) maps to 196 in the 6x6x6 cube."""
+        assert _rgb_to_ansi_256(255, 0, 0) == 196
+
+    def test_pure_green(self) -> None:
+        """Pure green (0,255,0) maps to 46 in the 6x6x6 cube."""
+        assert _rgb_to_ansi_256(0, 255, 0) == 46
+
+    def test_pure_blue(self) -> None:
+        """Pure blue (0,0,255) maps to 21 in the 6x6x6 cube."""
+        assert _rgb_to_ansi_256(0, 0, 255) == 21
+
+    @pytest.mark.parametrize(
+        ("red", "green", "blue"),
+        (
+            (0, 0, 0),
+            (128, 128, 128),
+            (255, 255, 255),
+        ),
+    )
+    def test_grayscale_values_are_in_range(
+        self,
+        red: int,
+        green: int,
+        blue: int,
+    ) -> None:
+        """Equal RGB values should map to the grayscale range or boundary colors.
+
+        Args:
+            red: Red component.
+            green: Green component.
+            blue: Blue component.
+        """
+        result = _rgb_to_ansi_256(red, green, blue)
+        assert 16 <= result <= 255
+
+
+class TestRgbToAnsi16:
+    """Tests for _rgb_to_ansi_16."""
+
+    def test_black(self) -> None:
+        """Pure black (0,0,0) maps to 30 (ANSI black foreground)."""
+        assert _rgb_to_ansi_16(0, 0, 0) == 30
+
+    def test_white(self) -> None:
+        """Pure white (255,255,255) maps to 7 (standard white foreground)."""
+        assert _rgb_to_ansi_16(255, 255, 255) == 7
+
+    def test_returns_int(self) -> None:
+        """Return type is always int."""
+        result = _rgb_to_ansi_16(100, 150, 200)
+        assert isinstance(result, int)

--- a/tests/unit/ui_framework/test_form_utils_helpers.py
+++ b/tests/unit/ui_framework/test_form_utils_helpers.py
@@ -1,0 +1,181 @@
+"""Tests for pure helper functions in form_utils module."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ansible_navigator.ui_framework.field_checks import FieldChecks
+from ansible_navigator.ui_framework.field_option import FieldOption
+from ansible_navigator.ui_framework.field_radio import FieldRadio
+from ansible_navigator.ui_framework.field_text import FieldText
+from ansible_navigator.ui_framework.form_utils import _build_checks_field
+from ansible_navigator.ui_framework.form_utils import _build_radio_field
+from ansible_navigator.ui_framework.form_utils import _build_text_field
+from ansible_navigator.ui_framework.form_utils import _rekey_fields_by_name
+
+
+class TestBuildTextField:
+    """Tests for _build_text_field."""
+
+    def test_returns_field_text(self) -> None:
+        """The builder returns a FieldText instance."""
+        field_data = {
+            "name": "username",
+            "prompt": "Enter username",
+            "validator": {"name": "something"},
+        }
+        result = _build_text_field(field_data)
+        assert isinstance(result, FieldText)
+
+    def test_name_and_prompt(self) -> None:
+        """Name and prompt are set correctly."""
+        field_data = {
+            "name": "host",
+            "prompt": "Enter host",
+            "validator": {"name": "something"},
+        }
+        result = _build_text_field(field_data)
+        assert result.name == "host"
+        assert result.prompt == "Enter host"
+
+    def test_default_value(self) -> None:
+        """Default is set when provided."""
+        field_data = {
+            "name": "port",
+            "prompt": "Enter port",
+            "validator": {"name": "something"},
+            "default": "8080",
+        }
+        result = _build_text_field(field_data)
+        assert result.default == "8080"
+
+    def test_validator_with_choices(self) -> None:
+        """Validator with choices creates a partial."""
+        field_data = {
+            "name": "color",
+            "prompt": "Pick color",
+            "validator": {"name": "one_of", "choices": ["red", "blue"]},
+        }
+        result = _build_text_field(field_data)
+        assert isinstance(result, FieldText)
+
+
+class TestBuildChecksField:
+    """Tests for _build_checks_field."""
+
+    def test_returns_field_checks(self) -> None:
+        """The builder returns a FieldChecks instance."""
+        field_data = {
+            "name": "features",
+            "prompt": "Select features",
+            "options": [
+                {"name": "opt_a", "text": "Option A"},
+                {"name": "opt_b", "text": "Option B"},
+            ],
+        }
+        result = _build_checks_field(field_data)
+        assert isinstance(result, FieldChecks)
+
+    def test_options_are_field_option_instances(self) -> None:
+        """Each option should be a FieldOption."""
+        field_data = {
+            "name": "features",
+            "prompt": "Select features",
+            "options": [
+                {"name": "opt_a", "text": "Option A"},
+            ],
+        }
+        result = _build_checks_field(field_data)
+        assert len(result.options) == 1
+        assert isinstance(result.options[0], FieldOption)
+        assert result.options[0].name == "opt_a"
+
+    def test_max_min_selected(self) -> None:
+        """Max and min selected are set when provided."""
+        field_data = {
+            "name": "features",
+            "prompt": "Select features",
+            "options": [
+                {"name": "opt_a", "text": "Option A"},
+            ],
+            "max_selected": 3,
+            "min_selected": 1,
+        }
+        result = _build_checks_field(field_data)
+        assert result.max_selected == 3
+        assert result.min_selected == 1
+
+
+class TestBuildRadioField:
+    """Tests for _build_radio_field."""
+
+    def test_returns_field_radio(self) -> None:
+        """The builder returns a FieldRadio instance."""
+        field_data = {
+            "name": "mode",
+            "prompt": "Select mode",
+            "options": [
+                {"name": "fast", "text": "Fast"},
+                {"name": "slow", "text": "Slow"},
+            ],
+        }
+        result = _build_radio_field(field_data)
+        assert isinstance(result, FieldRadio)
+
+    def test_options_populated(self) -> None:
+        """Options are populated correctly."""
+        field_data = {
+            "name": "mode",
+            "prompt": "Select mode",
+            "options": [
+                {"name": "fast", "text": "Fast"},
+                {"name": "slow", "text": "Slow"},
+            ],
+        }
+        result = _build_radio_field(field_data)
+        assert len(result.options) == 2
+        assert result.options[0].text == "Fast"
+        assert result.options[1].text == "Slow"
+
+
+class TestRekeyFieldsByName:
+    """Tests for _rekey_fields_by_name."""
+
+    def test_basic_rekey(self) -> None:
+        """Fields list is rekeyed by name."""
+        res = {
+            "fields": [
+                {"name": "username", "value": "admin"},
+                {"name": "password", "value": "secret"},
+            ],
+        }
+        result = _rekey_fields_by_name(res)
+        assert "username" in result
+        assert "password" in result
+        assert result["username"]["value"] == "admin"
+        assert result["password"]["value"] == "secret"
+
+    def test_rekey_with_options(self) -> None:
+        """Fields with options are also rekeyed by name."""
+        res = {
+            "fields": [
+                {
+                    "name": "features",
+                    "options": [
+                        {"name": "opt_a", "checked": True},
+                        {"name": "opt_b", "checked": False},
+                    ],
+                },
+            ],
+        }
+        result = _rekey_fields_by_name(res)
+        assert "features" in result
+        assert "opt_a" in result["features"]["options"]
+        assert "opt_b" in result["features"]["options"]
+        assert result["features"]["options"]["opt_a"]["checked"] is True
+
+    def test_empty_fields(self) -> None:
+        """Empty fields list produces empty dict."""
+        res: dict[str, list[Any]] = {"fields": []}
+        result = _rekey_fields_by_name(res)
+        assert not result


### PR DESCRIPTION
## Summary

- Extracted helper functions in `colorize.py` to reduce CC of `rgb_to_ansi`, `columns_and_colors`, `ansi_to_curses`, `strip_markdown`
- Extracted `_render_line_part` in `curses_window.py` to reduce CC of `_add_line`
- Extracted `_calculate_field_widths`, `_calculate_form_height`, `_generate_body_field_lines`, `_handle_form_input` in `form.py` to reduce CC of `_dimensions`, `_generate_form`, `present`
- Extracted `_handle_key_input` in `form_handler_options.py` to reduce CC of `handle`
- Extracted `_handle_arrow_down`, `_handle_arrow_up` in `form_handler_text.py` to reduce CC of `_do_command`
- Extracted `_build_text_field`, `_build_checks_field`, `_build_radio_field`, `_rekey_fields_by_name` in `form_utils.py` to reduce CC of `dict_to_form`, `form_to_dict`
- Extracted `_handle_display_key`, `_handle_obj_navigation`, `_handle_menu_cursor_keys` in `ui.py` to reduce CC of `_display`, `_show_obj_from_list`, `_show_menu`
- Removed stale `pylint: disable=too-many-locals` suppressions

## Test plan

- [ ] Verify all 15 S3776 SonarCloud issues are resolved
- [ ] Confirm no behavioral changes via existing test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved terminal color/markup rendering by reorganizing ANSI conversion, region application, and markdown stripping into clearer reusable helpers.
  * Streamlined curses line rendering to draw segments more consistently within the screen bounds.
  * Refined form layout, body line generation, input handling, and option/text key behavior through extracted helper logic.
  * Centralized UI key handling for display, list navigation, and menu cursor/scroll movement.
* **Tests**
  * Added unit tests for RGB-to-ANSI conversion helpers.
  * Added unit tests for form utility helper behaviors and field/option rekeying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->