### PR TITLE
fix: handle invalid artifact filename formats

### DIFF
--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -1176,12 +1176,23 @@ class NavigatorPostProcessor:
         """
         messages: list[LogMessage] = []
         exit_messages: list[ExitMessage] = []
-        # literal_text, fname, format_spec, conversion
-        found = {f for _, f, _, _ in Formatter().parse(entry.value.current) if f}
         available = {f for _, f, _, _ in Formatter().parse(entry.value.default) if f}
         non_defaults_also_available = {"playbook_status"}
 
         available.update(non_defaults_also_available)
+        # literal_text, fname, format_spec, conversion
+        try:
+            found = {f for _, f, _, _ in Formatter().parse(entry.value.current) if f}
+        except ValueError as exc:
+            exit_msg = (
+                f"The playbook artifact file name '{entry.value.current}', set by"
+                f" {entry.value.source.value.lower()}, has invalid format syntax: {exc!s}"
+            )
+            exit_messages.append(ExitMessage(message=exit_msg))
+            exit_msg = f"Try again with matching braces around {oxfordcomma(available, 'and/or')}"
+            exit_messages.append(ExitMessage(message=exit_msg, prefix=ExitPrefix.HINT))
+            return messages, exit_messages
+
         unknown = found - available
         if not unknown:
             return messages, exit_messages

--- a/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_post_processor.py
@@ -1205,12 +1205,23 @@ class NavigatorPostProcessor:
         """
         messages: list[LogMessage] = []
         exit_messages: list[ExitMessage] = []
-        # literal_text, fname, format_spec, conversion
-        found = {f for _, f, _, _ in Formatter().parse(entry.value.current) if f}
         available = {f for _, f, _, _ in Formatter().parse(entry.value.default) if f}
         non_defaults_also_available = {"playbook_status"}
 
         available.update(non_defaults_also_available)
+        # literal_text, fname, format_spec, conversion
+        try:
+            found = {f for _, f, _, _ in Formatter().parse(entry.value.current) if f}
+        except ValueError as exc:
+            exit_msg = (
+                f"The playbook artifact file name '{entry.value.current}', set by"
+                f" {entry.value.source.value.lower()}, has invalid format syntax: {exc!s}"
+            )
+            exit_messages.append(ExitMessage(message=exit_msg))
+            exit_msg = f"Try again with matching braces around {oxfordcomma(available, 'and/or')}"
+            exit_messages.append(ExitMessage(message=exit_msg, prefix=ExitPrefix.HINT))
+            return messages, exit_messages
+
         unknown = found - available
         if not unknown:
             return messages, exit_messages

--- a/tests/unit/configuration_subsystem/post_processors/test_playbook_artifact_save_as.py
+++ b/tests/unit/configuration_subsystem/post_processors/test_playbook_artifact_save_as.py
@@ -66,6 +66,14 @@ test_data = (
             " has unrecognized variables: 'name'"
         ),
     ),
+    Scenario(
+        name="4",
+        current="s{",
+        exit_message_substr=(
+            "The playbook artifact file name 's{', set by command line,"
+            " has invalid format syntax: Single '{' encountered in format string"
+        ),
+    ),
 )
 
 


### PR DESCRIPTION
Closes #2143

## Summary

Handle malformed braces in `playbook_artifact_save_as` as a configuration error instead of allowing `Formatter.parse()` to raise `ValueError` and crash the application. The error now identifies the invalid filename and provides a hint listing the supported variables.

## Test plan

- [x] Regression fails without the source fix and passes with it
- [x] Focused unit tests pass (`5 passed`)
- [x] Ruff check and format pass
- [x] Mypy passes for the changed source file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid artifact filename formats.
  * Added clear guidance about using matching braces and supported variables when format syntax is invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->