### PR TITLE
fix: handle OSError when checking a playbook path

### DIFF
--- a/src/ansible_navigator/utils/functions.py
+++ b/src/ansible_navigator/utils/functions.py
@@ -110,9 +110,14 @@ def check_playbook_type(playbook: str) -> str:
     """
     playbook_type = "file"
     playbook_path = str(playbook)
-    if Path(playbook_path).exists() is False:
+    try:
+        exists = Path(playbook_path).exists()
+    except OSError:
+        # The path cannot name a file on this system, e.g. it is too long
+        exists = False
+    if exists is False:
         playbook_type = "missing"
-    if Path(playbook_path).exists() is False and len(playbook_path.split(".")) >= 3:
+    if exists is False and len(playbook_path.split(".")) >= 3:
         playbook_type = "fqcn"
     return playbook_type
 

--- a/tests/unit/utils/test_functions_extended.py
+++ b/tests/unit/utils/test_functions_extended.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import errno
+import pathlib
 import shutil
 
 from typing import TYPE_CHECKING
@@ -65,6 +67,20 @@ def test_check_playbook_type_missing() -> None:
 def test_check_playbook_type_fqcn() -> None:
     """Test check_playbook_type with an FQCN playbook."""
     assert check_playbook_type("namespace.collection.playbook") == "fqcn"
+
+
+def test_check_playbook_type_name_too_long(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test check_playbook_type when the path cannot name a file on this system.
+
+    Args:
+        monkeypatch: The monkeypatch fixture
+    """
+
+    def raise_name_too_long(_self: pathlib.Path) -> bool:
+        raise OSError(errno.ENAMETOOLONG, "File name too long")
+
+    monkeypatch.setattr(pathlib.Path, "exists", raise_name_too_long)
+    assert check_playbook_type("a" * 300) == "missing"
 
 
 def test_clear_screen_vscode(


### PR DESCRIPTION
Fixes #2139

`check_playbook_type()` called `Path(playbook_path).exists()` unguarded, so a playbook path the filesystem cannot name — for example one longer than 255 bytes, passed via `--playbook` or `ANSIBLE_NAVIGATOR_PLAYBOOK` — raised `OSError: [Errno 36] File name too long` instead of the ordinary "missing playbook" error. The existence check now treats an `OSError` as not-existing, so such a path is classified `missing` and the normal user-facing message is produced.

Regression test added in `tests/unit/utils/test_functions_extended.py` next to the existing `check_playbook_type` tests; it fails without the source change and passes with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of playbook paths that are too long or otherwise trigger an operating system error.
  * Such paths are now correctly recognized as missing, while valid fully qualified collection names continue to be classified appropriately.

* **Tests**
  * Added coverage for overly long path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->