### PR TITLE
fix: handle undeterminable home directory when expanding a path

### DIFF
--- a/src/ansible_navigator/utils/functions.py
+++ b/src/ansible_navigator/utils/functions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import contextlib
 import datetime
 import decimal
 import html
@@ -64,7 +65,9 @@ def expand_path(path: str | Path) -> Path:
         Resolved file path
     """
     _path = Path(os.path.expandvars(path))
-    _path = _path.expanduser()
+    # The home directory may not be determinable, e.g. ~ names an unknown user
+    with contextlib.suppress(RuntimeError):
+        _path = _path.expanduser()
     return _path.resolve()
 
 

--- a/tests/unit/utils/test_functions.py
+++ b/tests/unit/utils/test_functions.py
@@ -116,6 +116,11 @@ def test_env_var_is_file_path(
     assert result == anticipated_result
 
 
+def test_expand_path_unknown_user() -> None:
+    """Test expand_path with a tilde naming a user without a home directory."""
+    assert expand_path("~nonexistentuser") == Path("~nonexistentuser").resolve()
+
+
 @pytest.mark.parametrize(
     ("value", "anticipated_result"),
     (


### PR DESCRIPTION
Fixes #2142

`expand_path()` called `Path.expanduser()` unguarded, so a path like `~nonexistentuser` (via `-i` or `ANSIBLE_NAVIGATOR_INVENTORY`) raised `RuntimeError: Could not determine home directory` and crashed before any user-facing error handling ran. The tilde is now left unexpanded when the home directory cannot be determined, so the path resolves as-is and the normal "not a valid file" handling reports it.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path expansion when a home-directory path references a nonexistent user.
  * Paths are now preserved and resolved correctly instead of failing unexpectedly.

* **Tests**
  * Added regression coverage for nonexistent-user tilde paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->