### PR TITLE
fix: drain event queue after runner finishes in stdout mode

### DIFF
--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -319,6 +319,7 @@ class Action(ActionBase):
         while True:
             self._dequeue()
             if self.runner.finished:
+                self._dequeue()
                 if self._args.playbook_artifact_enable:
                     self.write_artifact()
                 self._logger.debug("runner finished")


### PR DESCRIPTION
## Summary
- Fixes #606 — intermittent loss of final playbook output in stdout mode
- Adds a final `_dequeue()` call after detecting `runner.finished` to close a race condition where events arriving between the initial dequeue and the finished check are never consumed before `write_artifact()` runs

## Root Cause
The stdout-mode loop in `run.py` calls `_dequeue()` then checks `runner.finished`. If the runner posts final events to the queue between those two calls, the loop breaks immediately without draining them — the artifact is written with incomplete data. The interactive mode path does not have this problem because `_dequeue()` is called repeatedly by the UI event loop.

## Test plan
- [ ] Run a playbook in stdout mode with artifact saving enabled; verify full output appears in the artifact
- [ ] Stress test with rapid/large output playbooks to confirm the race window is closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command output capture by ensuring final runner messages are collected before artifacts are written and execution ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->