### PR TITLE
fix(docs): remove unused mkdocstrings plugin causing 429 failures

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -49,7 +49,6 @@ magiclink
 maskables
 maxsplit
 mergeable
-mkdocstrings
 mqueue              # https://github.com/ansible/ansible-runner/issues/984
 myuser
 myproject

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,19 +69,6 @@ plugins:
   - material/tags
   # https://github.com/manuzhang/mkdocs-htmlproofer-plugin
   # - htmlproofer
-  - mkdocstrings:
-      handlers:
-        python:
-          paths: [src]
-          options:
-            # Sphinx is for historical reasons, but we could consider switching if needed
-            # https://mkdocstrings.github.io/griffe/docstrings/
-            docstring_style: sphinx
-            merge_init_into_class: yes
-            show_submodules: yes
-          import:
-            - url: https://docs.ansible.com/ansible/latest/objects.inv
-              domains: [py, std]
 
 markdown_extensions:
   - markdown_include.include:


### PR DESCRIPTION
## Summary

- Remove the unused `mkdocstrings` plugin from `mkdocs.yml` and its dictionary entry

The mkdocstrings plugin is configured to fetch `objects.inv` from docs.ansible.com, which intermittently returns HTTP 429 (Too Many Requests). Since mkdocs runs in strict mode, this causes the docs CI job to fail.

The plugin is not actually used anywhere in the docs (no `:::` autodoc directives exist), so removing it is safe and has no effect on the generated documentation.

## Test plan

- [ ] Verify docs CI job passes without the mkdocstrings plugin
- [ ] Confirm no `:::` autodoc directives exist in the docs that would break

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the `mkdocstrings` documentation plugin and related Python and Ansible reference configuration.
  * Removed the associated documentation dictionary entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->