### PR TITLE
fix(docs): remove conflicting keys from .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,6 @@
 ---
 version: 2
 
-mkdocs:
-  fail_on_warning: true
-  configuration: mkdocs.yml
-
 build:
   os: ubuntu-24.04
   tools:
@@ -12,14 +8,3 @@ build:
   commands:
     - pip install --user tox
     - python3 -m tox -e docs -- build --strict --site-dir=_readthedocs/html/
-python:
-  install:
-    - method: pip
-      path: tox
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-submodules:
-  include: all
-  recursive: true


### PR DESCRIPTION
## Summary

- Remove `mkdocs`, `python`, and `submodules` keys from `.readthedocs.yml` that are silently ignored when `build.commands` is present
- Their presence may cause schema validation errors on newer ReadTheDocs versions, preventing builds and commit status reporting

## Context

The `docs/readthedocs.org:ansible-navigator` required status check has been stuck as "Expected — Waiting for status to be reported" on all PRs. Investigation found:

1. **No RTD status has been posted** on any of the last 270+ commits on `main` — the webhook integration appears disconnected
2. **The `.readthedocs.yml` config had conflicting keys** — `build.commands` (override mode) alongside `mkdocs`, `python`, and `submodules` sections that are ignored in override mode. Newer RTD versions may reject this as a schema validation error, preventing builds from starting

This PR fixes the config. Reconnecting the RTD webhook (or removing the required status check in favor of the existing `docs / python 3.11` GHA check) is a separate admin action.

## Test plan

- [x] Local `tox -e docs` build passes with the cleaned-up config
- [ ] Verify RTD builds trigger after webhook is reconnected (admin action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified documentation build configuration by removing unused setup options.
  * Preserved the existing environment and documentation build settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->