### PR TITLE
Add limited Apple Container support as container engine

### DIFF
--- a/docs/apple-container.md
+++ b/docs/apple-container.md
@@ -11,8 +11,8 @@ environment container engine.
 
 Use this guide when:
 
-- `--container-engine container` or `execution-environment.container-engine: container`
-  is selected
+- `--container-engine container` or
+  `execution-environment.container-engine: container` is selected
 - execution-environment behavior differs from Docker or Podman
 - you need Apple Container-specific setup, troubleshooting, or operational notes
 
@@ -51,8 +51,8 @@ commands:
 - `container image inspect`
 - `container image list`
 
-For execution-environment runs, `ansible-navigator` passes `container` through to
-`ansible-runner`, which launches the EE using `container run`.
+For execution-environment runs, `ansible-navigator` passes `container` through
+to `ansible-runner`, which launches the EE using `container run`.
 
 ## Passing Apple-specific engine options
 

--- a/docs/apple-container.md
+++ b/docs/apple-container.md
@@ -1,0 +1,198 @@
+<!-- cspell:ignore handicaps -->
+
+# Apple Container Guide
+
+This document gathers the `ansible-navigator`-specific behavior, requirements,
+trade-offs, and usage notes for using
+[apple/container](https://github.com/apple/container) as the execution
+environment container engine.
+
+## What this guide is for
+
+Use this guide when:
+
+- `--container-engine container` or `execution-environment.container-engine: container`
+  is selected
+- execution-environment behavior differs from Docker or Podman
+- you need Apple Container-specific setup, troubleshooting, or operational notes
+
+## Requirements
+
+Using Apple Container with `ansible-navigator` currently assumes:
+
+- macOS
+- Apple Container installed and working
+- the `container` CLI available on `PATH`
+- internet access for pulling execution-environment images
+- pre-existing registry authentication for private images via
+  `container registry login <registry>`
+
+## Installation
+
+Basic installation flow on macOS:
+
+1.  Install the Apple Container CLI.
+2.  Ensure `container --version` works from your shell.
+3.  Install `ansible-navigator`.
+4.  Run with `--ce container` when using execution environments.
+
+Example:
+
+```bash
+ansible-navigator run site.yml --ee true --ce container --mode stdout
+```
+
+## Runtime behavior
+
+When Apple Container is selected, `ansible-navigator` now uses Apple-style image
+commands:
+
+- `container image pull`
+- `container image inspect`
+- `container image list`
+
+For execution-environment runs, `ansible-navigator` passes `container` through to
+`ansible-runner`, which launches the EE using `container run`.
+
+## Passing Apple-specific engine options
+
+`ansible-navigator` does not hide Apple Container runtime flags. When you need
+runtime-specific behavior, pass those options through the normal
+execution-environment container-options setting.
+
+### CLI examples
+
+Use repeated `--co` values to pass Apple Container flags.
+
+Forward the host SSH agent using Apple Container's native SSH support:
+
+```bash
+ansible-navigator run site.yml --ee true --ce container --co=--ssh
+```
+
+Enable nested virtualization:
+
+```bash
+ansible-navigator run site.yml --ee true --ce container --co=--virtualization
+```
+
+Enable Rosetta in the container:
+
+```bash
+ansible-navigator run site.yml --ee true --ce container --co=--rosetta
+```
+
+You can combine them:
+
+```bash
+ansible-navigator run site.yml --ee true --ce container --co=--ssh --co=--rosetta
+```
+
+### Settings file example
+
+Use `execution-environment.container-options` when you want these flags to be
+persistent:
+
+```yaml
+ansible-navigator:
+  execution-environment:
+    enabled: true
+    container-engine: container
+    container-options:
+      - "--ssh"
+      - "--rosetta"
+```
+
+### Notes on important flags
+
+`--ssh` Usually the most useful Apple-specific option. Prefer this when your
+execution-environment workflow needs access to private Git repositories or other
+SSH-agent-backed credentials. It is generally cleaner than trying to hand-build
+equivalent socket mounts.
+
+`--virtualization` Exposes virtualization capabilities to the container. Use
+this only when the workload explicitly requires nested virtualization and the
+host platform supports it.
+
+`--rosetta` Enables Rosetta in the container. This is mainly useful for
+compatibility scenarios where the container workload needs x86_64 userland
+support on Apple Silicon. It should not be treated as a default setting.
+
+## Authentication model
+
+Apple Container uses its own registry login state.
+
+That means:
+
+- private-registry access should be prepared with
+  `container registry login <registry>`
+- `ansible-navigator` does not log in or log out on the user's behalf
+- if a private image pull fails, the recommended recovery is to authenticate
+  first and retry
+
+## Advantages
+
+Using Apple Container has some practical strengths on macOS:
+
+- native Apple tooling for execution environments
+- no requirement to depend on Docker Desktop or Podman for the validated
+  Apple-specific path
+- Apple-native image lifecycle commands
+- working end-to-end execution-environment run and cancel behavior in the
+  validated prototype and parity paths
+
+## Handicaps and trade-offs
+
+Apple Container support is functional, but it is not the same operational model
+as Docker or Podman.
+
+Important trade-offs:
+
+- registry authentication is based on prior login state, not runner-managed
+  auth-file injection
+- some Docker/Podman-specific flags and mount-label assumptions do not apply
+- container-runtime-specific output shapes required dedicated parsing in a few
+  places
+- auto-detection order may still prefer Podman or Docker before Apple Container
+  when `container-engine: auto` is used
+
+## FAQ
+
+### How do I authenticate to a private registry?
+
+Run:
+
+```bash
+container registry login <registry>
+```
+
+before invoking `ansible-navigator` against a private execution-environment
+image.
+
+### Why doesn’t `ansible-navigator` log me in automatically?
+
+Because Apple Container login is persistent host state. The chosen design keeps
+that authentication step explicit instead of hiding host-state mutation inside
+runner or navigator.
+
+### What should I do if an Apple Container image pull fails?
+
+First confirm:
+
+1.  the image name is correct
+2.  the registry is reachable
+3.  you have already authenticated with `container registry login <registry>` if
+    the image is private
+
+Then retry the `ansible-navigator` command.
+
+### Does `auto` always choose Apple Container?
+
+No. `auto` still preserves its configured preference order. If another supported
+engine is preferred and available, it may be selected first.
+
+### Are Docker and Podman behaviors changed by this guide?
+
+No. This guide exists specifically because Apple Container has runtime-specific
+differences that should be documented without changing the meaning of the
+existing Docker/Podman paths.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ To learn how to easily start leveraging the container technology with
 [Getting started with Execution Environments guide](https://docs.ansible.com/ansible/devel/getting_started_ee/index.html).
 
 - [Installation](installation.md)
+- [Apple Container Guide](apple-container.md)
 - [Settings](settings.md)
 - [Subcommands](subcommands.md)
 - [FAQ](faq.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -61,7 +61,7 @@
 
 ### Requirements (macos)
 
-- [Docker Desktop for Mac] or [Podman on macOS]
+- [Docker Desktop for Mac], [Podman on macOS], or [Apple Container]
 - macOS command line developer tools
 - Internet access (during initial installation)
 
@@ -69,6 +69,9 @@
 
 - [Docker Desktop for Mac] installation instructions
 - [Podman on MacOS] installation instructions
+- [Apple Container] installation instructions
+- For Apple Container-specific requirements, trade-offs, and private-registry
+  usage, see the [Apple Container Guide](apple-container.md)
 
 ### Install ansible-navigator (macos)
 

--- a/docs/subcommands.md
+++ b/docs/subcommands.md
@@ -10,7 +10,9 @@ some examples.
 ### `ansible`
 
 Use `ansible-navigator exec -- ansible` from shell. The exec subcommand requires
-execution environment support.
+execution environment support. When the selected execution-environment engine is
+Apple Container, see the [Apple Container Guide](apple-container.md) for
+runtime-specific differences.
 
 ### `ansible-builder`
 

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -316,17 +316,29 @@ class Action(ActionBase):
         self._subaction_type = "playbook"
         self._logger = logging.getLogger(f"{__name__}_{self._subaction_type}")
         self._run_runner()
-        while True:
-            self._dequeue()
-            if self.runner.finished:
+        try:
+            while True:
                 self._dequeue()
-                if self._args.playbook_artifact_enable:
-                    self.write_artifact()
-                self._logger.debug("runner finished")
-                break
-            # Sleep briefly to prevent 100% CPU utilization
-            # in mode stdout, the delay introduced by the curses key read is not present
-            time.sleep(0.01)
+                if self.runner.finished:
+                    self._dequeue()
+                    if self._args.playbook_artifact_enable:
+                        self.write_artifact()
+                    self._logger.debug("runner finished")
+                    break
+                # Sleep briefly to prevent 100% CPU utilization
+                # in mode stdout, the delay introduced by the curses key read is not present
+                time.sleep(0.01)
+        except KeyboardInterrupt:
+            self._logger.warning("Keyboard interrupt received, requesting runner cancellation")
+            self.runner.cancelled = True
+            while not self.runner.finished:
+                self._dequeue()
+                time.sleep(0.01)
+            return_code = self.runner.ansible_runner_instance.rc or 1
+            return RunStdoutReturn(
+                message="Please review the log for errors.",
+                return_code=return_code,
+            )
         return_code = self.runner.ansible_runner_instance.rc
         if return_code != 0:
             return RunStdoutReturn(

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -299,10 +299,10 @@ NavigatorConfiguration = ApplicationConfiguration(
         ),
         SettingsEntry(
             name="container_engine",
-            choices=["auto", "podman", "docker"],
+            choices=["auto", "podman", "docker", "container"],
             cli_parameters=CliParameters(short="--ce"),
             settings_file_path_override="execution-environment.container-engine",
-            short_description="Specify the container engine (auto=podman then docker)",
+            short_description="Specify the container engine (auto=podman then docker then container)",
             value=SettingsEntryValue(default="auto"),
             version_added="v1.0",
         ),

--- a/src/ansible_navigator/image_manager/inspector.py
+++ b/src/ansible_navigator/image_manager/inspector.py
@@ -33,10 +33,11 @@ class ImagesInspect:
         Returns:
             List of image inspection command objects
         """
+        inspect_command = "image inspect" if self._container_engine == "container" else "inspect"
         return [
             Command(
                 identity=image_id,
-                command=f"{self._container_engine} inspect {image_id}",
+                command=f"{self._container_engine} {inspect_command} {image_id}",
                 post_process=self.parse,
             )
             for image_id in self._image_ids
@@ -72,10 +73,11 @@ class ImagesList:
         Returns:
             List of the image lister commands
         """
+        list_command = "image list" if self._container_engine == "container" else "images"
         return [
             Command(
                 identity="images",
-                command=f"{self._container_engine} images",
+                command=f"{self._container_engine} {list_command}",
                 post_process=self.parse,
             ),
         ]

--- a/src/ansible_navigator/image_manager/puller.py
+++ b/src/ansible_navigator/image_manager/puller.py
@@ -199,7 +199,10 @@ class ImagePuller:
         Returns:
             The command
         """
-        command_line = [self._container_engine, "pull"]
+        if self._container_engine == "container":
+            command_line = [self._container_engine, "image", "pull"]
+        else:
+            command_line = [self._container_engine, "pull"]
         command_line.extend(self._arguments)
         command_line.append(self._image)
         joined_command = " ".join(command_line)


### PR DESCRIPTION
This PR adds limited support for the Apple Container (container) engine as a valid execution environment container engine with the following changes:
- Add 'container' to the choices for container_engine configuration
- Modify inspector and puller to handle Apple Container command syntax differences
- Update run action to handle SIGINT properly within stdout mode
- Add new documentation files for Apple Container usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Apple Container support for running and managing execution environments.
  - Added configuration options and guidance for installation, authentication, private registries, and usage.
  - Added comprehensive Apple Container documentation, including requirements, troubleshooting, trade-offs, and FAQs.
  - Documented container-engine fallback behavior.

- **Bug Fixes**
  - Improved interruption handling so cancelled runs shut down cleanly and report their status.
  - Updated image inspection, listing, and pulling commands for Apple Container compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->