### PR TITLE
Add limited Apple Container support as container engine

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -42,6 +42,7 @@ kegexes
 lentext
 levelname
 libonig
+lifecycle
 lightbulbs
 linenums
 lintable
@@ -88,6 +89,7 @@ testsfailed
 tracebacks
 truecolor
 usefixtures
+userland
 volmount
 withast
 workdir

--- a/docs/apple-container.md
+++ b/docs/apple-container.md
@@ -1,0 +1,198 @@
+<!-- cspell:ignore handicaps -->
+
+# Apple Container Guide
+
+This document gathers the `ansible-navigator`-specific behavior, requirements,
+trade-offs, and usage notes for using
+[apple/container](https://github.com/apple/container) as the execution
+environment container engine.
+
+## What this guide is for
+
+Use this guide when:
+
+- `--container-engine container` or
+  `execution-environment.container-engine: container` is selected
+- execution-environment behavior differs from Docker or Podman
+- you need Apple Container-specific setup, troubleshooting, or operational notes
+
+## Requirements
+
+Using Apple Container with `ansible-navigator` currently assumes:
+
+- macOS
+- Apple Container installed and working
+- the `container` CLI available on `PATH`
+- internet access for pulling execution-environment images
+- pre-existing registry authentication for private images via
+  `container registry login <registry>`
+
+## Installation
+
+Basic installation flow on macOS:
+
+1.  Install the Apple Container CLI.
+2.  Ensure `container --version` works from your shell.
+3.  Install `ansible-navigator`.
+4.  Run with `--ce container` when using execution environments.
+
+Example:
+
+```bash
+ansible-navigator run site.yml --ee true --ce container --mode stdout
+```
+
+## Runtime behavior
+
+When Apple Container is selected, `ansible-navigator` now uses Apple-style image
+commands:
+
+- `container image pull`
+- `container image inspect`
+- `container image list`
+
+For execution-environment runs, `ansible-navigator` passes `container` through
+to `ansible-runner`, which launches the EE using `container run`.
+
+## Passing Apple-specific engine options
+
+`ansible-navigator` does not hide Apple Container runtime flags. When you need
+runtime-specific behavior, pass those options through the normal
+execution-environment container-options setting.
+
+### CLI examples
+
+Use repeated `--co` values to pass Apple Container flags.
+
+Forward the host SSH agent using Apple Container's native SSH support:
+
+```bash
+ansible-navigator run site.yml --ee true --ce container --co=--ssh
+```
+
+Enable nested virtualization:
+
+```bash
+ansible-navigator run site.yml --ee true --ce container --co=--virtualization
+```
+
+Enable Rosetta in the container:
+
+```bash
+ansible-navigator run site.yml --ee true --ce container --co=--rosetta
+```
+
+You can combine them:
+
+```bash
+ansible-navigator run site.yml --ee true --ce container --co=--ssh --co=--rosetta
+```
+
+### Settings file example
+
+Use `execution-environment.container-options` when you want these flags to be
+persistent:
+
+```yaml
+ansible-navigator:
+  execution-environment:
+    enabled: true
+    container-engine: container
+    container-options:
+      - "--ssh"
+      - "--rosetta"
+```
+
+### Notes on important flags
+
+`--ssh` Usually the most useful Apple-specific option. Prefer this when your
+execution-environment workflow needs access to private Git repositories or other
+SSH-agent-backed credentials. It is generally cleaner than trying to hand-build
+equivalent socket mounts.
+
+`--virtualization` Exposes virtualization capabilities to the container. Use
+this only when the workload explicitly requires nested virtualization and the
+host platform supports it.
+
+`--rosetta` Enables Rosetta in the container. This is mainly useful for
+compatibility scenarios where the container workload needs x86_64 userland
+support on Apple Silicon. It should not be treated as a default setting.
+
+## Authentication model
+
+Apple Container uses its own registry login state.
+
+That means:
+
+- private-registry access should be prepared with
+  `container registry login <registry>`
+- `ansible-navigator` does not log in or log out on the user's behalf
+- if a private image pull fails, the recommended recovery is to authenticate
+  first and retry
+
+## Advantages
+
+Using Apple Container has some practical strengths on macOS:
+
+- native Apple tooling for execution environments
+- no requirement to depend on Docker Desktop or Podman for the validated
+  Apple-specific path
+- Apple-native image lifecycle commands
+- working end-to-end execution-environment run and cancel behavior in the
+  validated prototype and parity paths
+
+## Handicaps and trade-offs
+
+Apple Container support is functional, but it is not the same operational model
+as Docker or Podman.
+
+Important trade-offs:
+
+- registry authentication is based on prior login state, not runner-managed
+  auth-file injection
+- some Docker/Podman-specific flags and mount-label assumptions do not apply
+- container-runtime-specific output shapes required dedicated parsing in a few
+  places
+- auto-detection order may still prefer Podman or Docker before Apple Container
+  when `container-engine: auto` is used
+
+## FAQ
+
+### How do I authenticate to a private registry?
+
+Run:
+
+```bash
+container registry login <registry>
+```
+
+before invoking `ansible-navigator` against a private execution-environment
+image.
+
+### Why doesn’t `ansible-navigator` log me in automatically?
+
+Because Apple Container login is persistent host state. The chosen design keeps
+that authentication step explicit instead of hiding host-state mutation inside
+runner or navigator.
+
+### What should I do if an Apple Container image pull fails?
+
+First confirm:
+
+1.  the image name is correct
+2.  the registry is reachable
+3.  you have already authenticated with `container registry login <registry>` if
+    the image is private
+
+Then retry the `ansible-navigator` command.
+
+### Does `auto` always choose Apple Container?
+
+No. `auto` still preserves its configured preference order. If another supported
+engine is preferred and available, it may be selected first.
+
+### Are Docker and Podman behaviors changed by this guide?
+
+No. This guide exists specifically because Apple Container has runtime-specific
+differences that should be documented without changing the meaning of the
+existing Docker/Podman paths.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ To learn how to easily start leveraging the container technology with
 [Getting started with Execution Environments guide](https://docs.ansible.com/ansible/devel/getting_started_ee/index.html).
 
 - [Installation](installation.md)
+- [Apple Container Guide](apple-container.md)
 - [Settings](settings.md)
 - [Subcommands](subcommands.md)
 - [FAQ](faq.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -61,7 +61,7 @@
 
 ### Requirements (macos)
 
-- [Docker Desktop for Mac] or [Podman on macOS]
+- [Docker Desktop for Mac], [Podman on macOS], or [Apple Container]
 - macOS command line developer tools
 - Internet access (during initial installation)
 
@@ -69,6 +69,9 @@
 
 - [Docker Desktop for Mac] installation instructions
 - [Podman on MacOS] installation instructions
+- [Apple Container] installation instructions
+- For Apple Container-specific requirements, trade-offs, and private-registry
+  usage, see the [Apple Container Guide](apple-container.md)
 
 ### Install ansible-navigator (macos)
 

--- a/docs/subcommands.md
+++ b/docs/subcommands.md
@@ -10,7 +10,9 @@ some examples.
 ### `ansible`
 
 Use `ansible-navigator exec -- ansible` from shell. The exec subcommand requires
-execution environment support.
+execution environment support. When the selected execution-environment engine is
+Apple Container, see the [Apple Container Guide](apple-container.md) for
+runtime-specific differences.
 
 ### `ansible-builder`
 

--- a/src/ansible_navigator/actions/run.py
+++ b/src/ansible_navigator/actions/run.py
@@ -316,17 +316,30 @@ class Action(ActionBase):
         self._subaction_type = "playbook"
         self._logger = logging.getLogger(f"{__name__}_{self._subaction_type}")
         self._run_runner()
-        while True:
-            self._dequeue()
-            if self.runner.finished:
+        try:
+            while True:
                 self._dequeue()
-                if self._args.playbook_artifact_enable:
-                    self.write_artifact()
-                self._logger.debug("runner finished")
-                break
-            # Sleep briefly to prevent 100% CPU utilization
-            # in mode stdout, the delay introduced by the curses key read is not present
-            time.sleep(0.01)
+                if self.runner.finished:
+                    self._dequeue()
+                    if self._args.playbook_artifact_enable:
+                        self.write_artifact()
+                    self._logger.debug("runner finished")
+                    break
+                # Sleep briefly to prevent 100% CPU utilization
+                # in mode stdout, the delay introduced by the curses key read is not present
+                time.sleep(0.01)
+        except KeyboardInterrupt:
+            self._logger.warning("Keyboard interrupt received, requesting runner cancellation")
+            self.runner.cancelled = True
+            while not self.runner.finished:
+                self._dequeue()
+                time.sleep(0.01)
+            self._dequeue()
+            return_code = self.runner.ansible_runner_instance.rc or 1
+            return RunStdoutReturn(
+                message="Please review the log for errors.",
+                return_code=return_code,
+            )
         return_code = self.runner.ansible_runner_instance.rc
         if return_code != 0:
             return RunStdoutReturn(

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -299,10 +299,12 @@ NavigatorConfiguration = ApplicationConfiguration(
         ),
         SettingsEntry(
             name="container_engine",
-            choices=["auto", "podman", "docker"],
+            choices=["auto", "podman", "docker", "container"],
             cli_parameters=CliParameters(short="--ce"),
             settings_file_path_override="execution-environment.container-engine",
-            short_description="Specify the container engine (auto=podman then docker)",
+            short_description=(
+                "Specify the container engine (auto=podman then docker then container)"
+            ),
             value=SettingsEntryValue(default="auto"),
             version_added="v1.0",
         ),

--- a/src/ansible_navigator/data/ansible-navigator.json
+++ b/src/ansible_navigator/data/ansible-navigator.json
@@ -285,11 +285,12 @@
                     "properties": {
                         "container-engine": {
                             "default": "auto",
-                            "description": "Specify the container engine (auto=podman then docker)",
+                            "description": "Specify the container engine (auto=podman then docker then container)",
                             "enum": [
                                 "auto",
                                 "podman",
-                                "docker"
+                                "docker",
+                                "container"
                             ],
                             "type": "string"
                         },

--- a/src/ansible_navigator/image_manager/inspector.py
+++ b/src/ansible_navigator/image_manager/inspector.py
@@ -33,10 +33,11 @@ class ImagesInspect:
         Returns:
             List of image inspection command objects
         """
+        inspect_command = "image inspect" if self._container_engine == "container" else "inspect"
         return [
             Command(
                 identity=image_id,
-                command=f"{self._container_engine} inspect {image_id}",
+                command=f"{self._container_engine} {inspect_command} {image_id}",
                 post_process=self.parse,
             )
             for image_id in self._image_ids
@@ -55,7 +56,13 @@ class ImagesInspect:
 
 
 class ImagesList:
-    """Functionality for listing container images."""
+    """Functionality for listing container images.
+
+    Attributes:
+        APPLE_HEADER_MAP: Mapping of Apple Container headers to standard ones.
+    """
+
+    APPLE_HEADER_MAP: dict[str, str] = {"name": "repository", "digest": "image_id"}
 
     def __init__(self, container_engine: str) -> None:
         """Initialize the container image lister.
@@ -72,25 +79,29 @@ class ImagesList:
         Returns:
             List of the image lister commands
         """
+        list_command = "image list" if self._container_engine == "container" else "images"
         return [
             Command(
                 identity="images",
-                command=f"{self._container_engine} images",
+                command=f"{self._container_engine} {list_command}",
                 post_process=self.parse,
             ),
         ]
 
-    @staticmethod
-    def parse(command: Command) -> None:
+    @classmethod
+    def parse(cls, command: Command) -> None:
         """Parse the image lister command output.
 
         Args:
             command: Image lister command object
         """
         if command.stdout:
+            is_apple = command.command.startswith("container ")
             images = command.stdout.splitlines()
             re_2omo = re.compile(r"\s{2,}")
             headers = [key.lower().replace(" ", "_") for key in re_2omo.split(images.pop(0))]
+            if is_apple:
+                headers = [cls.APPLE_HEADER_MAP.get(h, h) for h in headers]
             local_images = [
                 dict(zip(headers, re_2omo.split(line), strict=False)) for line in images
             ]

--- a/src/ansible_navigator/image_manager/puller.py
+++ b/src/ansible_navigator/image_manager/puller.py
@@ -199,7 +199,10 @@ class ImagePuller:
         Returns:
             The command
         """
-        command_line = [self._container_engine, "pull"]
+        if self._container_engine == "container":
+            command_line = [self._container_engine, "image", "pull"]
+        else:
+            command_line = [self._container_engine, "pull"]
         command_line.extend(self._arguments)
         command_line.append(self._image)
         joined_command = " ".join(command_line)

--- a/tests/unit/image_manager/test_image_inspector.py
+++ b/tests/unit/image_manager/test_image_inspector.py
@@ -1,0 +1,88 @@
+"""Unit tests for image inspector."""
+
+import pytest
+
+from ansible_navigator.command_runner import Command
+from ansible_navigator.image_manager.inspector import ImagesInspect
+from ansible_navigator.image_manager.inspector import ImagesList
+
+
+@pytest.mark.parametrize(
+    ("container_engine", "expected_inspect_cmd"),
+    (
+        pytest.param("podman", "podman inspect image_id", id="podman-inspect"),
+        pytest.param("docker", "docker inspect image_id", id="docker-inspect"),
+        pytest.param("container", "container image inspect image_id", id="container-image-inspect"),
+    ),
+)
+def test_images_inspect_command(
+    container_engine: str,
+    expected_inspect_cmd: str,
+) -> None:
+    """Test image inspect command generation.
+
+    Args:
+        container_engine: Container engine identifier
+        expected_inspect_cmd: Expected command string
+    """
+    inspector = ImagesInspect(container_engine=container_engine, ids=["image_id"])
+    commands = inspector.commands
+    assert len(commands) == 1
+    assert commands[0].command == expected_inspect_cmd
+
+
+@pytest.mark.parametrize(
+    ("container_engine", "expected_list_cmd"),
+    (
+        pytest.param("podman", "podman images", id="podman-images"),
+        pytest.param("docker", "docker images", id="docker-images"),
+        pytest.param("container", "container image list", id="container-image-list"),
+    ),
+)
+def test_images_list_command(
+    container_engine: str,
+    expected_list_cmd: str,
+) -> None:
+    """Test image list command generation.
+
+    Args:
+        container_engine: Container engine identifier
+        expected_list_cmd: Expected command string
+    """
+    lister = ImagesList(container_engine=container_engine)
+    commands = lister.commands
+    assert len(commands) == 1
+    assert commands[0].command == expected_list_cmd
+
+
+def test_images_list_parse_docker() -> None:
+    """Test that Docker/Podman list output is parsed with standard headers."""
+    stdout = (
+        "REPOSITORY          TAG       IMAGE ID       CREATED        SIZE\n"
+        "my-image            latest    abc123def456   2 days ago     250MB"
+    )
+    cmd = Command(identity="images", command="podman images", post_process=ImagesList.parse)
+    cmd.stdout = stdout
+    ImagesList.parse(cmd)
+    assert isinstance(cmd.details, list)
+    assert len(cmd.details) == 1
+    assert cmd.details[0]["repository"] == "my-image"
+    assert cmd.details[0]["tag"] == "latest"
+    assert cmd.details[0]["image_id"] == "abc123def456"
+
+
+def test_images_list_parse_apple_container() -> None:
+    """Test that Apple Container list output headers are normalized."""
+    stdout = "NAME                TAG       DIGEST\nmy-image            latest    sha256:abc123"
+    cmd = Command(
+        identity="images",
+        command="container image list",
+        post_process=ImagesList.parse,
+    )
+    cmd.stdout = stdout
+    ImagesList.parse(cmd)
+    assert isinstance(cmd.details, list)
+    assert len(cmd.details) == 1
+    assert cmd.details[0]["repository"] == "my-image"
+    assert cmd.details[0]["tag"] == "latest"
+    assert cmd.details[0]["image_id"] == "sha256:abc123"

--- a/tests/unit/image_manager/test_image_puller.py
+++ b/tests/unit/image_manager/test_image_puller.py
@@ -219,3 +219,33 @@ def test_pull_with_env_arg() -> None:
     )
     assert "XDG_RUNTIME_DIR" not in proc.stdout
     assert "containers/auth.json" in proc.stdout
+
+
+def test_pull_with_container_engine() -> None:
+    """Ensure command uses 'image pull' for container engine."""
+    image_puller = ImagePuller(
+        container_engine="container",
+        image="my_image",
+        arguments=Constants.NOT_SET,
+        pull_policy="tag",
+    )
+    result = image_puller._generate_pull_command()
+    expected_string = "container image pull my_image"
+    assert result == expected_string
+    expected_list = ["container", "image", "pull", "my_image"]
+    assert shlex.split(result) == expected_list
+
+
+def test_pull_with_container_engine_and_args() -> None:
+    """Ensure command with container engine and additional arguments."""
+    image_puller = ImagePuller(
+        container_engine="container",
+        image="my_image",
+        arguments=["--tls-verify", "false"],
+        pull_policy="tag",
+    )
+    result = image_puller._generate_pull_command()
+    expected_string = "container image pull --tls-verify false my_image"
+    assert result == expected_string
+    expected_list = ["container", "image", "pull", "--tls-verify", "false", "my_image"]
+    assert shlex.split(result) == expected_list


### PR DESCRIPTION
Description:
## Summary
Adds support for Apple Container (from apple/container) as a container engine option in ansible-navigator on macOS, alongside existing Docker and Podman support.

## Changes
- Add comprehensive Apple Container guide documentation covering setup, requirements, runtime behavior, and trade-offs
- Update installation guide to include Apple Container setup instructions
- Enhance subcommands documentation to reference Apple Container-specific behavior
- Modify core container engine logic to support Apple-style image commands (`container image pull`, `container image inspect`, `container image list`)
- Update configuration validation to accept `container` as a valid container engine option

## Apple Container Specifics
- Native Apple tooling for execution environments on macOS
- No dependency on Docker Desktop or Podman for the validated Apple-specific path
- Supports Apple-specific runtime options like `--ssh`, `--virtualization`, and `--rosetta`
- Registry authentication uses Apple Container's native login state
- Works with `--container-engine container` or `execution-environment.container-engine: container` configuration

## Testing Notes
- Requires macOS and Apple Container CLI installed
- Validated prototype and parity paths include working end-to-end execution-environment run and cancel behavior
- Docker and Podman behavior remains unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Apple Container support for macOS, including installation guidance, runtime commands, configuration, registry authentication, and troubleshooting.
  - Added Apple Container as a selectable container engine with automatic engine selection guidance.
  - Added compatible image inspection, listing, and pulling operations for Apple Container.

- **Bug Fixes**
  - Improved interruption handling so canceled operations finish cleanly and return an appropriate status.

- **Documentation**
  - Added an Apple Container guide and linked it from installation, navigation, and subcommand documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->