### PR TITLE
fix: handle OSError when checking a playbook path

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -19,6 +19,7 @@ colval
 devel
 dumpable
 dunder
+enametoolong
 escdelay
 facelessuser
 fedoraproject

--- a/src/ansible_navigator/utils/functions.py
+++ b/src/ansible_navigator/utils/functions.py
@@ -110,10 +110,13 @@ def check_playbook_type(playbook: str) -> str:
     """
     playbook_type = "file"
     playbook_path = str(playbook)
-    if Path(playbook_path).exists() is False:
-        playbook_type = "missing"
-    if Path(playbook_path).exists() is False and len(playbook_path.split(".")) >= 3:
-        playbook_type = "fqcn"
+    try:
+        exists = Path(playbook_path).exists()
+    except OSError:
+        # The path cannot name a file on this system, e.g. it is too long
+        return "missing"
+    if exists is False:
+        playbook_type = "fqcn" if len(playbook_path.split(".")) >= 3 else "missing"
     return playbook_type
 
 

--- a/tests/unit/utils/test_functions_extended.py
+++ b/tests/unit/utils/test_functions_extended.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import errno
 import shutil
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import patch  # pylint: disable=preferred-module
 
 import pytest
@@ -26,10 +27,6 @@ from ansible_navigator.utils.functions import templar
 from ansible_navigator.utils.functions import time_stamp_for_file
 from ansible_navigator.utils.functions import timestamp_to_iso
 from ansible_navigator.utils.functions import to_list
-
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def test_check_for_ansible_found(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -65,6 +62,20 @@ def test_check_playbook_type_missing() -> None:
 def test_check_playbook_type_fqcn() -> None:
     """Test check_playbook_type with an FQCN playbook."""
     assert check_playbook_type("namespace.collection.playbook") == "fqcn"
+
+
+def test_check_playbook_type_name_too_long(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test check_playbook_type when the path cannot name a file on this system.
+
+    Args:
+        monkeypatch: The monkeypatch fixture
+    """
+
+    def raise_name_too_long(_self: Path) -> bool:
+        raise OSError(errno.ENAMETOOLONG, "File name too long")
+
+    monkeypatch.setattr(Path, "exists", raise_name_too_long)
+    assert check_playbook_type("a" * 300) == "missing"
 
 
 def test_clear_screen_vscode(


### PR DESCRIPTION
Handle OSError (e.g. ENAMETOOLONG) that can be raised when checking if a playbook path exists. When the path cannot name a file on this system, immediately return "missing" instead of attempting the FQCN fallback logic, which could incorrectly classify a too-long path as an FQCN playbook if it contains dots.

Changes:
- Wrap Path.exists() in try-except to catch OSError
- Return "missing" immediately on OSError to prevent FQCN fallback
- Restructure the FQCN logic to only apply when the file genuinely doesn't exist (not when the existence check fails)
- Add test case to verify OSError handling with too-long path names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playbook detection when a path cannot be checked by the system.
  * Such paths are now correctly reported as missing instead of causing an error.
  * Added safer handling for paths that exceed system filename or path-length limits.

* **Tests**
  * Added coverage confirming expected results when path checks fail due to system limits.
  * Expanded validation of missing-path detection in these edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->