### PR TITLE
fix: handle undeterminable home directory when expanding a path

### DIFF
--- a/src/ansible_navigator/utils/functions.py
+++ b/src/ansible_navigator/utils/functions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import contextlib
 import datetime
 import decimal
 import html
@@ -64,7 +65,9 @@ def expand_path(path: str | Path) -> Path:
         Resolved file path
     """
     _path = Path(os.path.expandvars(path))
-    _path = _path.expanduser()
+    # The home directory may not be determinable, e.g. ~ names an unknown user
+    with contextlib.suppress(RuntimeError):
+        _path = _path.expanduser()
     return _path.resolve()
 
 

--- a/tests/unit/utils/test_functions.py
+++ b/tests/unit/utils/test_functions.py
@@ -117,7 +117,11 @@ def test_env_var_is_file_path(
 
 
 def test_expand_path_unknown_user(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test expand_path when expanduser raises RuntimeError."""
+    """Test expand_path when expanduser raises RuntimeError.
+
+    Args:
+        monkeypatch: The monkeypatch fixture
+    """
 
     def mock_expanduser(self: Path) -> Path:
         msg = "unknown user"

--- a/tests/unit/utils/test_functions.py
+++ b/tests/unit/utils/test_functions.py
@@ -118,8 +118,10 @@ def test_env_var_is_file_path(
 
 def test_expand_path_unknown_user(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test expand_path when expanduser raises RuntimeError."""
+
     def mock_expanduser(self: Path) -> Path:
-        raise RuntimeError("unknown user")
+        msg = "unknown user"
+        raise RuntimeError(msg)
 
     monkeypatch.setattr(Path, "expanduser", mock_expanduser)
     result = expand_path("~/path")

--- a/tests/unit/utils/test_functions.py
+++ b/tests/unit/utils/test_functions.py
@@ -116,6 +116,11 @@ def test_env_var_is_file_path(
     assert result == anticipated_result
 
 
+def test_expand_path_unknown_user() -> None:
+    """Test expand_path with a tilde naming a user without a home directory."""
+    assert expand_path("~nonexistentuser") == Path("~nonexistentuser").resolve()
+
+
 @pytest.mark.parametrize(
     ("value", "anticipated_result"),
     (

--- a/tests/unit/utils/test_functions.py
+++ b/tests/unit/utils/test_functions.py
@@ -116,9 +116,14 @@ def test_env_var_is_file_path(
     assert result == anticipated_result
 
 
-def test_expand_path_unknown_user() -> None:
-    """Test expand_path with a tilde naming a user without a home directory."""
-    assert expand_path("~nonexistentuser") == Path("~nonexistentuser").resolve()
+def test_expand_path_unknown_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test expand_path when expanduser raises RuntimeError."""
+    def mock_expanduser(self: Path) -> Path:
+        raise RuntimeError("unknown user")
+
+    monkeypatch.setattr(Path, "expanduser", mock_expanduser)
+    result = expand_path("~/path")
+    assert str(result).endswith("~/path")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When a path contains a tilde that references a non-existent user, calling expanduser() raises a RuntimeError. This change wraps expanduser() with contextlib.suppress to gracefully handle this case and leave the path unchanged.

Also adds a test case to verify the behavior with non-existent user references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tilde paths referencing unknown users.
  * Such paths now resolve without raising an error when the home directory cannot be expanded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->